### PR TITLE
fix(formatter): color warning summary correctly

### DIFF
--- a/.changeset/stylish-summary-color.md
+++ b/.changeset/stylish-summary-color.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix stylish formatter to color summary yellow when only warnings are present

--- a/src/formatters/stylish.ts
+++ b/src/formatters/stylish.ts
@@ -31,7 +31,12 @@ export function stylish(results: LintResult[], useColor = true): string {
   const total = errorCount + warnCount;
   if (total > 0) {
     const summary = `${total} problems (${errorCount} errors, ${warnCount} warnings)`;
-    lines.push(useColor ? codes.red(summary) : summary);
+    if (useColor) {
+      const color = errorCount > 0 ? codes.red : codes.yellow;
+      lines.push(color(summary));
+    } else {
+      lines.push(summary);
+    }
   }
   return lines.join('\n');
 }

--- a/tests/formatters/formatters.test.ts
+++ b/tests/formatters/formatters.test.ts
@@ -47,6 +47,25 @@ test('stylish formatter outputs suggestions', () => {
   assert.ok(out.includes('Did you mean `--foo`?'));
 });
 
+test('stylish formatter uses yellow summary when only warnings', () => {
+  const results: LintResult[] = [
+    {
+      filePath: 'file.ts',
+      messages: [
+        {
+          ruleId: 'rule',
+          message: 'warn msg',
+          severity: 'warn',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+  ];
+  const out = stylish(results);
+  assert.ok(out.includes('\x1b[33m1 problems (0 errors, 1 warnings)\x1b[0m'));
+});
+
 test('json formatter outputs json', () => {
   const results: LintResult[] = [
     {


### PR DESCRIPTION
## Summary
- fix stylish formatter to color summary yellow when only warnings are present
- add regression test
- add changeset

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d9188ac83289014b7c4fc3426a5