### PR TITLE
refactor(core): modularize linter architecture

### DIFF
--- a/.changeset/modular-architecture.md
+++ b/.changeset/modular-architecture.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+refactor linter into modular architecture with rule registry, parser service, token tracker, and cache manager

--- a/docs/api.md
+++ b/docs/api.md
@@ -184,7 +184,7 @@ console.log(formatter(results));
 See [Formatters](./formatters.md) for built-in options and instructions on adding custom ones, and
 [Usage](./usage.md#options) for command‑line equivalents.
 
-## `applyFixes(text, messages)` ([source](../src/core/linter.ts))
+## `applyFixes(text, messages)` ([source](../src/core/cache-manager.ts))
 
 Apply autofixes to file contents using message fix data.
 

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -1,0 +1,85 @@
+import { promises as fs } from 'fs';
+import type { Cache, CacheEntry } from './cache.js';
+import type { LintResult, LintMessage, Fix } from './types.js';
+
+export class CacheManager {
+  constructor(
+    private cache: Cache | undefined,
+    private fix: boolean,
+  ) {}
+
+  async processFile(
+    filePath: string,
+    lintFn: (text: string, filePath: string) => Promise<LintResult>,
+  ): Promise<LintResult> {
+    try {
+      const stat = await fs.stat(filePath);
+      const cached = this.cache?.getKey<CacheEntry>(filePath);
+      if (
+        cached &&
+        cached.mtime === stat.mtimeMs &&
+        cached.size === stat.size &&
+        !this.fix
+      ) {
+        return cached.result;
+      }
+      const text = await fs.readFile(filePath, 'utf8');
+      let result = await lintFn(text, filePath);
+      let mtime = stat.mtimeMs;
+      let size = stat.size;
+      if (this.fix) {
+        const output = applyFixes(text, result.messages);
+        if (output !== text) {
+          await fs.writeFile(filePath, output, 'utf8');
+          result = await lintFn(output, filePath);
+          const newStat = await fs.stat(filePath);
+          mtime = newStat.mtimeMs;
+          size = newStat.size;
+        }
+      }
+      this.cache?.setKey(filePath, { mtime, size, result });
+      return result;
+    } catch (e: unknown) {
+      this.cache?.removeKey(filePath);
+      const err = e as { message?: string };
+      return {
+        filePath,
+        messages: [
+          {
+            ruleId: 'parse-error',
+            message: err.message || 'Failed to read file',
+            severity: 'error',
+            line: 1,
+            column: 1,
+          },
+        ],
+      } as LintResult;
+    }
+  }
+
+  save(cacheLocation?: string): void {
+    if (cacheLocation && this.cache) {
+      this.cache.save(true);
+    }
+  }
+}
+
+export function applyFixes(text: string, messages: LintMessage[]): string {
+  const fixes: Fix[] = messages
+    .filter((m): m is LintMessage & { fix: Fix } => !!m.fix)
+    .map((m) => m.fix);
+  if (fixes.length === 0) return text;
+  fixes.sort((a, b) => a.range[0] - b.range[0]);
+  const filtered: Fix[] = [];
+  let lastEnd = -1;
+  for (const f of fixes) {
+    if (f.range[0] < lastEnd) continue;
+    filtered.push(f);
+    lastEnd = f.range[1];
+  }
+  for (let i = filtered.length - 1; i >= 0; i--) {
+    const f = filtered[i];
+    text = text.slice(0, f.range[0]) + f.text + text.slice(f.range[1]);
+  }
+  return text;
+}

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -1,27 +1,15 @@
-import { promises as fs } from 'fs';
-import ts from 'typescript';
-import postcss from 'postcss';
-import postcssScss from 'postcss-scss';
-import postcssLess from 'postcss-less';
 import pLimit from 'p-limit';
 import os from 'node:os';
-import type { parse as svelteParse } from 'svelte/compiler';
-import type {
-  LintResult,
-  RuleModule,
-  RuleContext,
-  LintMessage,
-  DesignTokens,
-  CSSDeclaration,
-  Fix,
-} from './types.js';
-import { builtInRules } from '../rules/index.js';
-export { defaultIgnore } from './ignore.js';
-import { loadPlugins } from './plugin-loader.js';
-import { scanFiles } from './file-scanner.js';
-import type { Cache, CacheEntry } from './cache.js';
-import { normalizeTokens, mergeTokens } from './token-loader.js';
+import type { LintResult, DesignTokens } from './types.js';
+import { normalizeTokens } from './token-loader.js';
 import { extractVarName } from '../utils/token-match.js';
+export { defaultIgnore } from './ignore.js';
+import { scanFiles } from './file-scanner.js';
+import type { Cache } from './cache.js';
+import { RuleRegistry } from './rule-registry.js';
+import { ParserService } from './parser-service.js';
+import { TokenTracker } from './token-tracker.js';
+import { CacheManager } from './cache-manager.js';
 
 export interface Config {
   tokens?: DesignTokens | Record<string, DesignTokens>;
@@ -34,40 +22,16 @@ export interface Config {
   wrapTokensWithVar?: boolean;
 }
 
-interface EngineErrorOptions {
-  message: string;
-  context: string;
-  remediation: string;
-}
-
-function createEngineError(opts: EngineErrorOptions): Error {
-  return new Error(
-    `${opts.message}\nContext: ${opts.context}\nRemediation: ${opts.remediation}`,
-  );
-}
-
 /**
  * Lints files using built-in and plugin-provided rules.
  */
 export class Linter {
   private config: Config;
   private tokensByTheme: Record<string, DesignTokens> = {};
-  private ruleMap: Map<string, { rule: RuleModule; source: string }> =
-    new Map();
-  private pluginLoad: Promise<void>;
-  private pluginPaths: string[] = [];
-  private allTokenValues = new Set<string>();
-  private usedTokenValues = new Set<string>();
-  private unusedTokenRules: {
-    ruleId: string;
-    severity: 'error' | 'warn';
-    ignored: Set<string>;
-  }[] = [];
+  private ruleRegistry: RuleRegistry;
+  private parser: ParserService;
+  private tokenTracker: TokenTracker;
 
-  /**
-   * Create a new Linter instance.
-   * @param config Linter configuration.
-   */
   constructor(config: Config) {
     const normalized = normalizeTokens(
       config.tokens as DesignTokens | Record<string, DesignTokens>,
@@ -75,30 +39,11 @@ export class Linter {
     );
     this.tokensByTheme = normalized.themes;
     this.config = { ...config, tokens: normalized.merged };
-    for (const rule of builtInRules) {
-      this.ruleMap.set(rule.name, { rule, source: 'built-in' });
-    }
-    this.pluginLoad = loadPlugins(
-      this.config,
-      this.ruleMap,
-      createEngineError,
-    ).then((paths) => {
-      this.pluginPaths = paths;
-    });
-    this.allTokenValues = collectTokenValues(
-      this.config.tokens as DesignTokens,
-    );
+    this.ruleRegistry = new RuleRegistry(this.config);
+    this.tokenTracker = new TokenTracker(this.config.tokens as DesignTokens);
+    this.parser = new ParserService(this.tokensByTheme);
   }
 
-  /**
-   * Lint a single file.
-   * @param filePath Path to the file.
-   * @param fix Apply fixes to the file.
-   * @param cache Optional in-memory result cache.
-   * @param ignorePaths Additional ignore pattern files.
-   * @param cacheLocation Path to persistent cache file.
-   * @returns The lint result for the file.
-   */
   async lintFile(
     filePath: string,
     fix = false,
@@ -117,15 +62,6 @@ export class Linter {
     return res ?? { filePath, messages: [] };
   }
 
-  /**
-   * Lint multiple files or directories.
-   * @param targets Paths or globs to lint.
-   * @param fix Apply fixes to matching files.
-   * @param cache Optional in-memory cache.
-   * @param additionalIgnorePaths Additional ignore files.
-   * @param cacheLocation Persistent cache file location.
-   * @returns Lint results and list of ignore files encountered.
-   */
   async lintFiles(
     targets: string[],
     fix = false,
@@ -137,7 +73,7 @@ export class Linter {
     ignoreFiles: string[];
     warning?: string;
   }> {
-    await this.pluginLoad;
+    await this.ruleRegistry.load();
     const files = await scanFiles(targets, this.config, additionalIgnorePaths);
     const ignoreFiles: string[] = [];
     if (files.length === 0) {
@@ -157,82 +93,20 @@ export class Linter {
       Math.floor(this.config.concurrency ?? os.cpus().length),
     );
     const limit = pLimit(concurrency);
+    const cacheManager = new CacheManager(cache, fix);
     const tasks = files.map((filePath) =>
-      limit(async () => {
-        try {
-          const stat = await fs.stat(filePath);
-          const cached = cache?.getKey<CacheEntry>(filePath);
-          if (
-            cached &&
-            cached.mtime === stat.mtimeMs &&
-            cached.size === stat.size &&
-            !fix
-          ) {
-            return cached.result;
-          }
-          const text = await fs.readFile(filePath, 'utf8');
-          let result = await this.lintText(text, filePath);
-          let mtime = stat.mtimeMs;
-          let size = stat.size;
-          if (fix) {
-            const output = applyFixes(text, result.messages);
-            if (output !== text) {
-              await fs.writeFile(filePath, output, 'utf8');
-              result = await this.lintText(output, filePath);
-              const newStat = await fs.stat(filePath);
-              mtime = newStat.mtimeMs;
-              size = newStat.size;
-            }
-          }
-          cache?.setKey(filePath, { mtime, size, result });
-          return result;
-        } catch (e: unknown) {
-          cache?.removeKey(filePath);
-          const err = e as { message?: string };
-          return {
-            filePath,
-            messages: [
-              {
-                ruleId: 'parse-error',
-                message: err.message || 'Failed to read file',
-                severity: 'error',
-                line: 1,
-                column: 1,
-              },
-            ],
-          } as LintResult;
-        }
-      }),
+      limit(() => cacheManager.processFile(filePath, this.lintText.bind(this))),
     );
-
     const results = await Promise.all(tasks);
-    for (const { ruleId, severity, ignored } of this.unusedTokenRules) {
-      const unused = Array.from(this.allTokenValues).filter(
-        (t) => !this.usedTokenValues.has(t) && !ignored.has(t),
-      );
-      if (unused.length) {
-        results.push({
-          filePath: this.config.configPath || 'designlint.config',
-          messages: unused.map((t) => ({
-            ruleId,
-            message: `Token ${t} is defined but never used`,
-            severity,
-            line: 1,
-            column: 1,
-          })),
-        });
-      }
-    }
-    if (cacheLocation && cache) {
-      cache.save(true);
-    }
+    results.push(
+      ...this.tokenTracker.generateReports(
+        this.config.configPath || 'designlint.config',
+      ),
+    );
+    cacheManager.save(cacheLocation);
     return { results, ignoreFiles };
   }
 
-  /**
-   * Retrieve token names for editor completions.
-   * @returns Map of token groups to token variable names.
-   */
   getTokenCompletions(): Record<string, string[]> {
     const tokens = (this.config.tokens || {}) as DesignTokens;
     const completions: Record<string, string[]> = {};
@@ -252,554 +126,22 @@ export class Linter {
     return completions;
   }
 
-  /**
-   * Get resolved plugin paths.
-   * @returns Array of plugin file paths.
-   */
   async getPluginPaths(): Promise<string[]> {
-    await this.pluginLoad;
-    return this.pluginPaths;
+    return this.ruleRegistry.getPluginPaths();
   }
 
-  /**
-   * Lint raw text.
-   * @param text Source content to lint.
-   * @param filePath Pseudo path used in messages.
-   * @returns Lint result containing messages.
-   */
-  async lintText(text: string, filePath = 'unknown'): Promise<LintResult> {
-    await this.pluginLoad;
-    const enabled = this.getEnabledRules();
-    const unusedRules = enabled.filter(
-      (e) => e.rule.name === 'design-system/no-unused-tokens',
-    );
-    if (unusedRules.length) {
-      this.unusedTokenRules = unusedRules.map((u) => ({
-        ruleId: u.rule.name,
-        severity: u.severity,
-        ignored: new Set(
-          ((u.options as { ignore?: string[] }) || {}).ignore || [],
-        ),
-      }));
-      this.trackTokenUsage(text);
+  private async lintText(
+    text: string,
+    filePath = 'unknown',
+  ): Promise<LintResult> {
+    await this.ruleRegistry.load();
+    const enabled = this.ruleRegistry.getEnabledRules();
+    this.tokenTracker.configure(enabled);
+    if (this.tokenTracker.hasUnusedTokenRules()) {
+      this.tokenTracker.trackUsage(text);
     }
-    const messages: LintResult['messages'] = [];
-    const ruleDescriptions: Record<string, string> = {};
-    const disabledLines = getDisabledLines(text);
-    const listeners = enabled.map(({ rule, options, severity }) => {
-      ruleDescriptions[rule.name] = rule.meta.description;
-      const themes =
-        options &&
-        typeof options === 'object' &&
-        options !== null &&
-        Array.isArray((options as { themes?: unknown }).themes)
-          ? ((options as { themes?: string[] }).themes as string[])
-          : undefined;
-      const tokens = mergeTokens(this.tokensByTheme, themes);
-      const ctx: RuleContext = {
-        filePath,
-        tokens: tokens as DesignTokens,
-        options,
-        report: (m) =>
-          messages.push({ ...m, severity, ruleId: rule.name } as LintMessage),
-      };
-      return rule.create(ctx);
-    });
-
-    if (/\.vue$/.test(filePath)) {
-      try {
-        const { parse } = await import('@vue/compiler-sfc');
-        const { descriptor } = parse(text, { filename: filePath });
-        const template = descriptor.template?.content ?? '';
-        const templateTsx = template
-          .replace(/class=/g, 'className=')
-          .replace(
-            /:style="{([^}]+)}"/g,
-            (_, expr) => `style={{ ${expr.trim()} }}`,
-          );
-        const scripts: string[] = [];
-        if (descriptor.script?.content) scripts.push(descriptor.script.content);
-        if (descriptor.scriptSetup?.content)
-          scripts.push(descriptor.scriptSetup.content);
-        const scriptBlocks = scripts.length ? scripts : [''];
-        for (const scriptContent of scriptBlocks) {
-          const combined = `${scriptContent}\nfunction __render(){ return (${templateTsx}); }`;
-          const source = ts.createSourceFile(
-            filePath,
-            combined,
-            ts.ScriptTarget.Latest,
-            true,
-            ts.ScriptKind.TSX,
-          );
-          const visit = (node: ts.Node) => {
-            for (const l of listeners) l.onNode?.(node);
-            ts.forEachChild(node, visit);
-          };
-          visit(source);
-        }
-        for (const style of descriptor.styles) {
-          const decls = parseCSS(
-            style.content,
-            messages,
-            style.lang as string | undefined,
-          );
-          for (const decl of decls) {
-            for (const l of listeners) l.onCSSDeclaration?.(decl);
-          }
-        }
-      } catch (e: unknown) {
-        const err = e as { line?: number; column?: number; message?: string };
-        messages.push({
-          ruleId: 'parse-error',
-          message: err.message || 'Failed to parse Vue component',
-          severity: 'error',
-          line: typeof err.line === 'number' ? err.line : 1,
-          column: typeof err.column === 'number' ? err.column : 1,
-        });
-      }
-    } else if (/\.svelte$/.test(filePath)) {
-      try {
-        const { parse } = (await import('svelte/compiler')) as {
-          parse: typeof svelteParse;
-        };
-        const ast = parse(text);
-        const scripts: string[] = [];
-        if (ast.instance)
-          scripts.push(
-            text.slice(ast.instance.content.start, ast.instance.content.end),
-          );
-        if (ast.module)
-          scripts.push(
-            text.slice(ast.module.content.start, ast.module.content.end),
-          );
-
-        const styleDecls: CSSDeclaration[] = [];
-        const replacements: { start: number; end: number; text: string }[] = [];
-
-        const getLineAndColumn = (pos: number) => {
-          const sliced = text.slice(0, pos).split(/\r?\n/);
-          const line = sliced.length;
-          const column = sliced[sliced.length - 1].length + 1;
-          return { line, column };
-        };
-
-        const extractStyleAttribute = (attr: {
-          start: number;
-          end: number;
-          value: Array<{
-            type: string;
-            data?: string;
-            expression?: { start: number; end: number };
-          }>;
-        }): CSSDeclaration[] => {
-          const exprs: string[] = [];
-          let content = '';
-          for (const part of attr.value) {
-            if (part.type === 'Text') content += part.data ?? '';
-            else if (part.type === 'MustacheTag') {
-              const i = exprs.length;
-              exprs.push(
-                text.slice(part.expression!.start, part.expression!.end),
-              );
-              content += `__EXPR_${i}__`;
-            }
-          }
-          const attrText = text.slice(attr.start, attr.end);
-          const eqIdx = attrText.indexOf('=');
-          const valueStart = attr.start + eqIdx + 2; // after opening quote
-          // match arbitrary "prop: value" pairs within the style attribute
-          // and allow multiple declarations separated by semicolons
-          const regex = /([^:;]+?)\s*:\s*([^;]+?)(?:;|$)/g;
-          const decls: CSSDeclaration[] = [];
-          let m: RegExpExecArray | null;
-          while ((m = regex.exec(content))) {
-            const prop = m[1].trim();
-            let value = m[2]
-              .trim()
-              .replace(/__EXPR_(\d+)__/g, (_, i) => exprs[Number(i)]);
-            const { line, column } = getLineAndColumn(valueStart + m.index);
-            decls.push({ prop, value, line, column });
-          }
-          return decls;
-        };
-
-        const walk = (node: unknown): void => {
-          const n = node as { attributes?: unknown[]; children?: unknown[] };
-          if (!n) return;
-          for (const attrRaw of n.attributes ?? []) {
-            const attr = attrRaw as {
-              type: string;
-              name: string;
-              start: number;
-              end: number;
-              value: Array<{
-                type: string;
-                data?: string;
-                expression?: { start: number; end: number };
-              }>;
-            };
-            if (attr.type === 'Attribute' && attr.name === 'style') {
-              styleDecls.push(...extractStyleAttribute(attr));
-              replacements.push({
-                start: attr.start,
-                end: attr.end,
-                text: 'style={{}}',
-              });
-            } else if (attr.type === 'StyleDirective') {
-              const value = attr.value
-                .map((v) =>
-                  v.type === 'Text'
-                    ? v.data
-                    : text.slice(v.expression!.start, v.expression!.end),
-                )
-                .join('')
-                .trim();
-              const { line, column } = getLineAndColumn(attr.start);
-              styleDecls.push({ prop: attr.name, value, line, column });
-              replacements.push({ start: attr.start, end: attr.end, text: '' });
-            }
-          }
-          for (const child of n.children ?? []) walk(child);
-        };
-        walk(ast.html);
-
-        const templateStart = ast.html?.start ?? 0;
-        let template = ast.html ? text.slice(ast.html.start, ast.html.end) : '';
-        replacements
-          .sort((a, b) => b.start - a.start)
-          .forEach((r) => {
-            const start = r.start - templateStart;
-            const end = r.end - templateStart;
-            template = template.slice(0, start) + r.text + template.slice(end);
-          });
-        const templateTsx = template.replace(/class=/g, 'className=');
-
-        const scriptBlocks = scripts.length ? scripts : [''];
-        for (const scriptContent of scriptBlocks) {
-          const combined = `${scriptContent}\nfunction __render(){ return (${templateTsx}); }`;
-          const source = ts.createSourceFile(
-            filePath,
-            combined,
-            ts.ScriptTarget.Latest,
-            true,
-            ts.ScriptKind.TSX,
-          );
-          const visit = (node: ts.Node) => {
-            for (const l of listeners) l.onNode?.(node);
-            ts.forEachChild(node, visit);
-          };
-          visit(source);
-        }
-        for (const decl of styleDecls) {
-          for (const l of listeners) l.onCSSDeclaration?.(decl);
-        }
-        if (ast.css) {
-          const styleText = text.slice(
-            ast.css.content.start,
-            ast.css.content.end,
-          );
-          const langAttr = (
-            ast.css as unknown as {
-              attributes?: Array<{
-                name: string;
-                value?: Array<{ data?: string }>;
-              }>;
-            }
-          ).attributes?.find((a) => a.name === 'lang');
-          const lang = langAttr?.value?.[0]?.data;
-          const decls = parseCSS(styleText, messages, lang);
-          for (const decl of decls) {
-            for (const l of listeners) l.onCSSDeclaration?.(decl);
-          }
-        }
-      } catch (e: unknown) {
-        const err = e as { line?: number; column?: number; message?: string };
-        messages.push({
-          ruleId: 'parse-error',
-          message: err.message || 'Failed to parse Svelte component',
-          severity: 'error',
-          line: typeof err.line === 'number' ? err.line : 1,
-          column: typeof err.column === 'number' ? err.column : 1,
-        });
-      }
-    } else if (/\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(filePath)) {
-      const source = ts.createSourceFile(
-        filePath,
-        text,
-        ts.ScriptTarget.Latest,
-        true,
-      );
-      const getRootTag = (expr: ts.LeftHandSideExpression): string | null => {
-        if (ts.isIdentifier(expr)) return expr.text;
-        if (
-          ts.isPropertyAccessExpression(expr) ||
-          ts.isElementAccessExpression(expr)
-        ) {
-          return getRootTag(expr.expression as ts.LeftHandSideExpression);
-        }
-        if (ts.isCallExpression(expr)) {
-          return getRootTag(expr.expression as ts.LeftHandSideExpression);
-        }
-        return null;
-      };
-
-      const visit = (node: ts.Node) => {
-        for (const l of listeners) l.onNode?.(node);
-        if (
-          ts.isJsxAttribute(node) &&
-          node.name.getText() === 'style' &&
-          node.initializer &&
-          ts.isStringLiteral(node.initializer)
-        ) {
-          const init = node.initializer;
-          const start = source.getLineAndCharacterOfPosition(
-            init.getStart(source) + 1,
-          );
-          const tempMessages: LintMessage[] = [];
-          const decls = parseCSS(init.text, tempMessages);
-          for (const decl of decls) {
-            const line = start.line + decl.line - 1;
-            const column =
-              decl.line === 1 ? start.character + decl.column - 1 : decl.column;
-            for (const l of listeners)
-              l.onCSSDeclaration?.({ ...decl, line, column });
-          }
-          for (const m of tempMessages) {
-            const line = start.line + m.line - 1;
-            const column =
-              m.line === 1 ? start.character + m.column - 1 : m.column;
-            messages.push({ ...m, line, column });
-          }
-          return;
-        } else if (ts.isTaggedTemplateExpression(node)) {
-          const root = getRootTag(node.tag as ts.LeftHandSideExpression);
-          if (
-            root &&
-            ['styled', 'css', 'tw'].includes(root) &&
-            ts.isNoSubstitutionTemplateLiteral(node.template)
-          ) {
-            const tpl = node.template;
-            const start = source.getLineAndCharacterOfPosition(
-              tpl.getStart(source) + 1,
-            );
-            const tempMessages: LintMessage[] = [];
-            const decls = parseCSS(tpl.text, tempMessages);
-            for (const decl of decls) {
-              const line = start.line + decl.line - 1;
-              const column =
-                decl.line === 1
-                  ? start.character + decl.column - 1
-                  : decl.column;
-              for (const l of listeners)
-                l.onCSSDeclaration?.({ ...decl, line, column });
-            }
-            for (const m of tempMessages) {
-              const line = start.line + m.line - 1;
-              const column =
-                m.line === 1 ? start.character + m.column - 1 : m.column;
-              messages.push({ ...m, line, column });
-            }
-            return;
-          }
-        }
-        ts.forEachChild(node, visit);
-      };
-      visit(source);
-    } else if (/\.(?:css|scss|sass|less)$/.test(filePath)) {
-      let syntax: string | undefined;
-      if (/\.s[ac]ss$/i.test(filePath)) syntax = 'scss';
-      else if (/\.less$/i.test(filePath)) syntax = 'less';
-      const decls = parseCSS(text, messages, syntax);
-      for (const decl of decls) {
-        for (const l of listeners) l.onCSSDeclaration?.(decl);
-      }
-    }
-    const filtered = messages.filter((m) => !disabledLines.has(m.line));
-    return { filePath, messages: filtered, ruleDescriptions };
-  }
-
-  private getEnabledRules(): {
-    rule: RuleModule;
-    options: unknown;
-    severity: 'error' | 'warn';
-  }[] {
-    const entries: {
-      rule: RuleModule;
-      options: unknown;
-      severity: 'error' | 'warn';
-    }[] = [];
-    const ruleConfig = (this.config.rules || {}) as Record<string, unknown>;
-    const unknown: string[] = [];
-    for (const [name, setting] of Object.entries(ruleConfig)) {
-      const entry = this.ruleMap.get(name);
-      if (!entry) {
-        unknown.push(name);
-        continue;
-      }
-      const rule = entry.rule;
-      let severity: 'error' | 'warn' | undefined;
-      let options: unknown = undefined;
-      if (Array.isArray(setting)) {
-        severity = this.normalizeSeverity(setting[0]);
-        options = setting[1];
-      } else {
-        severity = this.normalizeSeverity(setting);
-      }
-      if (severity) {
-        entries.push({ rule, options, severity });
-      }
-    }
-    if (unknown.length > 0) {
-      throw createEngineError({
-        message: `Unknown rule(s): ${unknown.join(', ')}`,
-        context: 'Config.rules',
-        remediation: 'Remove or correct these rule names.',
-      });
-    }
-    return entries;
-  }
-
-  private normalizeSeverity(value: unknown): 'error' | 'warn' | undefined {
-    if (value === 0 || value === 'off') return undefined;
-    if (value === 2 || value === 'error') return 'error';
-    if (value === 1 || value === 'warn') return 'warn';
-    return undefined;
-  }
-
-  private trackTokenUsage(text: string): void {
-    for (const token of this.allTokenValues) {
-      if (this.usedTokenValues.has(token)) continue;
-      if (token.includes('--') || token.startsWith('-')) {
-        if (text.includes(`var(${token})`) || text.includes(token)) {
-          this.usedTokenValues.add(token);
-        }
-      } else if (token.startsWith('#')) {
-        const lowerText = text.toLowerCase();
-        if (lowerText.includes(token.toLowerCase())) {
-          this.usedTokenValues.add(token);
-        }
-      } else if (/^\d/.test(token)) {
-        const re = new RegExp(
-          `\\b${token.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}\\b`,
-        );
-        if (re.test(text)) this.usedTokenValues.add(token);
-      } else {
-        if (text.includes(token)) this.usedTokenValues.add(token);
-      }
-    }
+    return this.parser.lintText(text, filePath, enabled);
   }
 }
 
-function collectTokenValues(tokens?: DesignTokens): Set<string> {
-  const values = new Set<string>();
-  if (!tokens) return values;
-  for (const [group, defs] of Object.entries(tokens)) {
-    if (group === 'deprecations') continue;
-    if (Array.isArray(defs)) {
-      for (const t of defs) {
-        if (typeof t === 'string' && !t.includes('*')) values.add(t);
-      }
-    } else if (defs && typeof defs === 'object') {
-      for (const val of Object.values(defs as Record<string, unknown>)) {
-        if (typeof val === 'string') {
-          const m = val.match(/^var\((--[^)]+)\)$/);
-          values.add(m ? m[1] : val);
-        } else if (typeof val === 'number') {
-          values.add(String(val));
-        }
-      }
-    }
-  }
-  return values;
-}
-
-function parseCSS(
-  text: string,
-  messages: LintMessage[] = [],
-  lang?: string,
-): CSSDeclaration[] {
-  const decls: CSSDeclaration[] = [];
-  try {
-    const root: postcss.Root =
-      lang === 'scss' || lang === 'sass'
-        ? postcssScss.parse(text)
-        : lang === 'less'
-          ? postcssLess.parse(text)
-          : postcss.parse(text);
-    root.walkDecls((d) => {
-      decls.push({
-        prop: d.prop,
-        value: d.value,
-        line: d.source?.start?.line || 1,
-        column: d.source?.start?.column || 1,
-      });
-    });
-  } catch (e: unknown) {
-    const err = e as { line?: number; column?: number; message?: string };
-    messages.push({
-      ruleId: 'parse-error',
-      message: err.message || 'Failed to parse CSS',
-      severity: 'error',
-      line: typeof err.line === 'number' ? err.line : 1,
-      column: typeof err.column === 'number' ? err.column : 1,
-    });
-  }
-  return decls;
-}
-
-function getDisabledLines(text: string): Set<number> {
-  const disabled = new Set<number>();
-  const lines = text.split(/\r?\n/);
-  let block = false;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/\/\*\s*design-lint-disable\s*\*\//.test(line)) {
-      block = true;
-      continue;
-    }
-    if (/\/\*\s*design-lint-enable\s*\*\//.test(line)) {
-      block = false;
-      continue;
-    }
-    if (/(?:\/\/|\/\*)\s*design-lint-disable-next-line/.test(line)) {
-      disabled.add(i + 2);
-      continue;
-    }
-    if (/design-lint-disable-line/.test(line)) {
-      disabled.add(i + 1);
-      continue;
-    }
-    if (block) disabled.add(i + 1);
-  }
-  return disabled;
-}
-
-/**
- * Apply fixes to source text.
- * @param text Original source code.
- * @param messages Messages that may include fixes.
- * @returns Text with all non-overlapping fixes applied.
- */
-export function applyFixes(text: string, messages: LintMessage[]): string {
-  const fixes: Fix[] = messages
-    .filter((m): m is LintMessage & { fix: Fix } => !!m.fix)
-    .map((m) => m.fix);
-  if (fixes.length === 0) return text;
-
-  // Sort by start position to detect and skip overlapping ranges
-  fixes.sort((a, b) => a.range[0] - b.range[0]);
-  const filtered: Fix[] = [];
-  let lastEnd = -1;
-  for (const f of fixes) {
-    if (f.range[0] < lastEnd) continue; // overlapping with previous fix
-    filtered.push(f);
-    lastEnd = f.range[1];
-  }
-
-  // Apply fixes from right to left to avoid messing up subsequent ranges
-  for (let i = filtered.length - 1; i >= 0; i--) {
-    const [start, end] = filtered[i].range;
-    text = text.slice(0, start) + filtered[i].text + text.slice(end);
-  }
-  return text;
-}
+export { applyFixes } from './cache-manager.js';

--- a/src/core/parser-service.ts
+++ b/src/core/parser-service.ts
@@ -1,0 +1,402 @@
+import ts from 'typescript';
+import postcss from 'postcss';
+import postcssScss from 'postcss-scss';
+import postcssLess from 'postcss-less';
+import type { parse as svelteParse } from 'svelte/compiler';
+import type {
+  DesignTokens,
+  RuleModule,
+  LintMessage,
+  LintResult,
+  CSSDeclaration,
+  RuleContext,
+} from './types.js';
+import { mergeTokens } from './token-loader.js';
+
+export class ParserService {
+  constructor(private tokensByTheme: Record<string, DesignTokens>) {}
+
+  async lintText(
+    text: string,
+    filePath: string,
+    enabled: {
+      rule: RuleModule;
+      options: unknown;
+      severity: 'error' | 'warn';
+    }[],
+  ): Promise<LintResult> {
+    const messages: LintMessage[] = [];
+    const ruleDescriptions: Record<string, string> = {};
+    const disabledLines = getDisabledLines(text);
+    const listeners = enabled.map(({ rule, options, severity }) => {
+      ruleDescriptions[rule.name] = rule.meta.description;
+      const themes =
+        options &&
+        typeof options === 'object' &&
+        options !== null &&
+        Array.isArray((options as { themes?: unknown }).themes)
+          ? ((options as { themes?: string[] }).themes as string[])
+          : undefined;
+      const tokens = mergeTokens(this.tokensByTheme, themes);
+      const ctx: RuleContext = {
+        filePath,
+        tokens: tokens as DesignTokens,
+        options,
+        report: (m) => messages.push({ ...m, severity, ruleId: rule.name }),
+      };
+      return rule.create(ctx);
+    });
+
+    if (/\.vue$/.test(filePath)) {
+      await lintVue(text, filePath, listeners, messages);
+    } else if (/\.svelte$/.test(filePath)) {
+      await lintSvelte(text, filePath, listeners, messages);
+    } else if (/\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(filePath)) {
+      lintTS(text, filePath, listeners, messages);
+    } else if (/\.(?:css|scss|sass|less)$/.test(filePath)) {
+      let syntax: string | undefined;
+      if (/\.s[ac]ss$/i.test(filePath)) syntax = 'scss';
+      else if (/\.less$/i.test(filePath)) syntax = 'less';
+      const decls = parseCSS(text, messages, syntax);
+      for (const decl of decls) {
+        for (const l of listeners) l.onCSSDeclaration?.(decl);
+      }
+    }
+    const filtered = messages.filter((m) => !disabledLines.has(m.line));
+    return { filePath, messages: filtered, ruleDescriptions };
+  }
+}
+
+async function lintVue(
+  text: string,
+  filePath: string,
+  listeners: ReturnType<RuleModule['create']>[],
+  messages: LintMessage[],
+): Promise<void> {
+  const { parse } = await import('@vue/compiler-sfc');
+  const { descriptor } = parse(text, { filename: filePath });
+  const template = descriptor.template?.content ?? '';
+  const templateTsx = template
+    .replace(/class=/g, 'className=')
+    .replace(/:style="{([^}]+)}"/g, (_, expr) => `style={{ ${expr.trim()} }}`);
+  const scripts: string[] = [];
+  if (descriptor.script?.content) scripts.push(descriptor.script.content);
+  if (descriptor.scriptSetup?.content)
+    scripts.push(descriptor.scriptSetup.content);
+  const scriptBlocks = scripts.length ? scripts : [''];
+  for (const scriptContent of scriptBlocks) {
+    const combined = `${scriptContent}\nfunction __render(){ return (${templateTsx}); }`;
+    const source = ts.createSourceFile(
+      filePath,
+      combined,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+    const visit = (node: ts.Node) => {
+      for (const l of listeners) l.onNode?.(node);
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  for (const style of descriptor.styles) {
+    const decls = parseCSS(
+      style.content,
+      messages,
+      style.lang as string | undefined,
+    );
+    for (const decl of decls) {
+      for (const l of listeners) l.onCSSDeclaration?.(decl);
+    }
+  }
+}
+
+async function lintSvelte(
+  text: string,
+  filePath: string,
+  listeners: ReturnType<RuleModule['create']>[],
+  messages: LintMessage[],
+): Promise<void> {
+  const { parse } = (await import('svelte/compiler')) as {
+    parse: typeof svelteParse;
+  };
+  const ast = parse(text);
+  const scripts: string[] = [];
+  if (ast.instance)
+    scripts.push(
+      text.slice(ast.instance.content.start, ast.instance.content.end),
+    );
+  if (ast.module)
+    scripts.push(text.slice(ast.module.content.start, ast.module.content.end));
+  const styleDecls: CSSDeclaration[] = [];
+  const replacements: { start: number; end: number; text: string }[] = [];
+  const getLineAndColumn = (pos: number) => {
+    const sliced = text.slice(0, pos).split(/\r?\n/);
+    const line = sliced.length;
+    const column = sliced[sliced.length - 1].length + 1;
+    return { line, column };
+  };
+  const extractStyleAttribute = (attr: {
+    start: number;
+    end: number;
+    value: Array<{
+      type: string;
+      data?: string;
+      expression?: { start: number; end: number };
+    }>;
+  }): CSSDeclaration[] => {
+    const exprs: string[] = [];
+    let content = '';
+    for (const part of attr.value) {
+      if (part.type === 'Text') content += part.data ?? '';
+      else if (part.type === 'MustacheTag') {
+        const i = exprs.length;
+        exprs.push(text.slice(part.expression!.start, part.expression!.end));
+        content += `__EXPR_${i}__`;
+      }
+    }
+    const attrText = text.slice(attr.start, attr.end);
+    const eqIdx = attrText.indexOf('=');
+    const valueStart = attr.start + eqIdx + 2;
+    const regex = /([^:;]+?)\s*:\s*([^;]+?)(?:;|$)/g;
+    const decls: CSSDeclaration[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(content))) {
+      const prop = m[1].trim();
+      let value = m[2]
+        .trim()
+        .replace(/__EXPR_(\d+)__/g, (_, i) => exprs[Number(i)]);
+      const { line, column } = getLineAndColumn(valueStart + m.index);
+      decls.push({ prop, value, line, column });
+    }
+    return decls;
+  };
+  const walk = (node: unknown): void => {
+    const n = node as { attributes?: unknown[]; children?: unknown[] };
+    if (!n) return;
+    for (const attrRaw of n.attributes ?? []) {
+      const attr = attrRaw as {
+        type: string;
+        name: string;
+        start: number;
+        end: number;
+        value: Array<{
+          type: string;
+          data?: string;
+          expression?: { start: number; end: number };
+        }>;
+      };
+      if (attr.type === 'Attribute' && attr.name === 'style') {
+        styleDecls.push(...extractStyleAttribute(attr));
+        replacements.push({
+          start: attr.start,
+          end: attr.end,
+          text: 'style={{}}',
+        });
+      } else if (attr.type === 'StyleDirective') {
+        const value = attr.value
+          .map((v) =>
+            v.type === 'Text'
+              ? v.data
+              : text.slice(v.expression!.start, v.expression!.end),
+          )
+          .join('')
+          .trim();
+        const { line, column } = getLineAndColumn(attr.start);
+        styleDecls.push({ prop: attr.name, value, line, column });
+        replacements.push({ start: attr.start, end: attr.end, text: '' });
+      }
+    }
+    for (const child of n.children ?? []) walk(child);
+  };
+  walk(ast.html);
+  const templateStart = ast.html?.start ?? 0;
+  let template = ast.html ? text.slice(ast.html.start, ast.html.end) : '';
+  replacements
+    .sort((a, b) => b.start - a.start)
+    .forEach((r) => {
+      const start = r.start - templateStart;
+      const end = r.end - templateStart;
+      template = template.slice(0, start) + r.text + template.slice(end);
+    });
+  const templateTsx = template.replace(/class=/g, 'className=');
+  const scriptBlocks = scripts.length ? scripts : [''];
+  for (const scriptContent of scriptBlocks) {
+    const combined = `${scriptContent}\nfunction __render(){ return (${templateTsx}); }`;
+    const source = ts.createSourceFile(
+      filePath,
+      combined,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+    const visit = (node: ts.Node) => {
+      for (const l of listeners) l.onNode?.(node);
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  for (const decl of styleDecls) {
+    for (const l of listeners) l.onCSSDeclaration?.(decl);
+  }
+  if (ast.css) {
+    const styleText = text.slice(ast.css.content.start, ast.css.content.end);
+    const langAttr = (
+      ast.css as unknown as {
+        attributes?: Array<{ name: string; value?: Array<{ data?: string }> }>;
+      }
+    ).attributes?.find((a) => a.name === 'lang');
+    const lang = langAttr?.value?.[0]?.data;
+    const decls = parseCSS(styleText, messages, lang);
+    for (const decl of decls) {
+      for (const l of listeners) l.onCSSDeclaration?.(decl);
+    }
+  }
+}
+
+function lintTS(
+  text: string,
+  filePath: string,
+  listeners: ReturnType<RuleModule['create']>[],
+  messages: LintMessage[],
+): void {
+  const source = ts.createSourceFile(
+    filePath,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const getRootTag = (expr: ts.LeftHandSideExpression): string | null => {
+    if (ts.isIdentifier(expr)) return expr.text;
+    if (
+      ts.isPropertyAccessExpression(expr) ||
+      ts.isElementAccessExpression(expr)
+    ) {
+      return getRootTag(expr.expression as ts.LeftHandSideExpression);
+    }
+    if (ts.isCallExpression(expr)) {
+      return getRootTag(expr.expression as ts.LeftHandSideExpression);
+    }
+    return null;
+  };
+  const visit = (node: ts.Node) => {
+    for (const l of listeners) l.onNode?.(node);
+    if (
+      ts.isJsxAttribute(node) &&
+      node.name.getText() === 'style' &&
+      node.initializer &&
+      ts.isStringLiteral(node.initializer)
+    ) {
+      const init = node.initializer;
+      const start = source.getLineAndCharacterOfPosition(
+        init.getStart(source) + 1,
+      );
+      const tempMessages: LintMessage[] = [];
+      const decls = parseCSS(init.text, tempMessages);
+      for (const decl of decls) {
+        const line = start.line + decl.line - 1;
+        const column =
+          decl.line === 1 ? start.character + decl.column - 1 : decl.column;
+        for (const l of listeners)
+          l.onCSSDeclaration?.({ ...decl, line, column });
+      }
+      for (const m of tempMessages) {
+        const line = start.line + m.line - 1;
+        const column = m.line === 1 ? start.character + m.column - 1 : m.column;
+        messages.push({ ...m, line, column });
+      }
+      return;
+    } else if (ts.isTaggedTemplateExpression(node)) {
+      const root = getRootTag(node.tag as ts.LeftHandSideExpression);
+      if (
+        root &&
+        ['styled', 'css', 'tw'].includes(root) &&
+        ts.isNoSubstitutionTemplateLiteral(node.template)
+      ) {
+        const tpl = node.template;
+        const start = source.getLineAndCharacterOfPosition(
+          tpl.getStart(source) + 1,
+        );
+        const tempMessages: LintMessage[] = [];
+        const decls = parseCSS(tpl.text, tempMessages);
+        for (const decl of decls) {
+          const line = start.line + decl.line - 1;
+          const column =
+            decl.line === 1 ? start.character + decl.column - 1 : decl.column;
+          for (const l of listeners)
+            l.onCSSDeclaration?.({ ...decl, line, column });
+        }
+        for (const m of tempMessages) {
+          const line = start.line + m.line - 1;
+          const column =
+            m.line === 1 ? start.character + m.column - 1 : m.column;
+          messages.push({ ...m, line, column });
+        }
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+}
+
+function parseCSS(
+  text: string,
+  messages: LintMessage[] = [],
+  lang?: string,
+): CSSDeclaration[] {
+  const decls: CSSDeclaration[] = [];
+  try {
+    const root: postcss.Root =
+      lang === 'scss' || lang === 'sass'
+        ? postcssScss.parse(text)
+        : lang === 'less'
+          ? postcssLess.parse(text)
+          : postcss.parse(text);
+    root.walkDecls((d) => {
+      decls.push({
+        prop: d.prop,
+        value: d.value,
+        line: d.source?.start?.line || 1,
+        column: d.source?.start?.column || 1,
+      });
+    });
+  } catch (e: unknown) {
+    const err = e as { line?: number; column?: number; message?: string };
+    messages.push({
+      ruleId: 'parse-error',
+      message: err.message || 'Failed to parse CSS',
+      severity: 'error',
+      line: typeof err.line === 'number' ? err.line : 1,
+      column: typeof err.column === 'number' ? err.column : 1,
+    });
+  }
+  return decls;
+}
+
+function getDisabledLines(text: string): Set<number> {
+  const disabled = new Set<number>();
+  const lines = text.split(/\r?\n/);
+  let block = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/\/\*\s*design-lint-disable\s*\*\//.test(line)) {
+      block = true;
+      continue;
+    }
+    if (/\/\*\s*design-lint-enable\s*\*\//.test(line)) {
+      block = false;
+      continue;
+    }
+    if (/(?:\/\/|\/\*)\s*design-lint-disable-next-line/.test(line)) {
+      disabled.add(i + 2);
+      continue;
+    }
+    if (/design-lint-disable-line/.test(line)) {
+      disabled.add(i + 1);
+      continue;
+    }
+    if (block) disabled.add(i + 1);
+  }
+  return disabled;
+}

--- a/src/core/rule-registry.ts
+++ b/src/core/rule-registry.ts
@@ -1,0 +1,91 @@
+import type { Config } from './linter.js';
+import type { RuleModule } from './types.js';
+import { builtInRules } from '../rules/index.js';
+import { loadPlugins } from './plugin-loader.js';
+
+interface EngineErrorOptions {
+  message: string;
+  context: string;
+  remediation: string;
+}
+
+export function createEngineError(opts: EngineErrorOptions): Error {
+  return new Error(
+    `${opts.message}\nContext: ${opts.context}\nRemediation: ${opts.remediation}`,
+  );
+}
+
+export class RuleRegistry {
+  private ruleMap = new Map<string, { rule: RuleModule; source: string }>();
+  private pluginLoad: Promise<void>;
+  private pluginPaths: string[] = [];
+  constructor(private config: Config) {
+    for (const rule of builtInRules) {
+      this.ruleMap.set(rule.name, { rule, source: 'built-in' });
+    }
+    this.pluginLoad = loadPlugins(
+      this.config,
+      this.ruleMap,
+      createEngineError,
+    ).then((paths) => {
+      this.pluginPaths = paths;
+    });
+  }
+
+  async load(): Promise<void> {
+    await this.pluginLoad;
+  }
+
+  getEnabledRules(): {
+    rule: RuleModule;
+    options: unknown;
+    severity: 'error' | 'warn';
+  }[] {
+    const entries: {
+      rule: RuleModule;
+      options: unknown;
+      severity: 'error' | 'warn';
+    }[] = [];
+    const ruleConfig = (this.config.rules || {}) as Record<string, unknown>;
+    const unknown: string[] = [];
+    for (const [name, setting] of Object.entries(ruleConfig)) {
+      const entry = this.ruleMap.get(name);
+      if (!entry) {
+        unknown.push(name);
+        continue;
+      }
+      const rule = entry.rule;
+      let severity: 'error' | 'warn' | undefined;
+      let options: unknown = undefined;
+      if (Array.isArray(setting)) {
+        severity = this.normalizeSeverity(setting[0]);
+        options = setting[1];
+      } else {
+        severity = this.normalizeSeverity(setting);
+      }
+      if (severity) {
+        entries.push({ rule, options, severity });
+      }
+    }
+    if (unknown.length > 0) {
+      throw createEngineError({
+        message: `Unknown rule(s): ${unknown.join(', ')}`,
+        context: 'Config.rules',
+        remediation: 'Remove or correct these rule names.',
+      });
+    }
+    return entries;
+  }
+
+  private normalizeSeverity(value: unknown): 'error' | 'warn' | undefined {
+    if (value === 0 || value === 'off') return undefined;
+    if (value === 2 || value === 'error') return 'error';
+    if (value === 1 || value === 'warn') return 'warn';
+    return undefined;
+  }
+
+  async getPluginPaths(): Promise<string[]> {
+    await this.pluginLoad;
+    return this.pluginPaths;
+  }
+}

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -1,0 +1,108 @@
+import type { DesignTokens, LintResult } from './types.js';
+
+interface UnusedRuleConfig {
+  ruleId: string;
+  severity: 'error' | 'warn';
+  ignored: Set<string>;
+}
+
+export class TokenTracker {
+  private allTokenValues = new Set<string>();
+  private usedTokenValues = new Set<string>();
+  private unusedTokenRules: UnusedRuleConfig[] = [];
+
+  constructor(tokens?: DesignTokens) {
+    this.allTokenValues = collectTokenValues(tokens);
+  }
+
+  configure(
+    rules: {
+      rule: { name: string };
+      options: unknown;
+      severity: 'error' | 'warn';
+    }[],
+  ): void {
+    const unusedRules = rules.filter(
+      (e) => e.rule.name === 'design-system/no-unused-tokens',
+    );
+    this.unusedTokenRules = unusedRules.map((u) => ({
+      ruleId: u.rule.name,
+      severity: u.severity,
+      ignored: new Set(
+        ((u.options as { ignore?: string[] }) || {}).ignore || [],
+      ),
+    }));
+  }
+
+  hasUnusedTokenRules(): boolean {
+    return this.unusedTokenRules.length > 0;
+  }
+
+  trackUsage(text: string): void {
+    for (const token of this.allTokenValues) {
+      if (this.usedTokenValues.has(token)) continue;
+      if (token.includes('--') || token.startsWith('-')) {
+        if (text.includes(`var(${token})`) || text.includes(token)) {
+          this.usedTokenValues.add(token);
+        }
+      } else if (token.startsWith('#')) {
+        const lowerText = text.toLowerCase();
+        if (lowerText.includes(token.toLowerCase())) {
+          this.usedTokenValues.add(token);
+        }
+      } else if (/^\d/.test(token)) {
+        const re = new RegExp(
+          `\\b${token.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}\\b`,
+        );
+        if (re.test(text)) this.usedTokenValues.add(token);
+      } else {
+        if (text.includes(token)) this.usedTokenValues.add(token);
+      }
+    }
+  }
+
+  generateReports(configPath: string): LintResult[] {
+    const results: LintResult[] = [];
+    for (const { ruleId, severity, ignored } of this.unusedTokenRules) {
+      const unused = Array.from(this.allTokenValues).filter(
+        (t) => !this.usedTokenValues.has(t) && !ignored.has(t),
+      );
+      if (unused.length) {
+        results.push({
+          filePath: configPath,
+          messages: unused.map((t) => ({
+            ruleId,
+            message: `Token ${t} is defined but never used`,
+            severity,
+            line: 1,
+            column: 1,
+          })),
+        });
+      }
+    }
+    return results;
+  }
+}
+
+function collectTokenValues(tokens?: DesignTokens): Set<string> {
+  const values = new Set<string>();
+  if (!tokens) return values;
+  for (const [group, defs] of Object.entries(tokens)) {
+    if (group === 'deprecations') continue;
+    if (Array.isArray(defs)) {
+      for (const t of defs) {
+        if (typeof t === 'string' && !t.includes('*')) values.add(t);
+      }
+    } else if (defs && typeof defs === 'object') {
+      for (const val of Object.values(defs as Record<string, unknown>)) {
+        if (typeof val === 'string') {
+          const m = val.match(/^var\((--[^)]+)\)$/);
+          values.add(m ? m[1] : val);
+        } else if (typeof val === 'number') {
+          values.add(String(val));
+        }
+      }
+    }
+  }
+  return values;
+}

--- a/tests/core/cache-manager.test.ts
+++ b/tests/core/cache-manager.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CacheManager } from '../../src/core/cache-manager.ts';
+import { promises as fs } from 'fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { LintResult } from '../../src/core/types.ts';
+
+test('CacheManager applies fixes when enabled', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cm-'));
+  const file = path.join(dir, 'a.txt');
+  await fs.writeFile(file, 'bad');
+  const lintFn = async (
+    text: string,
+    filePath: string,
+  ): Promise<LintResult> => {
+    if (text === 'bad') {
+      return {
+        filePath,
+        messages: [
+          {
+            ruleId: 'test',
+            message: 'bad',
+            severity: 'error',
+            line: 1,
+            column: 1,
+            fix: { range: [0, 3], text: 'good' },
+          },
+        ],
+      };
+    }
+    return { filePath, messages: [] };
+  };
+  const manager = new CacheManager(undefined, true);
+  await manager.processFile(file, lintFn);
+  const updated = await fs.readFile(file, 'utf8');
+  assert.equal(updated, 'good');
+});

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../../src/core/linter.ts';
+import type { LintResult } from '../../src/core/types.ts';
+
+test('Linter integrates registry, parser and trackers', async () => {
+  const linter = new Linter({
+    tokens: {},
+    rules: { 'design-token/colors': 'error' },
+  });
+  type Internal = { lintText: (t: string, f: string) => Promise<LintResult> };
+  const res = await (linter as unknown as Internal).lintText(
+    'a{color:#fff;}',
+    'file.css',
+  );
+  assert.equal(res.messages.length, 1);
+});

--- a/tests/core/parser-service.test.ts
+++ b/tests/core/parser-service.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ParserService } from '../../src/core/parser-service.ts';
+import type { RuleModule, DesignTokens } from '../../src/core/types.ts';
+
+const tokensByTheme: Record<string, DesignTokens> = {};
+const parser = new ParserService(tokensByTheme);
+
+test('ParserService dispatches CSS declarations', async () => {
+  const rule: RuleModule = {
+    name: 'test',
+    meta: { description: 'test rule' },
+    create(ctx) {
+      return {
+        onCSSDeclaration(decl) {
+          if (decl.prop === 'color') {
+            ctx.report({
+              message: 'bad color',
+              line: decl.line,
+              column: decl.column,
+            });
+          }
+        },
+      };
+    },
+  };
+  const res = await parser.lintText('a{color:red;}', 'a.css', [
+    { rule, options: undefined, severity: 'error' },
+  ]);
+  assert.equal(res.messages.length, 1);
+  assert.equal(res.messages[0].message, 'bad color');
+});

--- a/tests/core/rule-registry.test.ts
+++ b/tests/core/rule-registry.test.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RuleRegistry } from '../../src/core/rule-registry.ts';
+import type { Config } from '../../src/core/linter.ts';
+
+test('RuleRegistry enables configured rules', async () => {
+  const config: Config = {
+    tokens: {},
+    rules: { 'design-token/colors': 'warn' },
+  };
+  const registry = new RuleRegistry(config);
+  await registry.load();
+  const enabled = registry.getEnabledRules();
+  assert.equal(enabled.length, 1);
+  assert.equal(enabled[0].rule.name, 'design-token/colors');
+  assert.equal(enabled[0].severity, 'warn');
+});

--- a/tests/core/token-tracker.test.ts
+++ b/tests/core/token-tracker.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { TokenTracker } from '../../src/core/token-tracker.ts';
+import type { DesignTokens } from '../../src/core/types.ts';
+
+test('TokenTracker reports unused tokens', () => {
+  const tokens: DesignTokens = {
+    colors: { red: 'var(--red)' },
+    spacing: ['4px'],
+  };
+  const tracker = new TokenTracker(tokens);
+  tracker.configure([
+    {
+      rule: { name: 'design-system/no-unused-tokens' },
+      options: {},
+      severity: 'error',
+    },
+  ]);
+  tracker.trackUsage('const c = "var(--red)";');
+  const reports = tracker.generateReports('config');
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].messages[0].message.includes('4px'), true);
+});


### PR DESCRIPTION
## Summary
- split linter responsibilities into dedicated modules for rule registry, parsing, token tracking, and caching
- simplify `Linter` to delegate to new services
- document and test the new architecture

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bccdf4356483288687034e404dee77