### PR TITLE
feat(core): lint tagged template literals

### DIFF
--- a/.changeset/tagged-template-linting.md
+++ b/.changeset/tagged-template-linting.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add support for linting CSS in tagged template literals in JS/TS files
+

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -26,6 +26,14 @@ When linting Svelte files, the linter understands both `style` attributes and `s
 npx design-lint src/App.svelte
 ```
 
+## Tagged template literals
+
+JavaScript and TypeScript files using tagged template literals are parsed so CSS
+inside constructs like `styled.div\`color: red;\`` and `css\`...\`` or
+`tw\`...\`` can be linted. Only static template strings without interpolated
+expressions are analyzed. Use the `patterns` configuration field to include or
+exclude JS/TS sources as needed.
+
 ## Web Components
 
 Custom elements can be linted in `.html`, `.js`, or `.ts` files. Both inline `style` attributes and `<style>` tags are parsed using standard CSS; preprocessors must be compiled ahead of time.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,6 +157,13 @@ and `style:` directives. Declarations like
 
 are parsed so each individual style is checked against the configured rules.
 
+### Tagged template literals
+
+CSS inside JavaScript/TypeScript tagged template literals such as
+`styled.div\`color: red;\`` and `css\`...\`` or `tw\`...\`` is linted. Only
+static template strings without `${}` interpolations are analyzed. Configure the
+`patterns` field to include or exclude JS/TS sources when needed.
+
 Flag deprecated tokens or components and automatically replace them with [`design-system/deprecation`](rules/design-system/deprecation.md):
 
 ```json

--- a/tests/fixtures/tagged-template/designlint.config.json
+++ b/tests/fixtures/tagged-template/designlint.config.json
@@ -1,0 +1,4 @@
+{
+  "tokens": { "colors": { "primary": "#000000" } },
+  "rules": { "design-token/colors": "error" }
+}

--- a/tests/fixtures/tagged-template/src/styled.ts
+++ b/tests/fixtures/tagged-template/src/styled.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { css } from '@emotion/css';
+
+export const Styled = styled.div`
+  color: red;
+`;
+
+export const Emotion = css`
+  color: red;
+`;
+
+const colorVar = 'blue';
+export const Dynamic = styled.div`
+  color: ${colorVar};
+`;

--- a/tests/tagged-template.test.ts
+++ b/tests/tagged-template.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { Linter } from '../src/core/linter.ts';
+import { loadConfig } from '../src/config/loader.ts';
+
+const fixtureDir = path.join(__dirname, 'fixtures', 'tagged-template');
+
+test('reports CSS in tagged template literals', async () => {
+  const config = await loadConfig(fixtureDir);
+  const linter = new Linter(config);
+  const file = path.join(fixtureDir, 'src', 'styled.ts');
+  const {
+    results: [res],
+  } = await linter.lintFiles([file]);
+  const colorMessages = res.messages.filter(
+    (m) => m.ruleId === 'design-token/colors',
+  );
+  assert.equal(colorMessages.length, 2);
+});


### PR DESCRIPTION
## Summary
- parse CSS from `styled`, `css`, and `tw` tagged template literals
- allow including/excluding JS/TS files via `patterns` config
- document linting of tagged templates and static-only limitation

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baad830fe48328be6dd1ff92a22914