### PR TITLE
fix: suggest init when config file missing

### DIFF
--- a/.changeset/config-file-init-hint.md
+++ b/.changeset/config-file-init-hint.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+add config init hint when config file is missing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -183,3 +183,9 @@ Set `DESIGNLINT_PROFILE=1` to print how long the initial file scan takes. This c
 DESIGNLINT_PROFILE=1 npx design-lint src
 # Scanned 42 files in 120.34ms
 ```
+
+## Troubleshooting
+
+### Config file not found
+
+If the CLI reports `Config file not found`, run `npx design-lint init` to create a configuration file.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -44,7 +44,9 @@ export async function loadConfig(
     try {
       if (target) await fs.promises.access(target);
     } catch {
-      throw new Error(`Config file not found at ${target}`);
+      throw new Error(
+        `Config file not found at ${target}. Run \`npx design-lint init\` to create a config.`,
+      );
     }
   }
   let exists = false;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -49,7 +49,7 @@ test('throws when specified config file is missing', async () => {
   const tmp = makeTmpDir();
   await assert.rejects(
     loadConfig(tmp, 'designlint.config.json'),
-    /Config file not found/,
+    /Config file not found.*npx design-lint init/,
   );
 });
 


### PR DESCRIPTION
## Summary
- hint to run `npx design-lint init` when a config file is missing
- document how to resolve "Config file not found" errors

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4454e38b083289b73651d6b7430f6