### PR TITLE
fix: handle case-insensitive hex tokens in no-unused-tokens

### DIFF
--- a/.changeset/case-insensitive-hex.md
+++ b/.changeset/case-insensitive-hex.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix no-unused-tokens rule to handle hex colors case-insensitively

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -618,8 +618,13 @@ export class Linter {
   private trackTokenUsage(text: string): void {
     for (const token of this.allTokenValues) {
       if (this.usedTokenValues.has(token)) continue;
-      if (/^[-#]/.test(token) || token.includes('--')) {
+      if (token.includes('--') || token.startsWith('-')) {
         if (text.includes(`var(${token})`) || text.includes(token)) {
+          this.usedTokenValues.add(token);
+        }
+      } else if (token.startsWith('#')) {
+        const lowerText = text.toLowerCase();
+        if (lowerText.includes(token.toLowerCase())) {
           this.usedTokenValues.add(token);
         }
       } else if (/^\d/.test(token)) {

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -53,3 +53,16 @@ test('design-system/no-unused-tokens can ignore tokens', async () => {
   );
   assert.equal(has, false);
 });
+
+test('design-system/no-unused-tokens matches hex case-insensitively', async () => {
+  const file = await tempFile('const color = "#ABCDEF";');
+  const linter = new Linter({
+    tokens: { colors: { primary: '#abcdef' } },
+    rules: { 'design-system/no-unused-tokens': 'warn' },
+  });
+  const { results } = await linter.lintFiles([file]);
+  const has = results.some((r) =>
+    r.messages.some((m) => m.ruleId === 'design-system/no-unused-tokens'),
+  );
+  assert.equal(has, false);
+});


### PR DESCRIPTION
## Summary
- handle hex token matching case-insensitively in `no-unused-tokens`
- add regression test for hex token case handling

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d951d108328bcc06e7ffda48be7