### PR TITLE
feat(rule): add variant prop rule

### DIFF
--- a/.changeset/enforce-variant-prop.md
+++ b/.changeset/enforce-variant-prop.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add variant-prop rule to enforce allowed component variants
+

--- a/docs/rules/design-system/variant-prop.md
+++ b/docs/rules/design-system/variant-prop.md
@@ -1,0 +1,54 @@
+# design-system/variant-prop
+
+Ensures that specified components use only allowed values for their variant prop.
+
+Works with React, Vue, Svelte, and Web Components.
+
+## Configuration
+
+```json
+{
+  "rules": {
+    "design-system/variant-prop": [
+      "error",
+      { "components": { "Button": ["primary", "secondary"] } }
+    ]
+  }
+}
+```
+
+### Options
+
+- `components` (`Record<string, string[]>`): map of component names to their allowed variant values.
+- `prop` (`string`, default: `"variant"`): prop name to validate.
+
+## Examples
+
+### Invalid
+
+```tsx
+<Button variant="danger" />
+```
+
+### Valid
+
+```tsx
+<Button variant="primary" />
+```
+
+### Custom Prop Name
+
+```json
+{
+  "rules": {
+    "design-system/variant-prop": [
+      "error",
+      { "prop": "tone", "components": { "Alert": ["info", "error"] } }
+    ]
+  }
+}
+```
+
+```tsx
+<Alert tone="info" />
+```

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -6,6 +6,7 @@ Design-lint includes several built-in rules categorized by domain.
 
 - [component-usage](./design-system/component-usage)
 - [deprecation](./design-system/deprecation)
+- [variant-prop](./design-system/variant-prop)
 
 ## Design Token
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -17,6 +17,7 @@ import { opacityRule } from './token-opacity.js';
 import { outlineRule } from './token-outline.js';
 import { componentUsageRule } from './component-usage.js';
 import { deprecationRule } from './deprecation.js';
+import { variantPropRule } from './variant-prop.js';
 
 export const builtInRules = [
   animationRule,
@@ -38,4 +39,5 @@ export const builtInRules = [
   zIndexRule,
   componentUsageRule,
   deprecationRule,
+  variantPropRule,
 ];

--- a/src/rules/variant-prop.ts
+++ b/src/rules/variant-prop.ts
@@ -1,0 +1,58 @@
+import ts from 'typescript';
+import type { RuleModule } from '../core/types.js';
+
+interface VariantPropOptions {
+  components?: Record<string, string[]>;
+  prop?: string;
+}
+
+export const variantPropRule: RuleModule = {
+  name: 'design-system/variant-prop',
+  meta: {
+    description:
+      'ensure specified components use allowed values for their variant prop',
+  },
+  create(context) {
+    const opts = (context.options as VariantPropOptions) || {};
+    const components = opts.components || {};
+    const propName = opts.prop || 'variant';
+    return {
+      onNode(node) {
+        if (!ts.isJsxOpeningLikeElement(node)) return;
+        const tag = node.tagName.getText();
+        const allowed = components[tag];
+        if (!allowed) return;
+        for (const attr of node.attributes.properties) {
+          if (!ts.isJsxAttribute(attr)) continue;
+          if (attr.name.getText() !== propName) continue;
+          if (!attr.initializer) continue;
+          let value: string | null = null;
+          const init = attr.initializer;
+          if (
+            ts.isStringLiteral(init) ||
+            ts.isNoSubstitutionTemplateLiteral(init)
+          ) {
+            value = init.text;
+          } else if (
+            ts.isJsxExpression(init) &&
+            init.expression &&
+            (ts.isStringLiteral(init.expression) ||
+              ts.isNoSubstitutionTemplateLiteral(init.expression))
+          ) {
+            value = init.expression.text;
+          }
+          if (value && !allowed.includes(value)) {
+            const pos = node
+              .getSourceFile()
+              .getLineAndCharacterOfPosition(attr.getStart());
+            context.report({
+              message: `Unexpected ${propName} "${value}" for ${tag}; allowed: ${allowed.join(', ')}`,
+              line: pos.line + 1,
+              column: pos.character + 1,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/tests/rules/variant-prop.test.ts
+++ b/tests/rules/variant-prop.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../../src/core/linter.ts';
+
+test('design-system/variant-prop flags invalid variant', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { components: { Button: ['primary', 'secondary'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    'const a = <Button variant="danger" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+  assert.ok(res.messages[0].message.includes('danger'));
+});
+
+test('design-system/variant-prop allows valid variant', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { components: { Button: ['primary', 'secondary'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    'const a = <Button variant="primary" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 0);
+});
+
+test('design-system/variant-prop flags string literals in expressions', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { components: { Button: ['primary', 'secondary'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    "const a = <Button variant={'danger'} />;",
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+  assert.ok(res.messages[0].message.includes('danger'));
+});
+
+test('design-system/variant-prop ignores dynamic expressions', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { components: { Button: ['primary', 'secondary'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    'const a = <Button variant={foo} />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 0);
+});
+
+test('design-system/variant-prop supports custom prop names', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { prop: 'tone', components: { Alert: ['info', 'error'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    'const a = <Alert tone="warn" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+  assert.ok(res.messages[0].message.includes('warn'));
+});
+
+test('design-system/variant-prop flags invalid variant in Vue components', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { components: { Button: ['primary', 'secondary'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    '<template><Button variant="danger" /></template>',
+    'file.vue',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/variant-prop flags invalid variant in Svelte components', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { components: { Button: ['primary', 'secondary'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    '<Button variant="danger" />',
+    'file.svelte',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/variant-prop flags invalid variant on custom elements', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/variant-prop': [
+        'error',
+        { components: { 'my-button': ['primary', 'secondary'] } },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    'const a = <my-button variant="danger" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+});


### PR DESCRIPTION
## Summary
- ensure variant prop rule works across React, Vue, Svelte, and Web Components
- document framework compatibility
- add tests for Vue, Svelte, and custom elements

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b31ac05ff08328b2b6a078aed113ee