### PR TITLE
fix: parse var names in token completions

### DIFF
--- a/.changeset/token-completion-var-handling.md
+++ b/.changeset/token-completion-var-handling.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix getTokenCompletions to handle var() fallbacks and whitespace
+

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -6,10 +6,19 @@ void test('getTokenCompletions returns token names', () => {
   const linter = new Linter({
     tokens: {
       spacing: ['--space-scale-100'],
-      colors: { primary: 'var(--color-primary)', secondary: '#fff' },
+      colors: {
+        primary: 'var(--color-primary)',
+        secondary: '#fff',
+        accent: 'var(--color-accent, #000)',
+        spaced: 'var(  --color-spaced  )',
+      },
     },
   });
   const comps = linter.getTokenCompletions();
   assert.deepEqual(comps.spacing, ['--space-scale-100']);
-  assert.deepEqual(comps.colors, ['--color-primary']);
+  assert.deepEqual(comps.colors, [
+    '--color-primary',
+    '--color-accent',
+    '--color-spaced',
+  ]);
 });


### PR DESCRIPTION
## Summary
- ensure token completion parsing handles `var()` fallbacks and whitespace
- test token completions with fallback and spaced CSS variables

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d8feff083289e3cd955d6248229