### PR TITLE
fix: bust cache when file size changes

### DIFF
--- a/.changeset/bust-cache-on-size.md
+++ b/.changeset/bust-cache-on-size.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+ensure file changes bust cache even when mtime is unchanged

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -4,7 +4,10 @@ import writeFileAtomic from 'write-file-atomic';
 import { z } from 'zod';
 import type { LintResult } from './types.js';
 
-export type CacheMap = Map<string, { mtime: number; result: LintResult }>;
+export type CacheMap = Map<
+  string,
+  { mtime: number; size?: number; result: LintResult }
+>;
 
 const LintMessageSchema = z.object({
   ruleId: z.string(),
@@ -30,6 +33,7 @@ const CacheEntrySchema = z.tuple([
   z.string(),
   z.object({
     mtime: z.number(),
+    size: z.number().optional(),
     result: LintResultSchema,
   }),
 ]);


### PR DESCRIPTION
## Summary
- store file size in cache entries and compare it to detect content changes even when mtime stays the same
- bust cache when file size differs so edits are linted
- test cache busting when file size changes but mtime is unchanged

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc20e6a86c8328bed396972f13533a