### PR TITLE
chore: loosen Node.js engine requirement

### DIFF
--- a/.changeset/node-engine-range.md
+++ b/.changeset/node-engine-range.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+broaden Node.js engine requirement to >=22

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "vitepress": "1.6.4"
       },
       "engines": {
-        "node": "24.7.0"
+        "node": ">=22"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "engines": {
-    "node": "24.7.0"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary
- set Node.js engines field to >=22
- add changeset for Node.js engine update

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d35a118832886d00d75cf282e7a