### PR TITLE
fix(core): respect disable-next-line only in comments

### DIFF
--- a/.changeset/no-directive-in-strings.md
+++ b/.changeset/no-directive-in-strings.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+prevent string literals from disabling next line linting directives

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -749,7 +749,7 @@ function getDisabledLines(text: string): Set<number> {
       block = false;
       continue;
     }
-    if (/design-lint-disable-next-line/.test(line)) {
+    if (/(?:\/\/|\/\*)\s*design-lint-disable-next-line/.test(line)) {
       disabled.add(i + 2);
       continue;
     }

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -27,3 +27,19 @@ test('inline directives disable linting', async () => {
   const lines = res.messages.map((m) => m.line).sort();
   assert.deepEqual(lines, [1, 8]);
 });
+
+test('strings resembling directives do not disable next line', async () => {
+  const dir = makeTmpDir();
+  const file = path.join(dir, 'file.ts');
+  fs.writeFileSync(
+    file,
+    "const a = 'design-lint-disable-next-line';\n" + "const b = 'old';\n",
+  );
+  const linter = new Linter({
+    tokens: { deprecations: { old: { replacement: 'new' } } },
+    rules: { 'design-system/deprecation': 'error' },
+  });
+  const res = await linter.lintFile(file);
+  assert.equal(res.messages.length, 1);
+  assert.equal(res.messages[0].line, 2);
+});


### PR DESCRIPTION
## Summary
- ensure `design-lint-disable-next-line` is honored only in comments
- add regression test for string literals containing directive text

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc89b20a2c832891ec02baf4643dd0