### PR TITLE
fix(utils): handle empty target path in relFrom

### DIFF
--- a/.changeset/relfrom-empty-path.md
+++ b/.changeset/relfrom-empty-path.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix relFrom to return empty string for empty target path

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -14,8 +14,9 @@ export const toPosix = (p: string) => p.split(path.sep).join('/');
  * @param p Target path.
  * @returns Relative path using POSIX separators.
  */
-export const relFrom = (root: string, p: string) => {
-  const rel = path.relative(root, p || '');
+export const relFrom = (root: string, p?: string) => {
+  if (!p) return '';
+  const rel = path.relative(root, p);
   return toPosix(rel);
 };
 

--- a/tests/path-utils.test.ts
+++ b/tests/path-utils.test.ts
@@ -24,6 +24,11 @@ test('relFrom handles empty path', () => {
   assert.equal(relFrom(process.cwd(), ''), '');
 });
 
+test('relFrom returns empty path for differing roots', () => {
+  const root = path.join(process.cwd(), 'foo');
+  assert.equal(relFrom(root, ''), '');
+});
+
 test('realpathIfExists resolves paths', () => {
   const tmp = makeTmpDir();
   const rp = realpathIfExists(tmp);


### PR DESCRIPTION
## Summary
- ensure relFrom returns empty string when target path is missing
- test relFrom against differing roots

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npx tsx --test tests/path-utils.test.ts`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc89af891c832884adeaa0fcb6529f