### PR TITLE
refactor(cli): reuse scanFiles for globbing

### DIFF
--- a/.changeset/remove-fast-glob-dep.md
+++ b/.changeset/remove-fast-glob-dep.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor CLI to use internal file scanner and drop fast-glob dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "commander": "14.0.0",
         "cosmiconfig": "9.0.0",
         "cosmiconfig-typescript-loader": "6.1.0",
-        "fast-glob": "3.3.3",
         "fast-levenshtein": "3.0.0",
         "flat-cache": "6.1.13",
         "globby": "14.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "commander": "14.0.0",
     "cosmiconfig": "9.0.0",
     "cosmiconfig-typescript-loader": "6.1.0",
-    "fast-glob": "3.3.3",
     "fast-levenshtein": "3.0.0",
     "flat-cache": "6.1.13",
     "globby": "14.1.0",


### PR DESCRIPTION
## Summary
- drop direct fast-glob usage in CLI and rely on built-in scanFiles
- remove fast-glob dependency

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcbdee46e0832896d2435b860b81d2