### PR TITLE
fix(formatter): update sarif rule descriptions

### DIFF
--- a/.changeset/update-sarif-rule-descriptions.md
+++ b/.changeset/update-sarif-rule-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix sarif formatter to update rule descriptions from later results

--- a/src/formatters/sarif.ts
+++ b/src/formatters/sarif.ts
@@ -39,7 +39,12 @@ export function sarifFormatter(
   for (const res of results) {
     if (res.ruleDescriptions) {
       for (const [id, desc] of Object.entries(res.ruleDescriptions)) {
-        if (!descMap.has(id)) descMap.set(id, desc);
+        descMap.set(id, desc);
+        const existingIndex = ruleMap.get(id);
+        if (existingIndex !== undefined) {
+          sarif.runs[0].tool.driver.rules[existingIndex].shortDescription.text =
+            desc;
+        }
       }
     }
     for (const msg of res.messages) {

--- a/tests/formatters/formatters.test.ts
+++ b/tests/formatters/formatters.test.ts
@@ -134,6 +134,44 @@ test('sarif formatter outputs rules and links results', () => {
   assert.equal(run.results[0].ruleIndex, 0);
 });
 
+test('sarif formatter updates rule descriptions from later results', () => {
+  const results: LintResult[] = [
+    {
+      filePath: 'a.ts',
+      messages: [
+        {
+          ruleId: 'rule',
+          message: 'first',
+          severity: 'error',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      filePath: 'b.ts',
+      messages: [
+        {
+          ruleId: 'rule',
+          message: 'second',
+          severity: 'error',
+          line: 1,
+          column: 1,
+        },
+      ],
+      ruleDescriptions: { rule: 'rule description' },
+    },
+  ];
+  const out = sarifFormatter(results);
+  const parsed = JSON.parse(out);
+  const run = parsed.runs[0];
+  assert.equal(run.tool.driver.rules.length, 1);
+  assert.equal(
+    run.tool.driver.rules[0].shortDescription.text,
+    'rule description',
+  );
+});
+
 test('getFormatter returns formatter for valid name', async () => {
   assert.equal(await getFormatter('json'), jsonFormatter);
 });


### PR DESCRIPTION
## Summary
- ensure SARIF formatter refreshes rule descriptions when later results provide them
- test SARIF formatter updates rule descriptions

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bc89c3cbd883289aff06f51da8ff26