### PR TITLE
fix(linter): handle non-positive concurrency

### DIFF
--- a/.changeset/guard-negative-concurrency.md
+++ b/.changeset/guard-negative-concurrency.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+handle non-positive concurrency values in lintFiles

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -153,7 +153,11 @@ export class Linter {
         if (!files.includes(key)) cache.delete(key);
       }
     }
-    const limit = pLimit(this.config.concurrency ?? os.cpus().length);
+    const concurrency = Math.max(
+      1,
+      Math.floor(this.config.concurrency ?? os.cpus().length),
+    );
+    const limit = pLimit(concurrency);
     const tasks = files.map((filePath) =>
       limit(async () => {
         try {

--- a/tests/core/concurrency.test.ts
+++ b/tests/core/concurrency.test.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Linter } from '../../src/index.ts';
+
+// Ensure lintFiles works when concurrency is 0 or negative
+// by falling back to a minimum concurrency of 1.
+test('lintFiles handles non-positive concurrency values', async () => {
+  const dir = await fs.mkdtemp(path.join(process.cwd(), 'tmp-'));
+  const file = path.join(dir, 'test.css');
+  await fs.writeFile(file, 'a{color:red}');
+  const linter = new Linter({ concurrency: 0 });
+  const res = await linter.lintFiles([file]);
+  assert.equal(res.results[0]?.filePath, file);
+  await fs.rm(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- ensure lintFiles falls back to a concurrency of at least 1
- add regression test for concurrency handling

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc89a1cad08328bfdd8499e5a9c440