### PR TITLE
fix: support design-lint-disable-line directive

### DIFF
--- a/.changeset/support-disable-line.md
+++ b/.changeset/support-disable-line.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+support design-lint-disable-line directive

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -753,6 +753,10 @@ function getDisabledLines(text: string): Set<number> {
       disabled.add(i + 2);
       continue;
     }
+    if (/design-lint-disable-line/.test(line)) {
+      disabled.add(i + 1);
+      continue;
+    }
     if (block) disabled.add(i + 1);
   }
   return disabled;

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -11,13 +11,14 @@ test('inline directives disable linting', async () => {
   fs.writeFileSync(
     file,
     "const a = 'old';\n" +
+      "const b = 'old'; // design-lint-disable-line\n" +
       '// design-lint-disable-next-line\n' +
-      "const b = 'old';\n" +
-      '/* design-lint-disable */\n' +
       "const c = 'old';\n" +
+      '/* design-lint-disable */\n' +
       "const d = 'old';\n" +
+      "const e = 'old';\n" +
       '/* design-lint-enable */\n' +
-      "const e = 'old';\n",
+      "const f = 'old';\n",
   );
   const linter = new Linter({
     tokens: { deprecations: { old: { replacement: 'new' } } },
@@ -25,5 +26,5 @@ test('inline directives disable linting', async () => {
   });
   const res = await linter.lintFile(file);
   const lines = res.messages.map((m) => m.line).sort();
-  assert.deepEqual(lines, [1, 8]);
+  assert.deepEqual(lines, [1, 9]);
 });


### PR DESCRIPTION
## Summary
- support `design-lint-disable-line` to disable checks on current line
- cover inline disable-line directive with tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc89b7b16c8328858b2ec327c7aa9f