### PR TITLE
fix: avoid duplicate reports for single style properties

### DIFF
--- a/.changeset/single-style-duplicate.md
+++ b/.changeset/single-style-duplicate.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+avoid duplicate reports for single style property strings

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -560,6 +560,7 @@ export class Linter {
               m.line === 1 ? start.character + m.column - 1 : m.column;
             messages.push({ ...m, line, column });
           }
+          return;
         } else if (ts.isTaggedTemplateExpression(node)) {
           const root = getRootTag(node.tag as ts.LeftHandSideExpression);
           if (
@@ -588,6 +589,7 @@ export class Linter {
                 m.line === 1 ? start.character + m.column - 1 : m.column;
               messages.push({ ...m, line, column });
             }
+            return;
           }
         }
         ts.forEachChild(node, visit);

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -62,3 +62,16 @@ test('reports raw tokens in string style attributes', async () => {
   assert.equal(res.messages.length, 3);
   assertIds(res.messages);
 });
+
+test('reports raw tokens once for single style property', async () => {
+  const linter = new Linter({
+    tokens: { colors: { primary: '#000000' } },
+    rules: { 'design-token/colors': 'error' },
+  });
+  const res = await linter.lintText(
+    `const C = () => <div style="color: #fff"></div>;`,
+    'file.tsx',
+  );
+  assert.equal(res.messages.length, 1);
+  assert.equal(res.messages[0]?.ruleId, 'design-token/colors');
+});


### PR DESCRIPTION
## Summary
- avoid double-reporting by skipping AST traversal of string style attributes
- test single style attribute property

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc89b407848328aa45feea6a729e21