### PR TITLE
feat(cli): show lint stats after run

### DIFF
--- a/.changeset/lint-stats-stylish.md
+++ b/.changeset/lint-stats-stylish.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+add lint run statistics to stylish output


### PR DESCRIPTION
## Summary
- output number of linted files and duration after running lint in stylish mode
- track lint timing via `perf_hooks`

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc622b3c0c83288dc1f1be6976cf3c