### PR TITLE
fix: ignore non-style JSX attributes in more rules

### DIFF
--- a/.changeset/ignore-non-style-jsx-attributes.md
+++ b/.changeset/ignore-non-style-jsx-attributes.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+ignore non-style JSX attributes in colors and deprecation rules to avoid false positives

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -8,6 +8,7 @@ import {
   extractVarName,
   closestToken,
 } from '../utils/token-match.js';
+import { isInNonStyleJsx } from '../utils/jsx.js';
 
 type ColorFormat =
   | 'hex'
@@ -76,6 +77,7 @@ export const colorsRule: RuleModule = {
       };
       return {
         onNode(node) {
+          if (isInNonStyleJsx(node)) return;
           const sourceFile = node.getSourceFile();
           const handle = (text: string, n: ts.Node) => {
             const pos = sourceFile.getLineAndCharacterOfPosition(n.getStart());
@@ -133,6 +135,7 @@ export const colorsRule: RuleModule = {
 
     return {
       onNode(node) {
+        if (isInNonStyleJsx(node)) return;
         const sourceFile = node.getSourceFile();
         const handle = (text: string, n: ts.Node) => {
           const pos = sourceFile.getLineAndCharacterOfPosition(n.getStart());

--- a/tests/rules/colors.test.ts
+++ b/tests/rules/colors.test.ts
@@ -137,3 +137,16 @@ test('design-token/colors warns when tokens missing', async () => {
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.colors'));
 });
+
+test('design-token/colors ignores non-style jsx attributes', async () => {
+  const linter = new Linter({
+    tokens: { colors: { primary: '#ffffff' } },
+    rules: { 'design-token/colors': 'error' },
+  });
+  const res = await linter.lintText(
+    'const a = <div aria-label="Pause audio" style="color: #000" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+  assert.equal(res.messages[0].ruleId, 'design-token/colors');
+});

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -16,6 +16,18 @@ test('design-system/deprecation flags deprecated token', async () => {
   });
 });
 
+test('design-system/deprecation ignores tokens in non-style jsx attributes', async () => {
+  const linter = new Linter({
+    tokens: { deprecations: { old: { replacement: 'new' } } },
+    rules: { 'design-system/deprecation': 'error' },
+  });
+  const res = await linter.lintText(
+    'const a = <div aria-label="old" />;',
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 0);
+});
+
 test('design-system/deprecation warns when tokens missing', async () => {
   const linter = new Linter({
     rules: { 'design-system/deprecation': 'warn' },


### PR DESCRIPTION
## Summary
- ignore non-style JSX attributes in deprecation rule to avoid false positives
- rename changeset to cover multiple rules and mention deprecation fix

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc3ac7a80c83288ff9343353247be0