### PR TITLE
fix: handle TypeScript config files as ESM

### DIFF
--- a/.changeset/fix-ts-config-loading.md
+++ b/.changeset/fix-ts-config-loading.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix TypeScript config loading by always treating .ts files as ESM

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -62,7 +62,8 @@ export async function loadConfig(
   if (abs && exists) {
     try {
       let loaded: Config = {};
-      if (abs.endsWith('.ts') || abs.endsWith('.mts')) {
+      const ext = path.extname(abs);
+      if (ext === '.ts' || ext === '.mts') {
         try {
           const tsxEsm = 'tsx/esm';
           await import(tsxEsm);
@@ -71,8 +72,8 @@ export async function loadConfig(
             'To load TypeScript config files, please install tsx.',
           );
         }
-      }
-      if (abs.endsWith('.json')) {
+        loaded = (await loadEsmConfig(abs)) as Config;
+      } else if (ext === '.json') {
         const data = await fs.promises.readFile(abs, 'utf8');
         loaded = JSON.parse(data) as Config;
       } else if (isESM(abs)) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -169,6 +169,20 @@ test('loads config from .ts using defineConfig', async () => {
   assert.equal(loaded.tokens?.colors?.primary, '#000');
 });
 
+test('loads config from .ts with type annotations', async () => {
+  const tmp = makeTmpDir();
+  const configPath = path.join(tmp, 'designlint.config.ts');
+  const rel = path
+    .relative(tmp, path.resolve('src/index.ts'))
+    .replace(/\\/g, '/');
+  fs.writeFileSync(
+    configPath,
+    `import { defineConfig } from '${rel}';\nconst colours: string[] = [];\nexport default defineConfig({ tokens: { colors: { primary: '#000' } } });`,
+  );
+  const loaded = await loadConfig(tmp);
+  assert.equal(loaded.tokens?.colors?.primary, '#000');
+});
+
 test('restores original .mts handler after loading config', async () => {
   const tmp = makeTmpDir();
   const configPath = path.join(tmp, 'designlint.config.mts');


### PR DESCRIPTION
## Summary
- ensure TypeScript config files are always loaded via tsx as ESM
- test TypeScript config loading with type annotations

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc1fb2307083289b22e4170999b70e