### PR TITLE
refactor: centralize plugin resolution and expose plugin paths

### DIFF
--- a/.changeset/plugin-path-resolution-helper.md
+++ b/.changeset/plugin-path-resolution-helper.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor plugin resolution into shared helper and expose resolved paths for watch mode

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -55,6 +55,7 @@ export class Linter {
   private ruleMap: Map<string, { rule: RuleModule; source: string }> =
     new Map();
   private pluginLoad: Promise<void>;
+  private pluginPaths: string[] = [];
   private allTokenValues = new Set<string>();
   private usedTokenValues = new Set<string>();
   private unusedTokenRules: {
@@ -77,7 +78,13 @@ export class Linter {
     for (const rule of builtInRules) {
       this.ruleMap.set(rule.name, { rule, source: 'built-in' });
     }
-    this.pluginLoad = loadPlugins(this.config, this.ruleMap, createEngineError);
+    this.pluginLoad = loadPlugins(
+      this.config,
+      this.ruleMap,
+      createEngineError,
+    ).then((paths) => {
+      this.pluginPaths = paths;
+    });
     this.allTokenValues = collectTokenValues(
       this.config.tokens as DesignTokens,
     );
@@ -243,6 +250,15 @@ export class Linter {
       }
     }
     return completions;
+  }
+
+  /**
+   * Get resolved plugin paths.
+   * @returns Array of plugin file paths.
+   */
+  async getPluginPaths(): Promise<string[]> {
+    await this.pluginLoad;
+    return this.pluginPaths;
   }
 
   /**

--- a/src/core/plugin-resolver.ts
+++ b/src/core/plugin-resolver.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import type { Config } from './linter.js';
+import { realpathIfExists, relFromCwd } from '../utils/paths.js';
+
+/**
+ * Resolve absolute paths for plugins defined in the config.
+ * @param config Linter configuration
+ * @returns Array of resolved plugin paths
+ */
+export function resolvePluginPaths(config: Config): string[] {
+  const req = config.configPath
+    ? createRequire(config.configPath)
+    : createRequire(import.meta.url);
+  const paths: string[] = [];
+  for (const p of config.plugins || []) {
+    try {
+      const resolved = realpathIfExists(req.resolve(p));
+      if (!fs.existsSync(resolved))
+        throw new Error(`Plugin not found: "${relFromCwd(resolved)}"`);
+      paths.push(resolved);
+    } catch {
+      const resolved = realpathIfExists(path.resolve(p));
+      if (!fs.existsSync(resolved))
+        throw new Error(`Plugin not found: "${relFromCwd(resolved)}"`);
+      paths.push(resolved);
+    }
+  }
+  return paths;
+}


### PR DESCRIPTION
## Summary
- add `resolvePluginPaths` helper
- reuse linter-resolved plugin paths in CLI and watch mode
- centralize plugin loading with shared resolver

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bcc7b71f6483289517dbb5736c6178