### PR TITLE
refactor(cli): replace dynamic chalk import with static import

### DIFF
--- a/.changeset/replace-dynamic-chalk-import.md
+++ b/.changeset/replace-dynamic-chalk-import.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+replace dynamic chalk import with static import
+

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,7 @@ import { pathToFileURL, fileURLToPath } from 'url';
 import type { LintResult } from '../core/types.js';
 import type { Config } from '../core/linter.js';
 import { getFormatter } from '../formatters/index.js';
-// chalk is ESM-only, so we use a dynamic import inside run()
+import chalk, { supportsColor } from 'chalk';
 import ignore from 'ignore';
 import chokidar, { FSWatcher } from 'chokidar';
 import { relFromCwd, realpathIfExists } from '../utils/paths.js';
@@ -132,7 +132,6 @@ export async function run(argv = process.argv.slice(2)) {
     process.exitCode = 1;
     return;
   }
-  const { default: chalk, supportsColor } = await import('chalk');
   let useColor = Boolean(process.stdout.isTTY && supportsColor);
   try {
     const { values, positionals } = parseArgs({


### PR DESCRIPTION
## Summary
- replace dynamic chalk import with static import
- add changeset for chalk import refactor

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b447ef4a0c8328b1ce4f8b67e32f5f