### PR TITLE
chore(renovate): pin engines to node >=22

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,15 @@
   "extends": [
     "config:recommended"
   ],
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "constraints": {
+    "node": ">=22"
+  },
+  "packageRules": [
+    {
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
+      "allowedVersions": ">=22"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- configure Renovate to enforce Node.js engines >=22

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb393bb4c832893262366e6d6d277