### PR TITLE
fix: respect negated ignore patterns

### DIFF
--- a/.changeset/respect-negated-ignore-patterns.md
+++ b/.changeset/respect-negated-ignore-patterns.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix scanning to respect negated ignore patterns
+

--- a/src/core/file-scanner.ts
+++ b/src/core/file-scanner.ts
@@ -69,7 +69,8 @@ export async function scanFiles(
             return neg ? `!${combined}` : combined;
           });
         ig.add(lines);
-        normalizedPatterns.push(...lines);
+        const positives = lines.filter((l) => !l.startsWith('!'));
+        normalizedPatterns.push(...positives);
       } catch {
         // ignore
       }

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -35,7 +35,8 @@ export async function loadIgnore(
         .split(/\r?\n/)
         .map((l) => l.trim())
         .filter((l) => l && !l.startsWith('#'));
-      ignorePatterns.push(...lines);
+      const positives = lines.filter((l) => !l.startsWith('!'));
+      ignorePatterns.push(...positives);
     } catch {
       // no ignore file
     }
@@ -50,7 +51,7 @@ export async function loadIgnore(
   if (config?.ignoreFiles) {
     const normalized = config.ignoreFiles.map((p) => p.replace(/\\/g, '/'));
     ig.add(normalized);
-    ignorePatterns.push(...normalized);
+    ignorePatterns.push(...normalized.filter((p) => !p.startsWith('!')));
   }
 
   const normalizedPatterns = ignorePatterns.map((p) => p.replace(/\\/g, '/'));

--- a/tests/core/glob-ignore.test.ts
+++ b/tests/core/glob-ignore.test.ts
@@ -24,3 +24,20 @@ test('scanFiles applies nested ignore files for glob targets', async () => {
     process.chdir(cwd);
   }
 });
+
+test('scanFiles respects negated patterns in ignore files', async () => {
+  const dir = makeTmpDir();
+  fs.writeFileSync(path.join(dir, 'keep.ts'), '');
+  fs.writeFileSync(path.join(dir, 'skip.ts'), '');
+  fs.writeFileSync(path.join(dir, '.gitignore'), '*.ts\n!keep.ts');
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const config: Config = { tokens: {}, rules: {} };
+    const { files } = await scanFiles(['**/*.ts'], config);
+    const rels = files.map((f) => path.relative(dir, f)).sort();
+    assert.deepEqual(rels, ['keep.ts']);
+  } finally {
+    process.chdir(cwd);
+  }
+});


### PR DESCRIPTION
## Summary
- handle negated patterns when reading ignore files so fast-glob doesn't exclude re-included files
- add regression test for negated ignore handling
- add changeset for patch release

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d9701c483288ea0b878d27597be