### PR TITLE
fix: output relative paths in stylish formatter

### DIFF
--- a/.changeset/stylish-relative-paths.md
+++ b/.changeset/stylish-relative-paths.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix stylish formatter to output relative paths

--- a/src/formatters/stylish.ts
+++ b/src/formatters/stylish.ts
@@ -1,4 +1,5 @@
 import type { LintResult } from '../core/types.js';
+import { relFromCwd } from '../utils/paths.js';
 
 const codes = {
   red: (s: string) => `\x1b[31m${s}\x1b[0m`,
@@ -12,12 +13,13 @@ export function stylish(results: LintResult[], useColor = true): string {
   let errorCount = 0;
   let warnCount = 0;
   for (const res of results) {
+    const filePath = relFromCwd(res.filePath);
     if (res.messages.length === 0) {
       const ok = useColor ? codes.green('[OK]') : '[OK]';
-      lines.push(`${ok} ${res.filePath}`);
+      lines.push(`${ok} ${filePath}`);
       continue;
     }
-    lines.push(useColor ? codes.underline(res.filePath) : res.filePath);
+    lines.push(useColor ? codes.underline(filePath) : filePath);
     for (const msg of res.messages) {
       if (msg.severity === 'error') errorCount++;
       else warnCount++;

--- a/tests/formatters/formatters.test.ts
+++ b/tests/formatters/formatters.test.ts
@@ -56,6 +56,13 @@ test('stylish formatter outputs OK for files without messages', () => {
   assert.equal(out, '[OK] a.ts\n[OK] b.ts');
 });
 
+test('stylish formatter outputs relative paths', () => {
+  const abs = join(process.cwd(), 'c.ts');
+  const results: LintResult[] = [{ filePath: abs, messages: [] }];
+  const out = stylish(results, false);
+  assert.equal(out, '[OK] c.ts');
+});
+
 test('stylish formatter does not insert blank line before summary', () => {
   const results: LintResult[] = [
     {


### PR DESCRIPTION
## Summary
- make stylish formatter print paths relative to cwd
- test relative path output

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd243626748328a701da2000f97195