### PR TITLE
feat: support multi-theme token validation

### DIFF
--- a/.changeset/multi-theme-tokens.md
+++ b/.changeset/multi-theme-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+support multiple theme roots with merged tokens and theme-aware validation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,30 @@ module.exports = {
 };
 ```
 
+### Multiple theme roots
+
+Provide tokens for several themes without custom code by nesting theme names at
+the top level. Token names are merged across themes internally:
+
+```ts
+import { defineConfig } from '@lapidist/design-lint';
+
+export default defineConfig({
+  tokens: {
+    base: { colors: { primary: '#000000' } },
+    light: { colors: { primary: '#ffffff' } },
+    dark: { colors: { primary: '#000000' } }
+  },
+  rules: {
+    // Validate only the light and dark themes
+    'design-token/colors': ['error', { themes: ['light', 'dark'] }],
+  },
+});
+```
+
+If no `themes` array is supplied, rules validate tokens from all themes by
+default.
+
 See [design-token/colors](rules/design-token/colors.md), [design-token/line-height](rules/design-token/line-height.md), [design-token/font-weight](rules/design-token/font-weight.md), [design-token/letter-spacing](rules/design-token/letter-spacing.md), [design-token/border-radius](rules/design-token/border-radius.md), [design-token/border-width](rules/design-token/border-width.md), [design-token/spacing](rules/design-token/spacing.md), [design-token/box-shadow](rules/design-token/box-shadow.md), [design-token/duration](rules/design-token/duration.md), [design-token/z-index](rules/design-token/z-index.md), [design-token/font-size](rules/design-token/font-size.md), and [design-token/font-family](rules/design-token/font-family.md) for rule details.
 
 @lapidist/design-lint searches for configuration starting from the current working

--- a/docs/examples/designlint.config.themes.ts
+++ b/docs/examples/designlint.config.themes.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@lapidist/design-lint';
+
+export default defineConfig({
+  tokens: {
+    base: { colors: { primary: '#000000' } },
+    light: { colors: { primary: '#ffffff' } },
+    dark: { colors: { primary: '#000000' } }
+  },
+  rules: {
+    'design-token/colors': ['error', { themes: ['light', 'dark'] }]
+  }
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -17,7 +17,7 @@ const ruleSettingSchema = z.union([
 
 const numberOrString = z.union([z.number(), z.string()]);
 
-const tokensSchema = z
+const baseTokensSchema = z
   .object({
     colors: z.record(z.string(), z.string()).optional(),
     spacing: z.record(z.string(), z.number()).optional(),
@@ -41,6 +41,11 @@ const tokensSchema = z
       .optional(),
   })
   .catchall(z.unknown());
+
+const tokensSchema = z.union([
+  baseTokensSchema,
+  z.record(z.string(), baseTokensSchema),
+]);
 
 export const configSchema: z.ZodSchema<Config> = z
   .object({

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -245,3 +245,19 @@ test('throws on unknown rule name', async () => {
     /Unknown rule\(s\): unknown\/rule/,
   );
 });
+
+test('loads config with multi-theme tokens', async () => {
+  const tmp = makeTmpDir();
+  const configPath = path.join(tmp, 'designlint.config.json');
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      tokens: {
+        light: { colors: { primary: '#fff' } },
+        dark: { colors: { primary: '#000' } },
+      },
+    }),
+  );
+  const loaded = await loadConfig(tmp);
+  assert.equal(loaded.tokens?.colors?.primary, '#fff');
+});

--- a/tests/token-loader.test.ts
+++ b/tests/token-loader.test.ts
@@ -5,8 +5,20 @@ import { Linter } from '../src/core/linter.ts';
 
 test('normalizeTokens wraps values with var when enabled', () => {
   const tokens = { colors: { primary: '--color-primary' } };
-  const normalized = normalizeTokens(tokens, true);
+  const normalized = normalizeTokens(tokens, true).merged;
   assert.equal(normalized.colors?.primary, 'var(--color-primary)');
+});
+
+test('normalizeTokens merges tokens across themes', () => {
+  const tokens = {
+    base: { colors: { primary: '#000' } },
+    light: { colors: { secondary: '#fff' } },
+  };
+  const normalized = normalizeTokens(tokens);
+  assert.equal(normalized.themes.base.colors?.primary, '#000');
+  assert.equal(normalized.themes.light.colors?.secondary, '#fff');
+  assert.equal(normalized.merged.colors?.primary, '#000');
+  assert.equal(normalized.merged.colors?.secondary, '#fff');
 });
 
 test('Linter applies wrapTokensWithVar option', async () => {
@@ -33,4 +45,32 @@ test('Linter reports unknown CSS variable with wrapTokensWithVar', async () => {
     'file.css',
   );
   assert.equal(res.messages.length, 1);
+});
+
+test('Rule theme filtering validates selected themes', async () => {
+  const linter = new Linter({
+    tokens: {
+      light: { colors: { primary: '#fff' } },
+      dark: { colors: { primary: '#000' } },
+    },
+    rules: { 'design-token/colors': ['error', { themes: ['dark'] }] },
+  });
+  const ok = await linter.lintText('.a{color:#000}', 'file.css');
+  assert.equal(ok.messages.length, 0);
+  const bad = await linter.lintText('.a{color:#fff}', 'file.css');
+  assert.equal(bad.messages.length, 1);
+});
+
+test('Rules validate all themes by default', async () => {
+  const linter = new Linter({
+    tokens: {
+      light: { colors: { primary: '#fff' } },
+      dark: { colors: { primary: '#000' } },
+    },
+    rules: { 'design-token/colors': 'error' },
+  });
+  const res1 = await linter.lintText('.a{color:#000}', 'file.css');
+  assert.equal(res1.messages.length, 0);
+  const res2 = await linter.lintText('.a{color:#fff}', 'file.css');
+  assert.equal(res2.messages.length, 0);
 });


### PR DESCRIPTION
## Summary
- allow tokens to be defined for multiple themes and merge them internally
- enable rules to target specific themes via `themes` option
- document multi-theme configuration

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68b9e06324788328a5ed6132bbf559cc