### PR TITLE
docs: include all rules in navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,10 +28,24 @@ export default defineConfig({
             text: 'Design System',
             items: [
               {
+                text: 'component-prefix',
+                link: '/rules/design-system/component-prefix',
+              },
+              {
                 text: 'component-usage',
                 link: '/rules/design-system/component-usage',
               },
               { text: 'deprecation', link: '/rules/design-system/deprecation' },
+              { text: 'icon-usage', link: '/rules/design-system/icon-usage' },
+              { text: 'import-path', link: '/rules/design-system/import-path' },
+              {
+                text: 'no-inline-styles',
+                link: '/rules/design-system/no-inline-styles',
+              },
+              {
+                text: 'variant-prop',
+                link: '/rules/design-system/variant-prop',
+              },
             ],
           },
           {

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -7,6 +7,9 @@ Design-lint includes several built-in rules categorized by domain.
 - [component-prefix](./design-system/component-prefix)
 - [component-usage](./design-system/component-usage)
 - [deprecation](./design-system/deprecation)
+- [icon-usage](./design-system/icon-usage)
+- [import-path](./design-system/import-path)
+- [no-inline-styles](./design-system/no-inline-styles)
 - [variant-prop](./design-system/variant-prop)
 
 ## Design Token


### PR DESCRIPTION
## Summary
- include all Design System rule pages in VitePress sidebar
- sync rules index with available docs

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68b32d1f85d48328a27109d8d6d7d22f