### PR TITLE
fix(token-match): support wildcard patterns

### DIFF
--- a/.changeset/wildcard-token-matching.md
+++ b/.changeset/wildcard-token-matching.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix token matcher wildcard handling

--- a/src/utils/token-match.ts
+++ b/src/utils/token-match.ts
@@ -8,7 +8,10 @@ function escapeRegExp(str: string): string {
 
 function patternToRegExp(pattern: TokenPattern): RegExp {
   if (pattern instanceof RegExp) return pattern;
-  const escaped = escapeRegExp(pattern).replace(/\\\*/g, '.*');
+  const escaped = pattern
+    .split('*')
+    .map((seg) => escapeRegExp(seg))
+    .join('.*');
   return new RegExp(`^${escaped}$`);
 }
 

--- a/tests/token-match.test.ts
+++ b/tests/token-match.test.ts
@@ -6,8 +6,9 @@ import {
   extractVarName,
 } from '../src/utils/token-match.ts';
 
-test('matchToken handles regexp patterns and missing matches', () => {
+test('matchToken handles regexp and wildcard patterns and missing matches', () => {
   assert.equal(matchToken('--brand-primary', [/^--brand-/]), '--brand-primary');
+  assert.equal(matchToken('--brand-primary', ['--brand-*']), '--brand-primary');
   assert.equal(matchToken('--foo', ['--bar']), null);
 });
 


### PR DESCRIPTION
## Summary
- handle wildcard token patterns using segment-based conversion
- test token matcher against wildcard patterns

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc89b2f5f88328aa491507962488e3