### PR TITLE
fix(cache): ignore missing cache file

### DIFF
--- a/.changeset/ignore-missing-cache.md
+++ b/.changeset/ignore-missing-cache.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+ignore ENOENT when reading cache file in loadCache to avoid spurious warnings

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -44,7 +44,9 @@ export async function loadCache(
   try {
     raw = await fs.readFile(cacheLocation, 'utf8');
   } catch (err) {
-    console.warn(`Failed to read cache at ${cacheLocation}:`, err);
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn(`Failed to read cache at ${cacheLocation}:`, err);
+    }
     return;
   }
 

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -48,9 +48,7 @@ test('loadCache handles missing cache file', async (t) => {
   await loadCache(cache, '/cache.json');
 
   assert.equal(cache.size, 0);
-  assert.ok(
-    warn.mock.calls[0]?.arguments[0].startsWith('Failed to read cache'),
-  );
+  assert.equal(warn.mock.callCount(), 0);
 });
 
 test('saveCache writes valid JSON', async () => {


### PR DESCRIPTION
## Summary
- suppress warnings when cache file is absent so smoke test doesn't fail
- test cache load without warning

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68baabd42fec8328988c6a6b37474ca8