### PR TITLE
refactor(core): add token classifiers

### DIFF
--- a/.changeset/token-classifiers-strategy-map.md
+++ b/.changeset/token-classifiers-strategy-map.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor token tracker to use classifier strategy map

--- a/tests/core/token-tracker.test.ts
+++ b/tests/core/token-tracker.test.ts
@@ -21,3 +21,75 @@ test('TokenTracker reports unused tokens', () => {
   assert.equal(reports.length, 1);
   assert.equal(reports[0].messages[0].message.includes('4px'), true);
 });
+
+test('cssVar classifier tracks custom property usage', () => {
+  const tokens: DesignTokens = {
+    colors: { used: 'var(--used)', unused: 'var(--unused)' },
+  };
+  const tracker = new TokenTracker(tokens);
+  tracker.configure([
+    {
+      rule: { name: 'design-system/no-unused-tokens' },
+      options: {},
+      severity: 'error',
+    },
+  ]);
+  tracker.trackUsage('color: var(--used);');
+  const reports = tracker.generateReports('config');
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].messages[0].message.includes('--unused'), true);
+});
+
+test('hexColor classifier is case-insensitive', () => {
+  const tokens: DesignTokens = {
+    colors: { brand: '#ABCDEF', other: '#123456' },
+  };
+  const tracker = new TokenTracker(tokens);
+  tracker.configure([
+    {
+      rule: { name: 'design-system/no-unused-tokens' },
+      options: {},
+      severity: 'error',
+    },
+  ]);
+  tracker.trackUsage('color: #abcdef;');
+  const reports = tracker.generateReports('config');
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].messages[0].message.includes('#123456'), true);
+});
+
+test('numeric classifier matches number tokens', () => {
+  const tokens: DesignTokens = {
+    spacing: ['4px', '8px'],
+  };
+  const tracker = new TokenTracker(tokens);
+  tracker.configure([
+    {
+      rule: { name: 'design-system/no-unused-tokens' },
+      options: {},
+      severity: 'error',
+    },
+  ]);
+  tracker.trackUsage('margin: 4px');
+  const reports = tracker.generateReports('config');
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].messages[0].message.includes('8px'), true);
+});
+
+test('string classifier matches plain string tokens', () => {
+  const tokens: DesignTokens = {
+    colors: { used: 'red', unused: 'blue' },
+  };
+  const tracker = new TokenTracker(tokens);
+  tracker.configure([
+    {
+      rule: { name: 'design-system/no-unused-tokens' },
+      options: {},
+      severity: 'error',
+    },
+  ]);
+  tracker.trackUsage('color: red;');
+  const reports = tracker.generateReports('config');
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].messages[0].message.includes('blue'), true);
+});


### PR DESCRIPTION
## Summary
- refactor token tracker to classify tokens (cssVar, hexColor, numeric, string)
- replace conditional loop with classifier strategy map
- test each classifier for unused-token reporting

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd3d6585708328966de5d9c6535bbb