### PR TITLE
feat: show OK status for clean files in stylish formatter

### DIFF
--- a/.changeset/stylish-ok-feedback.md
+++ b/.changeset/stylish-ok-feedback.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+add OK feedback for files without lint messages in stylish formatter and remove extra newlines

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -6,7 +6,8 @@ objects and an optional `useColor` flag and returns a string to print.
 
 ## Built-in formatters
 
-- `stylish` – default, colorized summary intended for terminals.
+- `stylish` – default, colorized summary intended for terminals. Files without
+  problems are prefixed with `[OK]`.
 - `json` – raw JSON results, useful for piping to other tools.
 - `sarif` – emits a [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) log for CI systems.
 

--- a/src/formatters/stylish.ts
+++ b/src/formatters/stylish.ts
@@ -3,6 +3,7 @@ import type { LintResult } from '../core/types.js';
 const codes = {
   red: (s: string) => `\x1b[31m${s}\x1b[0m`,
   yellow: (s: string) => `\x1b[33m${s}\x1b[0m`,
+  green: (s: string) => `\x1b[32m${s}\x1b[0m`,
   underline: (s: string) => `\x1b[4m${s}\x1b[0m`,
 };
 
@@ -11,6 +12,11 @@ export function stylish(results: LintResult[], useColor = true): string {
   let errorCount = 0;
   let warnCount = 0;
   for (const res of results) {
+    if (res.messages.length === 0) {
+      const ok = useColor ? codes.green('[OK]') : '[OK]';
+      lines.push(`${ok} ${res.filePath}`);
+      continue;
+    }
     lines.push(useColor ? codes.underline(res.filePath) : res.filePath);
     for (const msg of res.messages) {
       if (msg.severity === 'error') errorCount++;
@@ -26,7 +32,6 @@ export function stylish(results: LintResult[], useColor = true): string {
         `  ${msg.line}:${msg.column}  ${sev}  ${msg.message}${suggestion}  ${msg.ruleId}`,
       );
     }
-    lines.push('');
   }
   const total = errorCount + warnCount;
   if (total > 0) {

--- a/tests/formatters/formatters.test.ts
+++ b/tests/formatters/formatters.test.ts
@@ -47,6 +47,37 @@ test('stylish formatter outputs suggestions', () => {
   assert.ok(out.includes('Did you mean `--foo`?'));
 });
 
+test('stylish formatter outputs OK for files without messages', () => {
+  const results: LintResult[] = [
+    { filePath: 'a.ts', messages: [] },
+    { filePath: 'b.ts', messages: [] },
+  ];
+  const out = stylish(results, false);
+  assert.equal(out, '[OK] a.ts\n[OK] b.ts');
+});
+
+test('stylish formatter does not insert blank line before summary', () => {
+  const results: LintResult[] = [
+    {
+      filePath: 'a.ts',
+      messages: [
+        {
+          ruleId: 'rule',
+          message: 'msg',
+          severity: 'error',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+  ];
+  const out = stylish(results, false);
+  assert.equal(
+    out,
+    'a.ts\n  1:1  error  msg  rule\n1 problems (1 errors, 0 warnings)',
+  );
+});
+
 test('json formatter outputs json', () => {
   const results: LintResult[] = [
     {


### PR DESCRIPTION
## Summary
- add `[OK]` prefix for files without messages in stylish formatter
- remove extra blank lines so output is contiguous, including before summary
- test the stylish formatter's clean file and summary output

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e063a8c8328982a5e9b3d6c26b9