### PR TITLE
feat: add icon-usage rule

### DIFF
--- a/.changeset/icon-usage-rule.md
+++ b/.changeset/icon-usage-rule.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add icon-usage rule to discourage raw svg elements and non-design system icon components

--- a/docs/rules/design-system/icon-usage.md
+++ b/docs/rules/design-system/icon-usage.md
@@ -1,0 +1,35 @@
+# design-system/icon-usage
+
+Reports raw `<svg>` elements or non-design system icon components.
+
+## Configuration
+
+```json
+{
+  "rules": {
+    "design-system/icon-usage": [
+      "error",
+      { "substitutions": { "svg": "Icon", "FooIcon": "Icon" } }
+    ]
+  }
+}
+```
+
+### Options
+
+- `substitutions` (`Record<string, string>`): map of disallowed icon element or component names to their design system replacements. Keys are matched case-insensitively. Defaults to `{ "svg": "Icon" }`.
+
+## Examples
+
+### Invalid
+
+```tsx
+<svg />
+<FooIcon />
+```
+
+### Valid
+
+```tsx
+<Icon />
+```

--- a/src/rules/icon-usage.ts
+++ b/src/rules/icon-usage.ts
@@ -1,0 +1,61 @@
+import ts from 'typescript';
+import type { RuleModule } from '../core/types.js';
+
+interface IconUsageOptions {
+  /** Map of disallowed icon elements or components to their replacements. */
+  substitutions?: Record<string, string>;
+}
+
+export const iconUsageRule: RuleModule = {
+  name: 'design-system/icon-usage',
+  meta: {
+    description:
+      'disallow raw svg elements or non design system icon components',
+  },
+  create(context) {
+    const opts = (context.options as IconUsageOptions) || {};
+    const subs: Record<string, string> = {
+      svg: 'Icon',
+      ...(opts.substitutions || {}),
+    };
+    const lowerSubs: Record<string, string> = {};
+    for (const [key, val] of Object.entries(subs)) {
+      lowerSubs[key.toLowerCase()] = val;
+    }
+    const disallowed = new Set(Object.keys(lowerSubs));
+    return {
+      onNode(node) {
+        if (
+          ts.isJsxOpeningElement(node) ||
+          ts.isJsxSelfClosingElement(node) ||
+          ts.isJsxClosingElement(node)
+        ) {
+          const tag = node.tagName.getText();
+          const tagLower = tag.toLowerCase();
+          const isSvg = tagLower === 'svg';
+          const isCustomElement = tag.includes('-');
+          const isComponent =
+            tag[0] === tag[0].toUpperCase() || isCustomElement;
+          if (disallowed.has(tagLower) && (isSvg || isComponent)) {
+            const pos = node
+              .getSourceFile()
+              .getLineAndCharacterOfPosition(node.getStart());
+            const replacement = lowerSubs[tagLower];
+            const tagText = ts.isJsxClosingElement(node)
+              ? `</${tag}>`
+              : `<${tag}>`;
+            context.report({
+              message: `Use ${replacement} instead of ${tagText}`,
+              line: pos.line + 1,
+              column: pos.character + 1,
+              fix: {
+                range: [node.tagName.getStart(), node.tagName.getEnd()],
+                text: replacement,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -20,6 +20,7 @@ import { deprecationRule } from './deprecation.js';
 import { variantPropRule } from './variant-prop.js';
 import { componentPrefixRule } from './component-prefix.js';
 import { noInlineStylesRule } from './no-inline-styles.js';
+import { iconUsageRule } from './icon-usage.js';
 
 export const builtInRules = [
   animationRule,
@@ -44,4 +45,5 @@ export const builtInRules = [
   variantPropRule,
   componentPrefixRule,
   noInlineStylesRule,
+  iconUsageRule,
 ];

--- a/tests/rules/icon-usage.test.ts
+++ b/tests/rules/icon-usage.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../../src/core/linter.ts';
+import { applyFixes } from '../../src/index.ts';
+
+test('design-system/icon-usage reports raw svg', async () => {
+  const linter = new Linter({
+    rules: { 'design-system/icon-usage': 'error' },
+  });
+  const code = 'const a = <svg/>;';
+  const res = await linter.lintText(code, 'file.tsx');
+  assert.equal(res.messages.length, 1);
+  assert.ok(res.messages[0].message.includes('Icon'));
+  const fixed = applyFixes(code, res.messages);
+  assert.equal(fixed, 'const a = <Icon/>;');
+});
+
+test('design-system/icon-usage matches substitutions', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/icon-usage': [
+        'error',
+        { substitutions: { fooicon: 'Icon' } },
+      ],
+    },
+  });
+  const code = 'const a = <FooIcon></FooIcon>;';
+  const res = await linter.lintText(code, 'file.tsx');
+  assert.equal(res.messages.length, 2);
+  assert.ok(res.messages.every((m) => m.message.includes('Icon')));
+  const fixed = applyFixes(code, res.messages);
+  assert.equal(fixed, 'const a = <Icon></Icon>;');
+});
+
+test('design-system/icon-usage fixes svg opening and closing tags', async () => {
+  const linter = new Linter({
+    rules: { 'design-system/icon-usage': 'error' },
+  });
+  const code = 'const a = <svg></svg>;';
+  const res = await linter.lintText(code, 'file.tsx');
+  assert.equal(res.messages.length, 2);
+  assert.ok(res.messages.every((m) => m.fix));
+  const fixed = applyFixes(code, res.messages);
+  assert.equal(fixed, 'const a = <Icon></Icon>;');
+});


### PR DESCRIPTION
## Summary
- add `design-system/icon-usage` rule to flag raw `svg` elements and non-design system icon components
- document icon usage rule and configuration
- add tests for icon usage rule

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68b3270e919c8328937b7c633e56120f