### PR TITLE
feat(rules): add no-inline-styles rule

### DIFF
--- a/.changeset/no-inline-styles-rule.md
+++ b/.changeset/no-inline-styles-rule.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add no-inline-styles rule to report style and className usage on design system components

--- a/docs/rules/design-system/no-inline-styles.md
+++ b/docs/rules/design-system/no-inline-styles.md
@@ -1,0 +1,45 @@
+# design-system/no-inline-styles
+
+Disallows inline `style` and `className` (or `class`) attributes on design system components.
+
+Works with React, Vue, Svelte, and Web Components.
+
+## Configuration
+
+```json
+{
+  "rules": {
+    "design-system/no-inline-styles": [
+      "error",
+      { "ignoreClassName": false }
+    ]
+  }
+}
+```
+
+### Options
+
+- `ignoreClassName` (`boolean`, default: `false`): if `true`, `className`/`class` attributes are ignored.
+
+## Examples
+
+### Invalid
+
+```tsx
+<Button style={{ color: 'red' }} />
+```
+
+```tsx
+<Button className="custom" />
+```
+
+### Valid
+
+```tsx
+<Button />
+```
+
+```tsx
+<Button className="custom" />
+// when ignoreClassName is true
+```

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -19,6 +19,7 @@ import { componentUsageRule } from './component-usage.js';
 import { deprecationRule } from './deprecation.js';
 import { variantPropRule } from './variant-prop.js';
 import { componentPrefixRule } from './component-prefix.js';
+import { noInlineStylesRule } from './no-inline-styles.js';
 
 export const builtInRules = [
   animationRule,
@@ -42,4 +43,5 @@ export const builtInRules = [
   deprecationRule,
   variantPropRule,
   componentPrefixRule,
+  noInlineStylesRule,
 ];

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -1,0 +1,54 @@
+import ts from 'typescript';
+import type { RuleModule } from '../core/types.js';
+
+interface NoInlineStylesOptions {
+  /** When true, the rule will ignore class/className attributes. */
+  ignoreClassName?: boolean;
+}
+
+export const noInlineStylesRule: RuleModule = {
+  name: 'design-system/no-inline-styles',
+  meta: {
+    description:
+      'disallow inline style or className attributes on design system components',
+  },
+  create(context) {
+    const opts = (context.options as NoInlineStylesOptions) || {};
+    const ignoreClassName = !!opts.ignoreClassName;
+    return {
+      onNode(node) {
+        if (!ts.isJsxOpeningLikeElement(node)) return;
+        const tag = node.tagName.getText();
+        const isCustomElement = tag.includes('-');
+        const isComponent = tag[0] === tag[0].toUpperCase() || isCustomElement;
+        if (!isComponent) return;
+        for (const attr of node.attributes.properties) {
+          if (!ts.isJsxAttribute(attr)) continue;
+          const name = attr.name.getText();
+          if (name === 'style') {
+            const pos = node
+              .getSourceFile()
+              .getLineAndCharacterOfPosition(attr.getStart());
+            context.report({
+              message: `Unexpected style attribute on ${tag}`,
+              line: pos.line + 1,
+              column: pos.character + 1,
+            });
+            continue;
+          }
+          const isClassName = name === 'className' || name === 'class';
+          if (!ignoreClassName && isClassName) {
+            const pos = node
+              .getSourceFile()
+              .getLineAndCharacterOfPosition(attr.getStart());
+            context.report({
+              message: `Unexpected ${name} attribute on ${tag}`,
+              line: pos.line + 1,
+              column: pos.character + 1,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/tests/rules/no-inline-styles.test.ts
+++ b/tests/rules/no-inline-styles.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../../src/core/linter.ts';
+
+test('design-system/no-inline-styles flags style attribute on components', async () => {
+  const linter = new Linter({
+    rules: { 'design-system/no-inline-styles': 'error' },
+  });
+  const res = await linter.lintText(
+    'const a = <Button style={{ color: "red" }} />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/no-inline-styles flags className attribute on components', async () => {
+  const linter = new Linter({
+    rules: { 'design-system/no-inline-styles': 'error' },
+  });
+  const res = await linter.lintText(
+    'const a = <Button className="foo" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/no-inline-styles ignores className when configured', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/no-inline-styles': ['error', { ignoreClassName: true }],
+    },
+  });
+  const res = await linter.lintText(
+    'const a = <Button className="foo" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 0);
+});
+
+test('design-system/no-inline-styles flags inline styles in Vue templates', async () => {
+  const linter = new Linter({
+    rules: { 'design-system/no-inline-styles': 'error' },
+  });
+  const res = await linter.lintText(
+    '<template><Button style="color:red" /></template>',
+    'file.vue',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/no-inline-styles flags inline styles in Svelte components', async () => {
+  const linter = new Linter({
+    rules: { 'design-system/no-inline-styles': 'error' },
+  });
+  const res = await linter.lintText(
+    '<Button style="color:red" />',
+    'file.svelte',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/no-inline-styles flags inline styles on custom elements', async () => {
+  const linter = new Linter({
+    rules: { 'design-system/no-inline-styles': 'error' },
+  });
+  const res = await linter.lintText(
+    'const a = <my-button style="color:red"></my-button>;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+});


### PR DESCRIPTION
## Summary
- add `no-inline-styles` rule for design system components
- document option to ignore className
- test across React, Vue, Svelte and Web Components

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68b324545f1c832882c64e6a5172f7de