### PR TITLE
fix(config): surface ts config errors

### DIFF
--- a/.changeset/surface-ts-config-errors.md
+++ b/.changeset/surface-ts-config-errors.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix TypeScript config loading to surface actual errors

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -80,10 +80,16 @@ export async function loadConfig(
           const { tsImport } = await import('tsx/esm/api');
           const mod = await tsImport(abs, import.meta.url);
           loaded = unwrapDefault<Config>(mod);
-        } catch {
-          throw new Error(
-            'To load TypeScript config files, please install tsx.',
-          );
+        } catch (err) {
+          if (
+            (err as NodeJS.ErrnoException)?.code === 'ERR_MODULE_NOT_FOUND' &&
+            /['"]tsx['"]/.test((err as Error).message ?? '')
+          ) {
+            throw new Error(
+              'To load TypeScript config files, please install tsx.',
+            );
+          }
+          throw err;
         }
       } else if (ext === '.json') {
         const data = await fs.promises.readFile(abs, 'utf8');

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -319,3 +319,13 @@ test('loads config with multi-theme tokens', async () => {
   const loaded = await loadConfig(tmp);
   assert.equal(loaded.tokens?.colors?.primary, '#fff');
 });
+
+test('surfaces errors thrown by ts config', async () => {
+  const tmp = makeTmpDir();
+  const configPath = path.join(tmp, 'designlint.config.ts');
+  fs.writeFileSync(
+    configPath,
+    "throw new Error('boom'); export default {} as const;",
+  );
+  await assert.rejects(loadConfig(tmp), /boom/);
+});


### PR DESCRIPTION
## Summary
- handle missing `tsx` separately so real TypeScript config errors surface
- add regression test for propagating errors from TypeScript config files

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc8458562483288105bc0822556f86