### PR TITLE
feat(config): add wrapTokensWithVar option

### DIFF
--- a/.changeset/wrap-tokens-with-var.md
+++ b/.changeset/wrap-tokens-with-var.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add optional wrapTokensWithVar to normalize tokens as CSS variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,17 @@ export default defineConfig({
 - **opacity**: numbers between 0 and 1.
 - **outlines**: strings representing complete `outline` declarations.
 
+If your design tokens map directly to CSS custom properties, set
+`wrapTokensWithVar` to `true`. During normalization each string token will be
+wrapped in `var()` so rules compare against the corresponding CSS variable:
+
+```json
+{
+  "wrapTokensWithVar": true,
+  "tokens": { "colors": { "primary": "--color-primary" } }
+}
+```
+
 ```js
 module.exports = {
   tokens: {
@@ -100,6 +111,7 @@ syntax message.
 - `plugins`: Additional plugin packages to load.
 - `concurrency`: Maximum number of files processed concurrently. Defaults to the number of CPU cores.
 - `patterns`: Glob patterns used to search for files. Defaults to `['**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs,css,svelte,vue}']`.
+- `wrapTokensWithVar`: When `true`, wrap string token values in `var()` during normalization.
 
 ### Token dependencies
 

--- a/docs/examples/designlint.config.css-variables.json
+++ b/docs/examples/designlint.config.css-variables.json
@@ -1,16 +1,17 @@
 {
+  "wrapTokensWithVar": true,
   "tokens": {
     "colors": {
-      "primary": "var(--color-primary)",
-      "secondary": "var(--color-secondary)"
+      "primary": "--color-primary",
+      "secondary": "--color-secondary"
     },
     "spacing": {
-      "sm": "var(--spacing-sm)",
-      "lg": "var(--spacing-lg)"
+      "sm": "--spacing-sm",
+      "lg": "--spacing-lg"
     },
     "fontSizes": {
-      "base": "var(--font-size-base)",
-      "xl": "var(--font-size-xl)"
+      "base": "--font-size-base",
+      "xl": "--font-size-xl"
     }
   },
   "rules": {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -38,6 +38,7 @@ export async function loadConfig(
     ignoreFiles: [],
     plugins: [],
     configPath: abs,
+    wrapTokensWithVar: false,
   };
   if (configPath) {
     const target = abs ?? resolved;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -51,6 +51,7 @@ export const configSchema: z.ZodSchema<Config> = z
     configPath: z.string().optional(),
     concurrency: z.number().int().positive().optional(),
     patterns: z.array(z.string()).optional(),
+    wrapTokensWithVar: z.boolean().optional(),
   })
   .strict();
 

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -18,6 +18,7 @@ export { defaultIgnore } from './ignore.js';
 import { loadPlugins } from './plugin-loader.js';
 import { scanFiles } from './file-scanner.js';
 import { loadCache, saveCache, type CacheMap } from './cache.js';
+import { normalizeTokens } from './token-loader.js';
 
 export interface Config {
   tokens?: DesignTokens;
@@ -27,6 +28,7 @@ export interface Config {
   configPath?: string;
   concurrency?: number;
   patterns?: string[];
+  wrapTokensWithVar?: boolean;
 }
 
 interface EngineErrorOptions {
@@ -56,7 +58,10 @@ export class Linter {
    * @param config Linter configuration.
    */
   constructor(config: Config) {
-    this.config = config;
+    this.config = {
+      ...config,
+      tokens: normalizeTokens(config.tokens, config.wrapTokensWithVar ?? false),
+    };
     for (const rule of builtInRules) {
       this.ruleMap.set(rule.name, { rule, source: 'built-in' });
     }

--- a/src/core/token-loader.ts
+++ b/src/core/token-loader.ts
@@ -1,0 +1,42 @@
+import type { DesignTokens } from './types.js';
+
+/**
+ * Normalize design tokens.
+ * When wrapVar is true, string tokens are wrapped in `var()` unless they
+ * already use it.
+ *
+ * @param tokens Raw design tokens.
+ * @param wrapVar Wrap string tokens in `var()`.
+ * @returns Normalized tokens.
+ */
+export function normalizeTokens(
+  tokens: DesignTokens | undefined,
+  wrapVar = false,
+): DesignTokens {
+  const normalized: DesignTokens = {};
+  if (!tokens) return normalized;
+  for (const [group, defs] of Object.entries(tokens)) {
+    if (!defs || typeof defs !== 'object') {
+      (normalized as Record<string, unknown>)[group] = defs as unknown;
+      continue;
+    }
+    const map: Record<string, unknown> = {};
+    for (const [name, value] of Object.entries(
+      defs as Record<string, unknown>,
+    )) {
+      if (wrapVar && typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed.startsWith('var(')) {
+          map[name] = trimmed;
+        } else {
+          const tokenName = trimmed.startsWith('--') ? trimmed : `--${trimmed}`;
+          map[name] = `var(${tokenName})`;
+        }
+      } else {
+        map[name] = value;
+      }
+    }
+    (normalized as Record<string, unknown>)[group] = map;
+  }
+  return normalized;
+}

--- a/tests/token-loader.test.ts
+++ b/tests/token-loader.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeTokens } from '../src/core/token-loader.ts';
+import { Linter } from '../src/core/linter.ts';
+
+test('normalizeTokens wraps values with var when enabled', () => {
+  const tokens = { colors: { primary: '--color-primary' } };
+  const normalized = normalizeTokens(tokens, true);
+  assert.equal(normalized.colors?.primary, 'var(--color-primary)');
+});
+
+test('Linter applies wrapTokensWithVar option', async () => {
+  const linter = new Linter({
+    tokens: { fonts: { sans: '--font-sans' } },
+    wrapTokensWithVar: true,
+    rules: { 'design-token/font-family': 'error' },
+  });
+  const res = await linter.lintText(
+    '.a{font-family:var(--font-sans);}',
+    'file.css',
+  );
+  assert.equal(res.messages.length, 0);
+});
+
+test('Linter reports unknown CSS variable with wrapTokensWithVar', async () => {
+  const linter = new Linter({
+    tokens: { fonts: { sans: '--font-sans' } },
+    wrapTokensWithVar: true,
+    rules: { 'design-token/font-family': 'error' },
+  });
+  const res = await linter.lintText(
+    '.a{font-family:var(--other);}',
+    'file.css',
+  );
+  assert.equal(res.messages.length, 1);
+});


### PR DESCRIPTION
## Summary
- add `wrapTokensWithVar` option to normalize tokens into `var()` form
- document CSS variable token handling and update examples
- cover token wrapping in tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9be8071508328bc70a081f46629d2