### PR TITLE
refactor(cli): modularize run flow

### DIFF
--- a/.changeset/modular-cli-run.md
+++ b/.changeset/modular-cli-run.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": patch
+---
+
+refactor CLI run flow into modular helpers for environment setup, execution, and watch mode

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+import ignore, { type Ignore } from 'ignore';
+import { getFormatter } from '../formatters/index.js';
+import { relFromCwd, realpathIfExists } from '../utils/paths.js';
+import { loadCache, type Cache } from '../core/cache.js';
+import type { Config, Linter } from '../core/linter.js';
+import type { LintResult } from '../core/types.js';
+
+export interface Environment {
+  formatter: (results: LintResult[], useColor?: boolean) => string;
+  config: Config;
+  linterRef: { current: Linter };
+  pluginPaths: string[];
+  cache?: Cache;
+  cacheLocation?: string;
+  ignorePath?: string;
+  designIgnore: string;
+  gitIgnore: string;
+  refreshIgnore: () => Promise<void>;
+  state: { pluginPaths: string[]; ignoreFilePaths: string[] };
+  getIg: () => Ignore;
+}
+
+export async function prepareEnvironment(
+  options: Record<string, unknown>,
+): Promise<Environment> {
+  const [{ loadConfig }, { Linter }, { loadIgnore }] = await Promise.all([
+    import('../config/loader.js'),
+    import('../core/linter.js'),
+    import('../core/ignore.js'),
+  ]);
+
+  const formatter = await getFormatter(options.format as string);
+  let config = await loadConfig(
+    process.cwd(),
+    options.config as string | undefined,
+  );
+  if (options.concurrency !== undefined) {
+    config.concurrency = options.concurrency as number;
+  }
+  if (config.configPath) {
+    config.configPath = realpathIfExists(config.configPath);
+  }
+  const linterRef = { current: new Linter(config) };
+  const pluginPaths = await linterRef.current.getPluginPaths();
+
+  const cacheLocation = options.cache
+    ? path.resolve(
+        process.cwd(),
+        (options.cacheLocation as string) ?? '.designlintcache',
+      )
+    : undefined;
+  const cache = cacheLocation ? loadCache(cacheLocation) : undefined;
+
+  let ignorePath: string | undefined;
+  if (options.ignorePath) {
+    const resolved = path.resolve(options.ignorePath as string);
+    if (!fs.existsSync(resolved)) {
+      throw new Error(`Ignore file not found: "${relFromCwd(resolved)}"`);
+    }
+    ignorePath = realpathIfExists(resolved);
+  }
+
+  const gitIgnore = realpathIfExists(path.join(process.cwd(), '.gitignore'));
+  const designIgnore = realpathIfExists(
+    path.join(process.cwd(), '.designlintignore'),
+  );
+
+  let ig = ignore();
+  const refreshIgnore = async () => {
+    const { ig: newIg } = await loadIgnore(
+      config,
+      ignorePath ? [ignorePath] : [],
+    );
+    ig = newIg;
+  };
+  await refreshIgnore();
+
+  const state = { pluginPaths, ignoreFilePaths: [] as string[] };
+
+  return {
+    formatter,
+    config,
+    linterRef,
+    pluginPaths,
+    cache,
+    cacheLocation,
+    ignorePath,
+    designIgnore,
+    gitIgnore,
+    refreshIgnore,
+    state,
+    getIg: () => ig,
+  };
+}

--- a/src/cli/execute.ts
+++ b/src/cli/execute.ts
@@ -1,0 +1,69 @@
+import { performance } from 'node:perf_hooks';
+import chalk from 'chalk';
+import writeFileAtomic from 'write-file-atomic';
+import type { LintResult } from '../core/types.js';
+import type { Cache } from '../core/cache.js';
+import type { Linter } from '../core/linter.js';
+
+export interface ExecuteServices {
+  formatter: (results: LintResult[], useColor?: boolean) => string;
+  linterRef: { current: Linter };
+  cache?: Cache;
+  cacheLocation?: string;
+  ignorePath?: string;
+  state: { pluginPaths: string[]; ignoreFilePaths: string[] };
+  useColor: boolean;
+}
+
+export async function executeLint(
+  targets: string[],
+  opts: Record<string, unknown>,
+  services: ExecuteServices,
+): Promise<{ results: LintResult[]; exitCode: number; ignoreFiles: string[] }> {
+  const start = performance.now();
+  const {
+    results,
+    ignoreFiles = [],
+    warning,
+  } = await services.linterRef.current.lintFiles(
+    targets,
+    opts.fix as boolean | undefined,
+    services.cache,
+    services.ignorePath ? [services.ignorePath] : [],
+    services.cacheLocation,
+  );
+  const duration = performance.now() - start;
+  if (warning && !(opts.quiet as boolean)) console.warn(warning);
+  const output = services.formatter(results, services.useColor);
+  if (opts.output) {
+    await writeFileAtomic(opts.output as string, output);
+  } else if (!(opts.quiet as boolean)) {
+    console.log(output);
+  }
+  const fmt = opts.format as string | undefined;
+  if (!(opts.quiet as boolean) && (fmt === undefined || fmt === 'stylish')) {
+    const time = (duration / 1000).toFixed(2);
+    const count = results.length;
+    const stat = `\nLinted ${count} file${count === 1 ? '' : 's'} in ${time}s`;
+    console.log(services.useColor ? chalk.cyan.bold(stat) : stat);
+  }
+  if (opts.report) {
+    await writeFileAtomic(
+      opts.report as string,
+      JSON.stringify({ results, ignoreFiles }, null, 2),
+    );
+  }
+  const hasErrors = results.some((r) =>
+    r.messages.some((m) => m.severity === 'error'),
+  );
+  const warningCount = results.reduce(
+    (count, r) =>
+      count + r.messages.filter((m) => m.severity === 'warn').length,
+    0,
+  );
+  const maxWarnings = opts.maxWarnings as number | undefined;
+  let exitCode = hasErrors ? 1 : 0;
+  if (maxWarnings !== undefined && warningCount > maxWarnings) exitCode = 1;
+  services.state.ignoreFilePaths = ignoreFiles;
+  return { results, exitCode, ignoreFiles };
+}


### PR DESCRIPTION
## Summary
- refactor CLI run flow into reusable helpers for environment setup, lint execution, and watch mode
- streamline `run` composition using new helpers

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bd40869c448328acf50784c00c7e2c