### PR TITLE
feat(rules): enforce design system import paths

### DIFF
--- a/.changeset/import-path-rule.md
+++ b/.changeset/import-path-rule.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add import-path rule to ensure design system components are imported from allowed packages
+

--- a/docs/rules/design-system/import-path.md
+++ b/docs/rules/design-system/import-path.md
@@ -1,0 +1,37 @@
+# design-system/import-path
+
+Ensures design system components are imported from specific packages.
+
+Works with React, Vue, Svelte, and Web Components.
+
+## Configuration
+
+```json
+{
+  "rules": {
+    "design-system/import-path": [
+      "error",
+      { "packages": ["@acme/design-system"], "components": ["Button"] }
+    ]
+  }
+}
+```
+
+### Options
+
+- `packages` (`string[]`): allowed package names for design system components.
+- `components` (`string[]`): component names that must come from the specified packages.
+
+## Examples
+
+### Invalid
+
+```ts
+import { Button } from 'other-package';
+```
+
+### Valid
+
+```ts
+import { Button } from '@acme/design-system';
+```

--- a/src/rules/import-path.ts
+++ b/src/rules/import-path.ts
@@ -1,0 +1,53 @@
+import ts from 'typescript';
+import type { RuleModule } from '../core/types.js';
+
+interface ImportPathOptions {
+  packages?: string[];
+  components?: string[];
+}
+
+export const importPathRule: RuleModule = {
+  name: 'design-system/import-path',
+  meta: {
+    description:
+      'ensure design system components are imported from configured packages',
+  },
+  create(context) {
+    const opts = (context.options as ImportPathOptions) || {};
+    const packages = new Set(opts.packages || []);
+    const components = new Set(opts.components || []);
+    return {
+      onNode(node) {
+        if (!ts.isImportDeclaration(node)) return;
+        if (!node.importClause) return;
+        const moduleText = (node.moduleSpecifier as ts.StringLiteral).text;
+        if (packages.has(moduleText)) return;
+        const reportSpecifier = (nameNode: ts.Node, name: string) => {
+          const pos = nameNode
+            .getSourceFile()
+            .getLineAndCharacterOfPosition(nameNode.getStart());
+          context.report({
+            message: `Design system component "${name}" must be imported from ${
+              opts.packages?.join(', ') || 'configured packages'
+            }`,
+            line: pos.line + 1,
+            column: pos.character + 1,
+          });
+        };
+        const clause = node.importClause;
+        if (clause.name && components.has(clause.name.getText())) {
+          reportSpecifier(clause.name, clause.name.getText());
+        }
+        const bindings = clause.namedBindings;
+        if (bindings && ts.isNamedImports(bindings)) {
+          for (const elem of bindings.elements) {
+            const name = elem.name.getText();
+            if (components.has(name)) {
+              reportSpecifier(elem.name, name);
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -21,6 +21,7 @@ import { variantPropRule } from './variant-prop.js';
 import { componentPrefixRule } from './component-prefix.js';
 import { noInlineStylesRule } from './no-inline-styles.js';
 import { iconUsageRule } from './icon-usage.js';
+import { importPathRule } from './import-path.js';
 
 export const builtInRules = [
   animationRule,
@@ -46,4 +47,5 @@ export const builtInRules = [
   componentPrefixRule,
   noInlineStylesRule,
   iconUsageRule,
+  importPathRule,
 ];

--- a/tests/rules/import-path.test.ts
+++ b/tests/rules/import-path.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../../src/core/linter.ts';
+
+test('design-system/import-path flags components from wrong package', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/import-path': [
+        'error',
+        { packages: ['@acme/design-system'], components: ['Button'] },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    "import { Button } from 'other';",
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/import-path allows configured package', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/import-path': [
+        'error',
+        { packages: ['@acme/design-system'], components: ['Button'] },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    "import { Button } from '@acme/design-system';",
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 0);
+});
+
+test('design-system/import-path handles default imports', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/import-path': [
+        'error',
+        { packages: ['@acme/design-system'], components: ['Button'] },
+      ],
+    },
+  });
+  const res = await linter.lintText("import Button from 'other';", 'file.ts');
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/import-path enforces package in Vue components', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/import-path': [
+        'error',
+        { packages: ['@acme/design-system'], components: ['Button'] },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    "<script setup>import { Button } from 'other';</script>",
+    'file.vue',
+  );
+  assert.equal(res.messages.length, 1);
+});
+
+test('design-system/import-path enforces package in Svelte components', async () => {
+  const linter = new Linter({
+    rules: {
+      'design-system/import-path': [
+        'error',
+        { packages: ['@acme/design-system'], components: ['Button'] },
+      ],
+    },
+  });
+  const res = await linter.lintText(
+    "<script>import { Button } from 'other';</script>",
+    'file.svelte',
+  );
+  assert.equal(res.messages.length, 1);
+});


### PR DESCRIPTION
## Summary
- add `design-system/import-path` rule to require components be imported from allowed packages
- document import path rule configuration and usage
- test import path rule across React, Vue, Svelte, and TypeScript

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68b32a8fef5c8328a7ea103f6241eeda