### PR TITLE
refactor(tmp): use tempy for temporary directories

### DIFF
--- a/.changeset/use-tempy-for-temp-dirs.md
+++ b/.changeset/use-tempy-for-temp-dirs.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor tmp util to use tempy for temporary directories

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "postcss-value-parser": "4.2.0",
         "string-similarity": "^4.0.4",
         "svelte": "5.38.7",
+        "tempy": "^3.1.0",
         "typescript": "5.9.2",
         "write-file-atomic": "6.0.0",
         "zod": "4.1.5"
@@ -3571,6 +3572,33 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -4688,6 +4716,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-subdir": {
@@ -6830,6 +6870,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -7360,6 +7427,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -7393,6 +7472,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "postcss-value-parser": "4.2.0",
     "string-similarity": "^4.0.4",
     "svelte": "5.38.7",
+    "tempy": "^3.1.0",
     "typescript": "5.9.2",
     "write-file-atomic": "6.0.0",
     "zod": "4.1.5"

--- a/src/utils/tmp.ts
+++ b/src/utils/tmp.ts
@@ -1,18 +1,12 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
+import { temporaryDirectory } from 'tempy';
 
 /**
- * Create a temporary directory and return its resolved path.
+ * Create a temporary directory using {@link https://github.com/sindresorhus/tempy | tempy}.
+ *
  * @param prefix Directory name prefix.
  * @returns Absolute path to the created directory.
  */
 export function makeTmpDir(prefix = 'designlint-') {
-  const base = os.tmpdir();
-  const p = fs.mkdtempSync(path.join(base, prefix));
-  if (fs.realpathSync.native) {
-    return fs.realpathSync.native(p);
-  }
-  /* c8 ignore next */
-  return fs.realpathSync(p);
+  const sanitizedPrefix = prefix.replace(/[-_]+$/, '');
+  return temporaryDirectory({ prefix: sanitizedPrefix });
 }

--- a/tests/tmp-utils.test.ts
+++ b/tests/tmp-utils.test.ts
@@ -3,19 +3,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 
-test('makeTmpDir falls back when native realpath missing', () => {
-  const native = fs.realpathSync.native;
-  Object.defineProperty(fs.realpathSync, 'native', {
-    value: undefined,
-    configurable: true,
-    writable: true,
-  });
+test('makeTmpDir creates a temporary directory', () => {
   const dir = makeTmpDir('test-');
   assert.ok(fs.existsSync(dir));
   fs.rmSync(dir, { recursive: true, force: true });
-  Object.defineProperty(fs.realpathSync, 'native', {
-    value: native,
-    configurable: true,
-    writable: true,
-  });
 });


### PR DESCRIPTION
## Summary
- use tempy for tmp directory creation
- simplify tmp util tests
- add changeset for tempy tmp util

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bcc3bd282c8328b36f986f07e94b36