### PR TITLE
docs: add logo and external links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,12 +4,15 @@ export default defineConfig({
   title: 'design-lint',
   description: 'Design system linter',
   themeConfig: {
+    logo: '/logo.svg',
     nav: [
       { text: 'Usage', link: '/usage' },
       { text: 'Configuration', link: '/configuration' },
       { text: 'API', link: '/api' },
       { text: 'Plugins', link: '/plugins' },
       { text: 'Rules', link: '/rules/' },
+      { text: 'GitHub', link: 'https://github.com/bylapidist/design-lint' },
+      { text: 'Author', link: 'https://lapidist.net' },
     ],
     sidebar: [
       {

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,8 @@
+<svg width="44" height="44" viewBox="0 0 44 44" xmlns="http://www.w3.org/2000/svg">
+  <rect width="44" height="44" rx="8" fill="#F4F6FA"/>
+  <rect x="10" y="10" width="8" height="8" rx="2" fill="#6C63FF"/>
+  <rect x="24" y="10" width="8" height="8" rx="2" fill="#6C63FF"/>
+  <rect x="10" y="24" width="8" height="8" rx="2" fill="#6C63FF"/>
+  <rect x="24" y="24" width="8" height="8" rx="2" fill="#FF7043" transform="rotate(10 28 28)"/>
+  <line x1="24" y1="36" x2="36" y2="36" stroke="#00C853" stroke-width="2" stroke-linecap="round" stroke-dasharray="2,2"/>
+</svg>


### PR DESCRIPTION
## Summary
- show project logo on docs site
- add links to GitHub repo and website
- rename website nav link to "Author"

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42d1d6be88328866c39d5a3608fe4