### PR TITLE
feat: support CSS variable token patterns

### DIFF
--- a/.changeset/token-patterns.md
+++ b/.changeset/token-patterns.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+allow token groups to define CSS variable patterns

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,34 @@ wrapped in `var()` so rules compare against the corresponding CSS variable:
 }
 ```
 
+### Token patterns
+
+Token groups may be defined as arrays of patterns rather than explicit maps.
+Each group is either a record of named tokens or an array of pattern strings and
+`RegExp` literals—mixing the two formats is not supported. Strings may include
+`*` wildcards that match any sequence of characters. During linting each
+`var(--token)` reference is tested against the provided patterns, and diagnostics
+report the concrete variable that matched.
+
+```json
+{
+  "tokens": { "colors": ["--colour-*"] }
+}
+```
+
+```ts
+export default {
+  tokens: { colors: ["--brand-*", /^--theme-/] },
+};
+```
+
+See [examples/designlint.config.token-patterns.json](examples/designlint.config.token-patterns.json)
+and [examples/designlint.config.token-patterns.ts](examples/designlint.config.token-patterns.ts)
+for complete configurations.
+
+For completeness, a configuration that enumerates tokens for several categories
+might look like:
+
 ```js
 module.exports = {
   tokens: {

--- a/docs/examples/designlint.config.token-patterns.json
+++ b/docs/examples/designlint.config.token-patterns.json
@@ -1,0 +1,9 @@
+{
+  "tokens": {
+    "colors": ["--colour-*", "--brand-*"]
+  },
+  "rules": {
+    "design-token/colors": "error"
+  }
+}
+

--- a/docs/examples/designlint.config.token-patterns.ts
+++ b/docs/examples/designlint.config.token-patterns.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@lapidist/design-lint';
+
+export default defineConfig({
+  tokens: {
+    colors: ['--brand-*', /^--theme-/],
+  },
+  rules: {
+    'design-token/colors': 'error',
+  },
+});
+

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { Config } from '../core/linter.js';
+import type { DesignTokens } from '../core/types.js';
 
 const severitySchema = z.union([
   z.literal('error'),
@@ -17,25 +18,30 @@ const ruleSettingSchema = z.union([
 
 const numberOrString = z.union([z.number(), z.string()]);
 
+const tokenPatternArray = z.array(z.union([z.string(), z.instanceof(RegExp)]));
+
+const tokenGroup = (schema: z.ZodTypeAny) =>
+  z.union([z.record(z.string(), schema), tokenPatternArray]);
+
 const baseTokensSchema = z
   .object({
-    colors: z.record(z.string(), z.string()).optional(),
-    spacing: z.record(z.string(), z.number()).optional(),
-    zIndex: z.record(z.string(), z.number()).optional(),
-    borderRadius: z.record(z.string(), numberOrString).optional(),
-    borderWidths: z.record(z.string(), numberOrString).optional(),
-    shadows: z.record(z.string(), z.string()).optional(),
-    durations: z.record(z.string(), numberOrString).optional(),
-    animations: z.record(z.string(), z.string()).optional(),
-    blurs: z.record(z.string(), numberOrString).optional(),
-    borderColors: z.record(z.string(), z.string()).optional(),
-    opacity: z.record(z.string(), numberOrString).optional(),
-    outlines: z.record(z.string(), z.string()).optional(),
-    fontSizes: z.record(z.string(), numberOrString).optional(),
-    fonts: z.record(z.string(), z.string()).optional(),
-    lineHeights: z.record(z.string(), numberOrString).optional(),
-    fontWeights: z.record(z.string(), numberOrString).optional(),
-    letterSpacings: z.record(z.string(), numberOrString).optional(),
+    colors: tokenGroup(z.string()).optional(),
+    spacing: tokenGroup(z.number()).optional(),
+    zIndex: tokenGroup(z.number()).optional(),
+    borderRadius: tokenGroup(numberOrString).optional(),
+    borderWidths: tokenGroup(numberOrString).optional(),
+    shadows: tokenGroup(z.string()).optional(),
+    durations: tokenGroup(numberOrString).optional(),
+    animations: tokenGroup(z.string()).optional(),
+    blurs: tokenGroup(numberOrString).optional(),
+    borderColors: tokenGroup(z.string()).optional(),
+    opacity: tokenGroup(numberOrString).optional(),
+    outlines: tokenGroup(z.string()).optional(),
+    fontSizes: tokenGroup(numberOrString).optional(),
+    fonts: tokenGroup(z.string()).optional(),
+    lineHeights: tokenGroup(numberOrString).optional(),
+    fontWeights: tokenGroup(numberOrString).optional(),
+    letterSpacings: tokenGroup(numberOrString).optional(),
     deprecations: z
       .record(z.string(), z.object({ replacement: z.string().optional() }))
       .optional(),
@@ -45,7 +51,7 @@ const baseTokensSchema = z
 const tokensSchema = z.union([
   baseTokensSchema,
   z.record(z.string(), baseTokensSchema),
-]);
+]) as unknown as z.ZodType<DesignTokens | Record<string, DesignTokens>>;
 
 export const configSchema: z.ZodSchema<Config> = z
   .object({

--- a/src/core/token-loader.ts
+++ b/src/core/token-loader.ts
@@ -35,6 +35,10 @@ function isMultiTheme(
 function normalizeSingle(tokens: DesignTokens, wrapVar: boolean): DesignTokens {
   const normalized: DesignTokens = {};
   for (const [group, defs] of Object.entries(tokens)) {
+    if (Array.isArray(defs)) {
+      (normalized as Record<string, unknown>)[group] = defs;
+      continue;
+    }
     if (!defs || typeof defs !== 'object') {
       (normalized as Record<string, unknown>)[group] = defs as unknown;
       continue;
@@ -70,6 +74,14 @@ export function mergeTokens(
     const source = tokensByTheme[theme];
     if (!source) continue;
     for (const [group, defs] of Object.entries(source)) {
+      if (Array.isArray(defs)) {
+        const target = ((merged as Record<string, unknown>)[group] ||
+          []) as unknown[];
+        (merged as Record<string, unknown>)[group] = Array.from(
+          new Set([...target, ...defs]),
+        );
+        continue;
+      }
       if (!defs || typeof defs !== 'object') {
         if ((merged as Record<string, unknown>)[group] === undefined) {
           (merged as Record<string, unknown>)[group] = defs as unknown;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,39 +2,39 @@ import type ts from 'typescript';
 
 export interface DesignTokens {
   /** Color tokens. */
-  colors?: Record<string, string>;
+  colors?: Record<string, string> | (string | RegExp)[];
   /** Spacing scale tokens. */
-  spacing?: Record<string, number>;
+  spacing?: Record<string, number> | (string | RegExp)[];
   /** z-index tokens. */
-  zIndex?: Record<string, number>;
+  zIndex?: Record<string, number> | (string | RegExp)[];
   /** Border radius tokens. */
-  borderRadius?: Record<string, number | string>;
+  borderRadius?: Record<string, number | string> | (string | RegExp)[];
   /** Border width tokens. */
-  borderWidths?: Record<string, number | string>;
+  borderWidths?: Record<string, number | string> | (string | RegExp)[];
   /** Box shadow tokens. */
-  shadows?: Record<string, string>;
+  shadows?: Record<string, string> | (string | RegExp)[];
   /** Motion duration tokens. */
-  durations?: Record<string, number | string>;
+  durations?: Record<string, number | string> | (string | RegExp)[];
   /** Animation tokens. */
-  animations?: Record<string, string>;
+  animations?: Record<string, string> | (string | RegExp)[];
   /** Blur tokens. */
-  blurs?: Record<string, number | string>;
+  blurs?: Record<string, number | string> | (string | RegExp)[];
   /** Border color tokens. */
-  borderColors?: Record<string, string>;
+  borderColors?: Record<string, string> | (string | RegExp)[];
   /** Opacity tokens. */
-  opacity?: Record<string, number | string>;
+  opacity?: Record<string, number | string> | (string | RegExp)[];
   /** Outline tokens. */
-  outlines?: Record<string, string>;
+  outlines?: Record<string, string> | (string | RegExp)[];
   /** Font size tokens. */
-  fontSizes?: Record<string, number | string>;
+  fontSizes?: Record<string, number | string> | (string | RegExp)[];
   /** Font family tokens. */
-  fonts?: Record<string, string>;
+  fonts?: Record<string, string> | (string | RegExp)[];
   /** Line height tokens. */
-  lineHeights?: Record<string, number | string>;
+  lineHeights?: Record<string, number | string> | (string | RegExp)[];
   /** Font weight tokens. */
-  fontWeights?: Record<string, number | string>;
+  fontWeights?: Record<string, number | string> | (string | RegExp)[];
   /** Letter spacing tokens. */
-  letterSpacings?: Record<string, number | string>;
+  letterSpacings?: Record<string, number | string> | (string | RegExp)[];
   /** Deprecated tokens and their replacements. */
   deprecations?: Record<string, { replacement?: string }>;
   /** Allow additional custom token groups. */

--- a/src/rules/token-font-family.ts
+++ b/src/rules/token-font-family.ts
@@ -1,11 +1,17 @@
 import type { RuleModule } from '../core/types.js';
+import { matchToken, extractVarName } from '../utils/token-match.js';
 
 export const fontFamilyRule: RuleModule = {
   name: 'design-token/font-family',
   meta: { description: 'enforce font-family tokens' },
   create(context) {
     const fontFamilies = context.tokens?.fonts;
-    if (!fontFamilies || Object.keys(fontFamilies).length === 0) {
+    if (
+      !fontFamilies ||
+      (Array.isArray(fontFamilies)
+        ? fontFamilies.length === 0
+        : Object.keys(fontFamilies).length === 0)
+    ) {
       context.report({
         message:
           'design-token/font-family requires fonts tokens; configure tokens.fonts to enable this rule.',
@@ -13,6 +19,22 @@ export const fontFamilyRule: RuleModule = {
         column: 1,
       });
       return {};
+    }
+    if (Array.isArray(fontFamilies)) {
+      return {
+        onCSSDeclaration(decl) {
+          if (decl.prop === 'font-family') {
+            const name = extractVarName(decl.value);
+            if (!name || !matchToken(name, fontFamilies)) {
+              context.report({
+                message: `Unexpected font family ${decl.value}`,
+                line: decl.line,
+                column: decl.column,
+              });
+            }
+          }
+        },
+      };
     }
     const fonts = new Set(Object.values(fontFamilies));
     return {

--- a/src/rules/token-font-size.ts
+++ b/src/rules/token-font-size.ts
@@ -1,11 +1,17 @@
 import type { RuleModule } from '../core/types.js';
+import { matchToken, extractVarName } from '../utils/token-match.js';
 
 export const fontSizeRule: RuleModule = {
   name: 'design-token/font-size',
   meta: { description: 'enforce font-size tokens' },
   create(context) {
     const fontSizes = context.tokens?.fontSizes;
-    if (!fontSizes || Object.keys(fontSizes).length === 0) {
+    if (
+      !fontSizes ||
+      (Array.isArray(fontSizes)
+        ? fontSizes.length === 0
+        : Object.keys(fontSizes).length === 0)
+    ) {
       context.report({
         message:
           'design-token/font-size requires fontSizes tokens; configure tokens.fontSizes to enable this rule.',
@@ -13,6 +19,22 @@ export const fontSizeRule: RuleModule = {
         column: 1,
       });
       return {};
+    }
+    if (Array.isArray(fontSizes)) {
+      return {
+        onCSSDeclaration(decl) {
+          if (decl.prop === 'font-size') {
+            const name = extractVarName(decl.value);
+            if (!name || !matchToken(name, fontSizes)) {
+              context.report({
+                message: `Unexpected font size ${decl.value}`,
+                line: decl.line,
+                column: decl.column,
+              });
+            }
+          }
+        },
+      };
     }
     const parseSize = (val: unknown): number | null => {
       if (typeof val === 'number') return val;

--- a/src/rules/token-outline.ts
+++ b/src/rules/token-outline.ts
@@ -1,12 +1,18 @@
 import valueParser from 'postcss-value-parser';
 import type { RuleModule } from '../core/types.js';
+import { matchToken, extractVarName } from '../utils/token-match.js';
 
 export const outlineRule: RuleModule = {
   name: 'design-token/outline',
   meta: { description: 'enforce outline tokens' },
   create(context) {
     const outlineTokens = context.tokens?.outlines;
-    if (!outlineTokens || Object.keys(outlineTokens).length === 0) {
+    if (
+      !outlineTokens ||
+      (Array.isArray(outlineTokens)
+        ? outlineTokens.length === 0
+        : Object.keys(outlineTokens).length === 0)
+    ) {
       context.report({
         message:
           'design-token/outline requires outline tokens; configure tokens.outlines to enable this rule.',
@@ -14,6 +20,22 @@ export const outlineRule: RuleModule = {
         column: 1,
       });
       return {};
+    }
+    if (Array.isArray(outlineTokens)) {
+      return {
+        onCSSDeclaration(decl) {
+          if (decl.prop === 'outline') {
+            const name = extractVarName(decl.value);
+            if (!name || !matchToken(name, outlineTokens)) {
+              context.report({
+                message: `Unexpected outline ${decl.value}`,
+                line: decl.line,
+                column: decl.column,
+              });
+            }
+          }
+        },
+      };
     }
     const normalize = (val: string): string =>
       valueParser.stringify(valueParser(val).nodes).trim();

--- a/src/utils/token-match.ts
+++ b/src/utils/token-match.ts
@@ -1,0 +1,33 @@
+export type TokenPattern = string | RegExp;
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function patternToRegExp(pattern: TokenPattern): RegExp {
+  if (pattern instanceof RegExp) return pattern;
+  const escaped = escapeRegExp(pattern).replace(/\\\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+/**
+ * Match a CSS variable name against provided token patterns.
+ * @param name CSS variable name (e.g. --color-primary)
+ * @param patterns List of allowed token patterns or explicit names.
+ * @returns The concrete token that matched or null if no match.
+ */
+export function matchToken(
+  name: string,
+  patterns: TokenPattern[],
+): string | null {
+  for (const p of patterns) {
+    if (patternToRegExp(p).test(name)) return name;
+  }
+  return null;
+}
+
+/** Extract a CSS variable name from a value like `var(--foo)` */
+export function extractVarName(value: string): string | null {
+  const m = value.trim().match(/^var\((--[A-Za-z0-9-_]+)\)$/);
+  return m ? m[1] : null;
+}

--- a/tests/token-patterns.test.ts
+++ b/tests/token-patterns.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../src/core/linter.ts';
+
+const rule = { 'design-token/colors': 'error' };
+
+void test('accepts CSS variables matching string patterns', async () => {
+  const linter = new Linter({
+    tokens: { colors: ['--colour-*'] },
+    rules: rule,
+  });
+  const { results } = await linter.lintText(
+    'a{color:var(--colour-primary);}',
+    'x.css',
+  );
+  assert.equal(results[0]?.messages.length, 0);
+});
+
+void test('reports variables not matching patterns', async () => {
+  const linter = new Linter({
+    tokens: { colors: ['--colour-*'] },
+    rules: rule,
+  });
+  const { results } = await linter.lintText('a{color:var(--other);}', 'x.css');
+  assert.equal(
+    results[0]?.messages[0]?.message,
+    'Unexpected color var(--other)',
+  );
+});
+
+void test('supports regex token patterns', async () => {
+  const linter = new Linter({ tokens: { colors: [/^--brand-/] }, rules: rule });
+  const { results } = await linter.lintText(
+    'a{color:var(--brand-primary);}',
+    'x.css',
+  );
+  assert.equal(results[0]?.messages.length, 0);
+});


### PR DESCRIPTION
## Summary
- allow token groups to define strings or regex patterns
- lint CSS variables against token patterns
- document and test pattern-based tokens
- expand docs with pattern examples and example configs

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68ba9ab5b24c83288577839e45154fc9