### PR TITLE
fix: flag zero opacity values

### DIFF
--- a/.changeset/flag-opacity-zero.md
+++ b/.changeset/flag-opacity-zero.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix token-opacity to flag zero values in CSS

--- a/src/rules/token-opacity.ts
+++ b/src/rules/token-opacity.ts
@@ -61,7 +61,7 @@ export const opacityRule: RuleModule = {
       onNode(node) {
         if (ts.isNumericLiteral(node)) {
           const value = Number(node.text);
-          if (!allowed.has(value)) {
+          if (!Number.isNaN(value) && !allowed.has(value)) {
             const pos = node
               .getSourceFile()
               .getLineAndCharacterOfPosition(node.getStart());
@@ -76,8 +76,8 @@ export const opacityRule: RuleModule = {
       onCSSDeclaration(decl) {
         if (decl.prop === 'opacity') {
           const parsed = valueParser.unit(decl.value);
-          const num = parsed ? parseFloat(parsed.number) : Number(decl.value);
-          if (!isNaN(num) && !allowed.has(num)) {
+          const num = Number(parsed ? parsed.number : decl.value);
+          if (!Number.isNaN(num) && !allowed.has(num)) {
             context.report({
               message: `Unexpected opacity ${decl.value}`,
               line: decl.line,

--- a/tests/rules/opacity.test.ts
+++ b/tests/rules/opacity.test.ts
@@ -11,6 +11,15 @@ test('design-token/opacity reports invalid value', async () => {
   assert.equal(res.messages.length, 1);
 });
 
+test('design-token/opacity reports zero value', async () => {
+  const linter = new Linter({
+    tokens: { opacity: { low: 0.2 } },
+    rules: { 'design-token/opacity': 'error' },
+  });
+  const res = await linter.lintText('.a{opacity:0;}', 'file.css');
+  assert.equal(res.messages.length, 1);
+});
+
 test('design-token/opacity accepts valid values', async () => {
   const linter = new Linter({
     tokens: { opacity: { low: 0.2 } },


### PR DESCRIPTION
## Summary
- ensure token-opacity rule reports zero values
- add regression test for opacity zero literals

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc2421afe48328b5420db397b5deb5