### PR TITLE
fix: ignore numbers in non-style JSX props

### DIFF
--- a/.changeset/jsx-prop-ignore.md
+++ b/.changeset/jsx-prop-ignore.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix token rules to ignore numbers in non-style JSX props

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -6,6 +6,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const borderRadiusRule: RuleModule = {
   name: 'design-token/border-radius',
@@ -70,6 +71,7 @@ export const borderRadiusRule: RuleModule = {
     );
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         if (ts.isNumericLiteral(node)) {
           const value = Number(node.text);
           if (!allowed.has(value)) {

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -6,6 +6,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const borderWidthRule: RuleModule = {
   name: 'design-token/border-width',
@@ -81,6 +82,7 @@ export const borderWidthRule: RuleModule = {
     };
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         const report = (raw: string, value: number, n: ts.Node) => {
           if (!allowed.has(value)) {
             const pos = n

--- a/src/rules/token-duration.ts
+++ b/src/rules/token-duration.ts
@@ -6,6 +6,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const durationRule: RuleModule = {
   name: 'design-token/duration',
@@ -76,6 +77,7 @@ export const durationRule: RuleModule = {
     }
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         if (ts.isNumericLiteral(node)) {
           const value = Number(node.text);
           if (!allowed.has(value)) {

--- a/src/rules/token-font-weight.ts
+++ b/src/rules/token-font-weight.ts
@@ -5,6 +5,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const fontWeightRule: RuleModule = {
   name: 'design-token/font-weight',
@@ -53,6 +54,7 @@ export const fontWeightRule: RuleModule = {
     }
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         if (ts.isNumericLiteral(node)) {
           const value = Number(node.text);
           if (!numeric.has(value)) {

--- a/src/rules/token-letter-spacing.ts
+++ b/src/rules/token-letter-spacing.ts
@@ -5,6 +5,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const letterSpacingRule: RuleModule = {
   name: 'design-token/letter-spacing',
@@ -67,6 +68,7 @@ export const letterSpacingRule: RuleModule = {
     }
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         if (ts.isNumericLiteral(node)) {
           const value = Number(node.text);
           if (!numeric.has(value)) {

--- a/src/rules/token-line-height.ts
+++ b/src/rules/token-line-height.ts
@@ -5,6 +5,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const lineHeightRule: RuleModule = {
   name: 'design-token/line-height',
@@ -71,6 +72,7 @@ export const lineHeightRule: RuleModule = {
     );
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         const report = (raw: string, value: number, n: ts.Node) => {
           if (!allowed.has(value)) {
             const pos = n

--- a/src/rules/token-opacity.ts
+++ b/src/rules/token-opacity.ts
@@ -6,6 +6,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const opacityRule: RuleModule = {
   name: 'design-token/opacity',
@@ -59,6 +60,7 @@ export const opacityRule: RuleModule = {
     );
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         if (ts.isNumericLiteral(node)) {
           const value = Number(node.text);
           if (!allowed.has(value)) {

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -6,6 +6,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const spacingRule: RuleModule = {
   name: 'design-token/spacing',
@@ -64,6 +65,7 @@ export const spacingRule: RuleModule = {
     };
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         const report = (raw: string, value: number, n: ts.Node) => {
           if (!isAllowed(value)) {
             const pos = n

--- a/src/rules/token-z-index.ts
+++ b/src/rules/token-z-index.ts
@@ -5,6 +5,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const zIndexRule: RuleModule = {
   name: 'design-token/z-index',
@@ -50,6 +51,7 @@ export const zIndexRule: RuleModule = {
     );
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         if (ts.isNumericLiteral(node)) {
           const value = Number(node.text);
           if (!allowed.has(value)) {

--- a/src/utils/jsx.ts
+++ b/src/utils/jsx.ts
@@ -1,0 +1,18 @@
+import ts from 'typescript';
+
+export function isInNonStyleJsx(node: ts.Node): boolean {
+  let inJsx = false;
+  for (let curr = node.parent; curr; curr = curr.parent) {
+    if (ts.isJsxAttribute(curr)) {
+      return curr.name.getText() !== 'style';
+    }
+    if (
+      ts.isJsxElement(curr) ||
+      ts.isJsxSelfClosingElement(curr) ||
+      ts.isJsxFragment(curr)
+    ) {
+      inJsx = true;
+    }
+  }
+  return inJsx;
+}

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -75,6 +75,16 @@ test('design-token/spacing ignores var() fallbacks', async () => {
   assert.equal(res.messages.length, 0);
 });
 
+test('design-token/spacing ignores numbers in JSX props', async () => {
+  const linter = new Linter({
+    tokens: { spacing: { sm: 4, md: 8 } },
+    rules: { 'design-token/spacing': ['error', { base: 4 }] },
+  });
+  const code = 'export const C = () => <Component headingLevel={2} />;';
+  const res = await linter.lintText(code, 'file.tsx');
+  assert.equal(res.messages.length, 0);
+});
+
 test('design-token/spacing ignores nested functions', async () => {
   const linter = new Linter({
     tokens: { spacing: { sm: 4, md: 8 } },


### PR DESCRIPTION
## Summary
- avoid linting numeric literals in non-style JSX props
- add utility for detecting JSX context
- add regression test for spacing rule

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc247a0f888328b3ea0730f1c8ae41