### PR TITLE
feat(rules): add component-prefix rule

### DIFF
--- a/.changeset/component-prefix-rule.md
+++ b/.changeset/component-prefix-rule.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add component-prefix rule to enforce design system component prefixes
+

--- a/docs/rules/design-system/component-prefix.md
+++ b/docs/rules/design-system/component-prefix.md
@@ -1,0 +1,36 @@
+# design-system/component-prefix
+
+Enforces a prefix for design system component names.
+
+Works with React, Vue, Svelte, and Web Components.
+
+## Configuration
+
+```json
+{
+  "rules": {
+    "design-system/component-prefix": [
+      "error",
+      { "prefix": "DS" }
+    ]
+  }
+}
+```
+
+### Options
+
+- `prefix` (`string`, default: `"DS"`): required prefix for component names.
+
+## Examples
+
+### Invalid
+
+```tsx
+<Button />
+```
+
+### Valid
+
+```tsx
+<DSButton />
+```

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -4,6 +4,7 @@ Design-lint includes several built-in rules categorized by domain.
 
 ## Design System
 
+- [component-prefix](./design-system/component-prefix)
 - [component-usage](./design-system/component-usage)
 - [deprecation](./design-system/deprecation)
 - [variant-prop](./design-system/variant-prop)

--- a/src/rules/component-prefix.ts
+++ b/src/rules/component-prefix.ts
@@ -1,0 +1,47 @@
+import ts from 'typescript';
+import type { RuleModule } from '../core/types.js';
+
+interface ComponentPrefixOptions {
+  prefix?: string;
+}
+
+export const componentPrefixRule: RuleModule = {
+  name: 'design-system/component-prefix',
+  meta: {
+    description: 'enforce a prefix for design system components',
+  },
+  create(context) {
+    const opts = (context.options as ComponentPrefixOptions) || {};
+    const prefix = opts.prefix || 'DS';
+    return {
+      onNode(node) {
+        if (
+          ts.isJsxOpeningElement(node) ||
+          ts.isJsxSelfClosingElement(node) ||
+          ts.isJsxClosingElement(node)
+        ) {
+          const tag = node.tagName.getText();
+          if (!tag) return;
+          const isCustomElement = tag.includes('-');
+          const isComponent =
+            tag[0] === tag[0].toUpperCase() || isCustomElement;
+          if (!isComponent) return; // ignore standard HTML tags
+          if (!tag.startsWith(prefix)) {
+            const pos = node
+              .getSourceFile()
+              .getLineAndCharacterOfPosition(node.tagName.getStart());
+            context.report({
+              message: `Component "${tag}" should be prefixed with "${prefix}"`,
+              line: pos.line + 1,
+              column: pos.character + 1,
+              fix: {
+                range: [node.tagName.getStart(), node.tagName.getEnd()],
+                text: `${prefix}${tag}`,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -18,6 +18,7 @@ import { outlineRule } from './token-outline.js';
 import { componentUsageRule } from './component-usage.js';
 import { deprecationRule } from './deprecation.js';
 import { variantPropRule } from './variant-prop.js';
+import { componentPrefixRule } from './component-prefix.js';
 
 export const builtInRules = [
   animationRule,
@@ -40,4 +41,5 @@ export const builtInRules = [
   componentUsageRule,
   deprecationRule,
   variantPropRule,
+  componentPrefixRule,
 ];

--- a/tests/rules/component-prefix.test.ts
+++ b/tests/rules/component-prefix.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../../src/core/linter.ts';
+import { applyFixes } from '../../src/index.ts';
+
+test('design-system/component-prefix enforces prefix on components', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+    },
+  });
+  const res = await linter.lintText('const a = <Button/>;', 'file.tsx');
+  assert.equal(res.messages.length, 1);
+  assert.ok(res.messages[0].message.includes('DS'));
+});
+
+test('design-system/component-prefix ignores lowercase tags', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+    },
+  });
+  const res = await linter.lintText('const a = <div/>;', 'file.tsx');
+  assert.equal(res.messages.length, 0);
+});
+
+test('design-system/component-prefix fixes self-closing tags', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+    },
+  });
+  const code = 'const a = <Button/>';
+  const res = await linter.lintText(code, 'file.tsx');
+  assert.equal(res.messages.length, 1);
+  assert.ok(res.messages[0].fix);
+  const fixed = applyFixes(code, res.messages);
+  assert.equal(fixed, 'const a = <DSButton/>');
+});
+
+test('design-system/component-prefix fixes opening and closing tags', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+    },
+  });
+  const code = 'const a = <Button></Button>';
+  const res = await linter.lintText(code, 'file.tsx');
+  assert.equal(res.messages.length, 2);
+  assert.ok(res.messages.every((m) => m.fix));
+  const fixed = applyFixes(code, res.messages);
+  assert.equal(fixed, 'const a = <DSButton></DSButton>');
+});
+
+test('design-system/component-prefix enforces prefix in Vue components', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+    },
+  });
+  const res = await linter.lintText(
+    '<template><Button/></template>',
+    'file.vue',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/component-prefix enforces prefix in Svelte components', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+    },
+  });
+  const res = await linter.lintText('<Button/>', 'file.svelte');
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/component-prefix enforces prefix on custom elements', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/component-prefix': ['error', { prefix: 'ds-' }],
+    },
+  });
+  const code = 'const a = <my-button></my-button>';
+  const res = await linter.lintText(code, 'file.tsx');
+  assert.equal(res.messages.length, 2);
+  const fixed = applyFixes(code, res.messages);
+  assert.equal(fixed, 'const a = <ds-my-button></ds-my-button>');
+});


### PR DESCRIPTION
## Summary
- enforce configurable prefix for JSX components
- document component-prefix rule
- test component-prefix rule
- ensure component-prefix works across React, Vue, Svelte, and Web Components

## Testing
- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`

