### PR TITLE
fix(utils): handle React.createElement in isInNonStyleJsx

### DIFF
--- a/.changeset/fix-react-create-element-jsx.md
+++ b/.changeset/fix-react-create-element-jsx.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+handle React.createElement and h props in isInNonStyleJsx

--- a/src/utils/jsx.ts
+++ b/src/utils/jsx.ts
@@ -1,18 +1,46 @@
 import ts from 'typescript';
 
 export function isInNonStyleJsx(node: ts.Node): boolean {
-  let inJsx = false;
   for (let curr = node.parent; curr; curr = curr.parent) {
     if (ts.isJsxAttribute(curr)) {
       return curr.name.getText() !== 'style';
+    }
+    if (ts.isPropertyAssignment(curr)) {
+      if (curr.name.getText() === 'style') return false;
+      let p: ts.Node | undefined = curr.parent;
+      while (p) {
+        if (ts.isPropertyAssignment(p) && p.name.getText() === 'style') {
+          return false;
+        }
+        if (
+          ts.isJsxElement(p) ||
+          ts.isJsxSelfClosingElement(p) ||
+          ts.isJsxFragment(p)
+        ) {
+          return true;
+        }
+        if (ts.isCallExpression(p)) {
+          const expr = p.expression;
+          if (
+            (ts.isPropertyAccessExpression(expr) &&
+              expr.name.getText() === 'createElement' &&
+              expr.expression.getText() === 'React') ||
+            (ts.isIdentifier(expr) && expr.text === 'h')
+          ) {
+            return true;
+          }
+          break;
+        }
+        p = p.parent;
+      }
     }
     if (
       ts.isJsxElement(curr) ||
       ts.isJsxSelfClosingElement(curr) ||
       ts.isJsxFragment(curr)
     ) {
-      inJsx = true;
+      return true;
     }
   }
-  return inJsx;
+  return false;
 }

--- a/tests/utils/jsx-utils.test.ts
+++ b/tests/utils/jsx-utils.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ts from 'typescript';
+import { isInNonStyleJsx } from '../../src/utils/jsx.ts';
+
+function getStrings(code: string): ts.StringLiteral[] {
+  const sf = ts.createSourceFile(
+    'x.tsx',
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const nodes: ts.StringLiteral[] = [];
+  const walk = (node: ts.Node) => {
+    if (ts.isStringLiteral(node)) nodes.push(node);
+    ts.forEachChild(node, walk);
+  };
+  walk(sf);
+  return nodes;
+}
+
+test('isInNonStyleJsx handles React.createElement props', () => {
+  const [, title, color] = getStrings(
+    "React.createElement('div', { title: 'foo', style: { color: 'bar' } })",
+  );
+  assert.equal(isInNonStyleJsx(title), true);
+  assert.equal(isInNonStyleJsx(color), false);
+});
+
+test('isInNonStyleJsx handles h() props', () => {
+  const [, title, color] = getStrings(
+    "h('div', { title: 'foo', style: { color: 'bar' } })",
+  );
+  assert.equal(isInNonStyleJsx(title), true);
+  assert.equal(isInNonStyleJsx(color), false);
+});


### PR DESCRIPTION
## Summary
- detect React.createElement and h call props in `isInNonStyleJsx`
- add tests for `isInNonStyleJsx` utility
- document patch

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc5d909f548328a2d88f3283bdb0db