### PR TITLE
fix: tighten extractVarName validation

### DIFF
--- a/.changeset/fix-extract-varname-regex.md
+++ b/.changeset/fix-extract-varname-regex.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix extractVarName to reject invalid characters in variable names

--- a/src/utils/token-match.ts
+++ b/src/utils/token-match.ts
@@ -52,6 +52,6 @@ export function closestToken(
 
 /** Extract a CSS variable name from a value like `var(--foo)` */
 export function extractVarName(value: string): string | null {
-  const m = value.trim().match(/^var\(\s*(--[A-Za-z0-9-_]+)\s*(?:,.*)?\)$/);
+  const m = value.trim().match(/^var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,.*)?\)$/);
   return m ? m[1] : null;
 }

--- a/tests/token-match.test.ts
+++ b/tests/token-match.test.ts
@@ -21,4 +21,5 @@ test('extractVarName parses var() and ignores invalid values', () => {
   assert.equal(extractVarName('var(--x, 10px)'), '--x');
   assert.equal(extractVarName('var(  --x  )'), '--x');
   assert.equal(extractVarName('--x'), null);
+  assert.equal(extractVarName('var(--foo.bar)'), null);
 });


### PR DESCRIPTION
## Summary
- ensure extractVarName rejects invalid characters in variable names
- add regression test

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc89c723c88328b9409814352819f2