### PR TITLE
ci: publish docs to github pages

### DIFF
--- a/.changeset/public-ads-drum.md
+++ b/.changeset/public-ads-drum.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+publish docs to github pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci --prefer-offline
+      - name: Build docs
+        run: npm run docs:build
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,6 @@
-export default {
+import { defineConfig } from 'vitepress';
+
+export default defineConfig({
   title: 'design-lint',
   description: 'Design system linter',
   themeConfig: {
@@ -7,7 +9,7 @@ export default {
       { text: 'Configuration', link: '/configuration' },
       { text: 'API', link: '/api' },
       { text: 'Plugins', link: '/plugins' },
-      { text: 'Rules', link: '/rules/' }
+      { text: 'Rules', link: '/rules/' },
     ],
     sidebar: [
       {
@@ -16,8 +18,8 @@ export default {
           { text: 'Usage', link: '/usage' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'API', link: '/api' },
-          { text: 'Plugins', link: '/plugins' }
-        ]
+          { text: 'Plugins', link: '/plugins' },
+        ],
       },
       {
         text: 'Rules',
@@ -25,9 +27,12 @@ export default {
           {
             text: 'Design System',
             items: [
-              { text: 'component-usage', link: '/rules/design-system/component-usage' },
-              { text: 'deprecation', link: '/rules/design-system/deprecation' }
-            ]
+              {
+                text: 'component-usage',
+                link: '/rules/design-system/component-usage',
+              },
+              { text: 'deprecation', link: '/rules/design-system/deprecation' },
+            ],
           },
           {
             text: 'Design Token',
@@ -35,19 +40,28 @@ export default {
               { text: 'colors', link: '/rules/design-token/colors' },
               { text: 'line-height', link: '/rules/design-token/line-height' },
               { text: 'font-weight', link: '/rules/design-token/font-weight' },
-              { text: 'letter-spacing', link: '/rules/design-token/letter-spacing' },
-              { text: 'border-radius', link: '/rules/design-token/border-radius' },
-              { text: 'border-width', link: '/rules/design-token/border-width' },
+              {
+                text: 'letter-spacing',
+                link: '/rules/design-token/letter-spacing',
+              },
+              {
+                text: 'border-radius',
+                link: '/rules/design-token/border-radius',
+              },
+              {
+                text: 'border-width',
+                link: '/rules/design-token/border-width',
+              },
               { text: 'box-shadow', link: '/rules/design-token/box-shadow' },
               { text: 'duration', link: '/rules/design-token/duration' },
               { text: 'spacing', link: '/rules/design-token/spacing' },
               { text: 'font-size', link: '/rules/design-token/font-size' },
               { text: 'font-family', link: '/rules/design-token/font-family' },
-              { text: 'z-index', link: '/rules/design-token/z-index' }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-};
+              { text: 'z-index', link: '/rules/design-token/z-index' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lapidist/design-lint",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lapidist/design-lint",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-sfc": "^3.5.20",


### PR DESCRIPTION
## Summary

<!-- Briefly explain the changes and the motivation behind them. -->
Publish the vitepress docs to github pages so we can access them without running the project locally.

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`

<!-- If no tests were run, explain why. -->

## Issue

<!-- Link to the issue(s) this PR addresses. -->

## Notes

<!-- Any additional information for reviewers. -->
