### PR TITLE
fix: handle whitespace and fallbacks in extractVarName

### DIFF
--- a/.changeset/extract-var-name-fallback.md
+++ b/.changeset/extract-var-name-fallback.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix extractVarName to support whitespace and fallback values
+

--- a/src/utils/token-match.ts
+++ b/src/utils/token-match.ts
@@ -52,6 +52,6 @@ export function closestToken(
 
 /** Extract a CSS variable name from a value like `var(--foo)` */
 export function extractVarName(value: string): string | null {
-  const m = value.trim().match(/^var\((--[A-Za-z0-9-_]+)\)$/);
+  const m = value.trim().match(/^var\(\s*(--[A-Za-z0-9-_]+)\s*(?:,.*)?\)$/);
   return m ? m[1] : null;
 }

--- a/tests/token-match.test.ts
+++ b/tests/token-match.test.ts
@@ -18,5 +18,7 @@ test('closestToken skips non-string patterns and handles no suggestion', () => {
 
 test('extractVarName parses var() and ignores invalid values', () => {
   assert.equal(extractVarName('var(--x)'), '--x');
+  assert.equal(extractVarName('var(--x, 10px)'), '--x');
+  assert.equal(extractVarName('var(  --x  )'), '--x');
   assert.equal(extractVarName('--x'), null);
 });


### PR DESCRIPTION
## Summary
- allow extractVarName to parse CSS vars with whitespace and fallback values
- test extractVarName against whitespace and fallback scenarios
- add changeset

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc2f54c76c83289a135153d8d58744