### PR TITLE
refactor: remove option casting

### DIFF
--- a/.changeset/no-double-negation.md
+++ b/.changeset/no-double-negation.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+replace boolean casting with explicit checks in cache manager and no-inline-styles rule

--- a/.changeset/no-fs-alias.md
+++ b/.changeset/no-fs-alias.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor cache manager to import fs/promises directly instead of aliasing

--- a/.changeset/remove-config-cast.md
+++ b/.changeset/remove-config-cast.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor config loader to merge results without type assertions

--- a/.changeset/remove-non-null-assertions.md
+++ b/.changeset/remove-non-null-assertions.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+guard parser-service and sarif formatter to avoid non-null assertions

--- a/.changeset/typed-blur-options.md
+++ b/.changeset/typed-blur-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type blur rule options to remove casts

--- a/.changeset/typed-border-radius-options.md
+++ b/.changeset/typed-border-radius-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type token-border-radius rule options and drop casts

--- a/.changeset/typed-border-width-options.md
+++ b/.changeset/typed-border-width-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type border-width rule options so units are read without casts

--- a/.changeset/typed-cache-manager-errors.md
+++ b/.changeset/typed-cache-manager-errors.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+remove cache-manager error casts

--- a/.changeset/typed-cli-package-json.md
+++ b/.changeset/typed-cli-package-json.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type CLI package.json parsing to avoid casts

--- a/.changeset/typed-color-options.md
+++ b/.changeset/typed-color-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type color rule options to remove casts

--- a/.changeset/typed-component-prefix-options.md
+++ b/.changeset/typed-component-prefix-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor component-prefix rule to use typed options instead of casting

--- a/.changeset/typed-component-usage-options.md
+++ b/.changeset/typed-component-usage-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type component-usage rule options to remove cast

--- a/.changeset/typed-duration-tokens.md
+++ b/.changeset/typed-duration-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type duration tokens in token-duration rule to remove casts

--- a/.changeset/typed-execute-options.md
+++ b/.changeset/typed-execute-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type execute options to remove casts

--- a/.changeset/typed-formatter-loading.md
+++ b/.changeset/typed-formatter-loading.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type guard dynamic formatter imports to remove casts

--- a/.changeset/typed-icon-usage-options.md
+++ b/.changeset/typed-icon-usage-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type icon-usage rule options to remove cast

--- a/.changeset/typed-import-path-options.md
+++ b/.changeset/typed-import-path-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type import-path rule options

--- a/.changeset/typed-linter-config-tokens.md
+++ b/.changeset/typed-linter-config-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type linter config tokens to avoid casts

--- a/.changeset/typed-no-inline-styles-options.md
+++ b/.changeset/typed-no-inline-styles-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type no-inline-styles rule options and drop casts

--- a/.changeset/typed-parser-service.md
+++ b/.changeset/typed-parser-service.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type parser-service AST helpers and option parsing to remove casts

--- a/.changeset/typed-plugin-loading.md
+++ b/.changeset/typed-plugin-loading.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type plugin loading to remove casts

--- a/.changeset/typed-spacing-options.md
+++ b/.changeset/typed-spacing-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type spacing rule options, removing runtime casts

--- a/.changeset/typed-token-loader.md
+++ b/.changeset/typed-token-loader.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type token loader to avoid casts

--- a/.changeset/typed-token-schema.md
+++ b/.changeset/typed-token-schema.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type token schema to avoid casts

--- a/.changeset/typed-token-tracker-options.md
+++ b/.changeset/typed-token-tracker-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type token tracker rule options to remove casts

--- a/.changeset/typed-variant-prop-options.md
+++ b/.changeset/typed-variant-prop-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type variant-prop rule options to remove casts

--- a/.changeset/typed-watch-options.md
+++ b/.changeset/typed-watch-options.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+type watch mode options so output and report paths don't need casts

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,10 +27,11 @@ function initConfig(initFormat?: string) {
       const pkgPath = path.resolve(process.cwd(), 'package.json');
       if (fs.existsSync(pkgPath)) {
         try {
-          const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+          const pkgText = fs.readFileSync(pkgPath, 'utf8');
+          const pkg: {
             dependencies?: Record<string, unknown>;
             devDependencies?: Record<string, unknown>;
-          };
+          } = JSON.parse(pkgText);
           if (pkg.dependencies?.typescript || pkg.devDependencies?.typescript)
             format = 'ts';
         } catch {}
@@ -140,9 +141,8 @@ export async function run(argv = process.argv.slice(2)) {
 
   let useColor = Boolean(process.stdout.isTTY && supportsColor);
   const pkgPath = fileURLToPath(new URL('../../package.json', import.meta.url));
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
-    version: string;
-  };
+  const pkgData = fs.readFileSync(pkgPath, 'utf8');
+  const pkg: { version: string } = JSON.parse(pkgData);
 
   const program = createProgram(pkg.version);
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -66,8 +66,12 @@ export async function loadConfig(
       ? realpathIfExists(result.filepath)
       : undefined,
   };
-
-  const merged = { ...base, ...(result?.config as object | undefined) };
+  const isObject = (val: unknown): val is Record<string, unknown> =>
+    typeof val === 'object' && val !== null;
+  const merged = {
+    ...base,
+    ...(isObject(result?.config) ? result.config : {}),
+  };
   const parsed = configSchema.safeParse(merged);
   if (!parsed.success) {
     const location = result?.filepath ? ` at ${result.filepath}` : '';

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -20,10 +20,12 @@ const numberOrString = z.union([z.number(), z.string()]);
 
 const tokenPatternArray = z.array(z.union([z.string(), z.instanceof(RegExp)]));
 
-const tokenGroup = (schema: z.ZodTypeAny) =>
+const tokenGroup = <T extends z.ZodTypeAny>(
+  schema: T,
+): z.ZodType<Record<string, z.infer<T>> | (string | RegExp)[]> =>
   z.union([z.record(z.string(), schema), tokenPatternArray]);
 
-const baseTokensSchema = z
+const baseTokensSchema: z.ZodType<DesignTokens> = z
   .object({
     colors: tokenGroup(z.string()).optional(),
     spacing: tokenGroup(z.number()).optional(),
@@ -48,10 +50,8 @@ const baseTokensSchema = z
   })
   .catchall(z.unknown());
 
-const tokensSchema = z.union([
-  baseTokensSchema,
-  z.record(z.string(), baseTokensSchema),
-]) as unknown as z.ZodType<DesignTokens | Record<string, DesignTokens>>;
+const tokensSchema: z.ZodType<DesignTokens | Record<string, DesignTokens>> =
+  z.union([baseTokensSchema, z.record(z.string(), baseTokensSchema)]);
 
 export const configSchema: z.ZodSchema<Config> = z
   .object({

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -22,11 +22,15 @@ export interface Config {
   wrapTokensWithVar?: boolean;
 }
 
+interface ResolvedConfig extends Omit<Config, 'tokens'> {
+  tokens: DesignTokens;
+}
+
 /**
  * Lints files using built-in and plugin-provided rules.
  */
 export class Linter {
-  private config: Config;
+  private config: ResolvedConfig;
   private tokensByTheme: Record<string, DesignTokens> = {};
   private ruleRegistry: RuleRegistry;
   private parser: ParserService;
@@ -34,13 +38,13 @@ export class Linter {
 
   constructor(config: Config) {
     const normalized = normalizeTokens(
-      config.tokens as DesignTokens | Record<string, DesignTokens>,
+      config.tokens,
       config.wrapTokensWithVar ?? false,
     );
     this.tokensByTheme = normalized.themes;
     this.config = { ...config, tokens: normalized.merged };
     this.ruleRegistry = new RuleRegistry(this.config);
-    this.tokenTracker = new TokenTracker(this.config.tokens as DesignTokens);
+    this.tokenTracker = new TokenTracker(this.config.tokens);
     this.parser = new ParserService(this.tokensByTheme);
   }
 
@@ -108,7 +112,7 @@ export class Linter {
   }
 
   getTokenCompletions(): Record<string, string[]> {
-    const tokens = (this.config.tokens || {}) as DesignTokens;
+    const tokens = this.config.tokens;
     const completions: Record<string, string[]> = {};
     for (const [group, defs] of Object.entries(tokens)) {
       if (Array.isArray(defs)) {

--- a/src/core/rule-registry.ts
+++ b/src/core/rule-registry.ts
@@ -32,7 +32,7 @@ export class RuleRegistry {
       options: unknown;
       severity: 'error' | 'warn';
     }[] = [];
-    const ruleConfig = (this.config.rules || {}) as Record<string, unknown>;
+    const ruleConfig: Record<string, unknown> = this.config.rules ?? {};
     const unknown: string[] = [];
     for (const [name, setting] of Object.entries(ruleConfig)) {
       const entry = this.ruleMap.get(name);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -57,19 +57,19 @@ export interface LintResult {
   ruleDescriptions?: Record<string, string>;
 }
 
-export interface RuleContext {
+export interface RuleContext<TOptions = unknown> {
   report: (msg: Omit<LintMessage, 'ruleId' | 'severity'>) => void;
   tokens: DesignTokens;
-  options?: unknown;
+  options?: TOptions;
   filePath: string;
 }
 
-export interface RuleModule {
+export interface RuleModule<TOptions = unknown> {
   name: string;
   meta: {
     description: string;
   };
-  create: (context: RuleContext) => RuleListener;
+  create(context: RuleContext<TOptions>): RuleListener;
 }
 
 export interface RuleListener {

--- a/src/formatters/sarif.ts
+++ b/src/formatters/sarif.ts
@@ -48,9 +48,10 @@ export function sarifFormatter(
       }
     }
     for (const msg of res.messages) {
+      const existingIndex = ruleMap.get(msg.ruleId);
       let ruleIndex: number;
-      if (ruleMap.has(msg.ruleId)) {
-        ruleIndex = ruleMap.get(msg.ruleId)!;
+      if (existingIndex !== undefined) {
+        ruleIndex = existingIndex;
       } else {
         ruleIndex = sarif.runs[0].tool.driver.rules.length;
         ruleMap.set(msg.ruleId, ruleIndex);

--- a/src/rules/component-prefix.ts
+++ b/src/rules/component-prefix.ts
@@ -5,14 +5,13 @@ interface ComponentPrefixOptions {
   prefix?: string;
 }
 
-export const componentPrefixRule: RuleModule = {
+export const componentPrefixRule: RuleModule<ComponentPrefixOptions> = {
   name: 'design-system/component-prefix',
   meta: {
     description: 'enforce a prefix for design system components',
   },
   create(context) {
-    const opts = (context.options as ComponentPrefixOptions) || {};
-    const prefix = opts.prefix || 'DS';
+    const prefix = context.options?.prefix ?? 'DS';
     return {
       onNode(node) {
         if (

--- a/src/rules/component-usage.ts
+++ b/src/rules/component-usage.ts
@@ -1,18 +1,18 @@
 import ts from 'typescript';
 import type { RuleModule } from '../core/types.js';
 
-export const componentUsageRule: RuleModule = {
+export interface ComponentUsageOptions {
+  substitutions?: Record<string, string>;
+}
+
+export const componentUsageRule: RuleModule<ComponentUsageOptions> = {
   name: 'design-system/component-usage',
   meta: {
     description:
       'disallow raw HTML elements when design system components exist',
   },
   create(context) {
-    const opts =
-      (context.options as {
-        substitutions?: Record<string, string>;
-      }) || {};
-    const subs: Record<string, string> = opts.substitutions || {};
+    const subs = context.options?.substitutions ?? {};
     const lowerSubs: Record<string, string> = {};
     for (const [key, val] of Object.entries(subs)) {
       lowerSubs[key.toLowerCase()] = val;

--- a/src/rules/icon-usage.ts
+++ b/src/rules/icon-usage.ts
@@ -6,17 +6,16 @@ interface IconUsageOptions {
   substitutions?: Record<string, string>;
 }
 
-export const iconUsageRule: RuleModule = {
+export const iconUsageRule: RuleModule<IconUsageOptions> = {
   name: 'design-system/icon-usage',
   meta: {
     description:
       'disallow raw svg elements or non design system icon components',
   },
   create(context) {
-    const opts = (context.options as IconUsageOptions) || {};
     const subs: Record<string, string> = {
       svg: 'Icon',
-      ...(opts.substitutions || {}),
+      ...(context.options?.substitutions ?? {}),
     };
     const lowerSubs: Record<string, string> = {};
     for (const [key, val] of Object.entries(subs)) {

--- a/src/rules/import-path.ts
+++ b/src/rules/import-path.ts
@@ -6,21 +6,22 @@ interface ImportPathOptions {
   components?: string[];
 }
 
-export const importPathRule: RuleModule = {
+export const importPathRule: RuleModule<ImportPathOptions> = {
   name: 'design-system/import-path',
   meta: {
     description:
       'ensure design system components are imported from configured packages',
   },
   create(context) {
-    const opts = (context.options as ImportPathOptions) || {};
-    const packages = new Set(opts.packages || []);
-    const components = new Set(opts.components || []);
+    const opts: ImportPathOptions = context.options ?? {};
+    const packages = new Set(opts.packages ?? []);
+    const components = new Set(opts.components ?? []);
     return {
       onNode(node) {
         if (!ts.isImportDeclaration(node)) return;
         if (!node.importClause) return;
-        const moduleText = (node.moduleSpecifier as ts.StringLiteral).text;
+        if (!ts.isStringLiteral(node.moduleSpecifier)) return;
+        const moduleText = node.moduleSpecifier.text;
         if (packages.has(moduleText)) return;
         const reportSpecifier = (nameNode: ts.Node, name: string) => {
           const pos = nameNode

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -23,8 +23,9 @@ import { noInlineStylesRule } from './no-inline-styles.js';
 import { iconUsageRule } from './icon-usage.js';
 import { importPathRule } from './import-path.js';
 import { noUnusedTokensRule } from './no-unused-tokens.js';
+import type { RuleModule } from '../core/types.js';
 
-export const builtInRules = [
+export const builtInRules: RuleModule[] = [
   animationRule,
   blurRule,
   borderColorRule,

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -6,15 +6,14 @@ interface NoInlineStylesOptions {
   ignoreClassName?: boolean;
 }
 
-export const noInlineStylesRule: RuleModule = {
+export const noInlineStylesRule: RuleModule<NoInlineStylesOptions> = {
   name: 'design-system/no-inline-styles',
   meta: {
     description:
       'disallow inline style or className attributes on design system components',
   },
   create(context) {
-    const opts = (context.options as NoInlineStylesOptions) || {};
-    const ignoreClassName = !!opts.ignoreClassName;
+    const ignoreClassName = context.options?.ignoreClassName ?? false;
     return {
       onNode(node) {
         if (!ts.isJsxOpeningLikeElement(node)) return;

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -6,7 +6,11 @@ import {
   closestToken,
 } from '../utils/token-match.js';
 
-export const blurRule: RuleModule = {
+interface BlurRuleOptions {
+  units?: string[];
+}
+
+export const blurRule: RuleModule<BlurRuleOptions> = {
   name: 'design-token/blur',
   meta: { description: 'enforce blur tokens' },
   create(context) {
@@ -59,13 +63,9 @@ export const blurRule: RuleModule = {
         .filter((n): n is number => n !== null),
     );
     const allowedUnits = new Set(
-      (
-        (context.options as { units?: string[] } | undefined)?.units ?? [
-          'px',
-          'rem',
-          'em',
-        ]
-      ).map((u) => u.toLowerCase()),
+      (context.options?.units ?? ['px', 'rem', 'em']).map((u) =>
+        u.toLowerCase(),
+      ),
     );
     return {
       onCSSDeclaration(decl) {

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -8,7 +8,11 @@ import {
 } from '../utils/token-match.js';
 import { isStyleValue } from '../utils/style.js';
 
-export const borderRadiusRule: RuleModule = {
+interface BorderRadiusOptions {
+  units?: string[];
+}
+
+export const borderRadiusRule: RuleModule<BorderRadiusOptions> = {
   name: 'design-token/border-radius',
   meta: { description: 'enforce border-radius tokens' },
   create(context) {
@@ -61,13 +65,9 @@ export const borderRadiusRule: RuleModule = {
         .filter((n): n is number => n !== null),
     );
     const allowedUnits = new Set(
-      (
-        (context.options as { units?: string[] } | undefined)?.units ?? [
-          'px',
-          'rem',
-          'em',
-        ]
-      ).map((u) => u.toLowerCase()),
+      (context.options?.units ?? ['px', 'rem', 'em']).map((u) =>
+        u.toLowerCase(),
+      ),
     );
     return {
       onNode(node) {

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -8,7 +8,11 @@ import {
 } from '../utils/token-match.js';
 import { isStyleValue } from '../utils/style.js';
 
-export const borderWidthRule: RuleModule = {
+interface BorderWidthOptions {
+  units?: string[];
+}
+
+export const borderWidthRule: RuleModule<BorderWidthOptions> = {
   name: 'design-token/border-width',
   meta: { description: 'enforce border-width tokens' },
   create(context) {
@@ -61,13 +65,9 @@ export const borderWidthRule: RuleModule = {
         .filter((n): n is number => n !== null),
     );
     const allowedUnits = new Set(
-      (
-        (context.options as { units?: string[] } | undefined)?.units ?? [
-          'px',
-          'rem',
-          'em',
-        ]
-      ).map((u) => u.toLowerCase()),
+      (context.options?.units ?? ['px', 'rem', 'em']).map((u) =>
+        u.toLowerCase(),
+      ),
     );
     const parseValue = (text: string): number | null => {
       const trimmed = text.trim();

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -43,7 +43,7 @@ interface ColorRuleOptions {
   allow?: ColorFormat[];
 }
 
-export const colorsRule: RuleModule = {
+export const colorsRule: RuleModule<ColorRuleOptions> = {
   name: 'design-token/colors',
   meta: { description: 'disallow raw colors' },
   create(context) {
@@ -103,8 +103,8 @@ export const colorsRule: RuleModule = {
     const allowed = new Set(
       Object.values(colorTokens).map((value) => value.toLowerCase()),
     );
-    const opts = (context.options as ColorRuleOptions) || {};
-    const allowFormats = new Set(opts.allow || []);
+    const opts = context.options ?? {};
+    const allowFormats = new Set(opts.allow ?? []);
     const parserFormats = new Set<ColorFormat>([
       'hex',
       'rgb',

--- a/src/rules/token-duration.ts
+++ b/src/rules/token-duration.ts
@@ -12,9 +12,7 @@ export const durationRule: RuleModule = {
   name: 'design-token/duration',
   meta: { description: 'enforce duration tokens' },
   create(context) {
-    const durationTokens = (
-      context.tokens as { durations?: unknown } | undefined
-    )?.durations as Record<string, unknown> | (string | RegExp)[] | undefined;
+    const durationTokens = context.tokens.durations;
     if (
       !durationTokens ||
       (Array.isArray(durationTokens)

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -8,7 +8,12 @@ import {
 } from '../utils/token-match.js';
 import { isStyleValue } from '../utils/style.js';
 
-export const spacingRule: RuleModule = {
+interface SpacingOptions {
+  base?: number;
+  units?: string[];
+}
+
+export const spacingRule: RuleModule<SpacingOptions> = {
   name: 'design-token/spacing',
   meta: { description: 'enforce spacing scale' },
   create(context) {
@@ -44,9 +49,7 @@ export const spacingRule: RuleModule = {
       };
     }
     const allowed = new Set(Object.values(spacingTokens));
-    const opts =
-      (context.options as { base?: number; units?: string[] } | undefined) ??
-      {};
+    const opts = context.options ?? {};
     const base = opts.base ?? 4;
     const isAllowed = (n: number) => allowed.has(n) || n % base === 0;
     const allowedUnits = new Set(

--- a/src/rules/variant-prop.ts
+++ b/src/rules/variant-prop.ts
@@ -6,16 +6,15 @@ interface VariantPropOptions {
   prop?: string;
 }
 
-export const variantPropRule: RuleModule = {
+export const variantPropRule: RuleModule<VariantPropOptions> = {
   name: 'design-system/variant-prop',
   meta: {
     description:
       'ensure specified components use allowed values for their variant prop',
   },
   create(context) {
-    const opts = (context.options as VariantPropOptions) || {};
-    const components = opts.components || {};
-    const propName = opts.prop || 'variant';
+    const { components = {}, prop: propName = 'variant' } =
+      context.options ?? {};
     return {
       onNode(node) {
         if (!ts.isJsxOpeningLikeElement(node)) return;

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -11,10 +11,8 @@ test('loadCache loads and saves entries via flat-cache', async () => {
   const file = path.join(dir, 'cache.json');
 
   let cache = loadCache(file);
-  const entry = {
-    mtime: 1,
-    result: { filePath: 'foo', messages: [] } as LintResult,
-  };
+  const result: LintResult = { filePath: 'foo', messages: [] };
+  const entry = { mtime: 1, result };
   cache.setKey('foo', entry);
   cache.save(true);
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -85,7 +85,14 @@ test('--init-format overrides detection', () => {
 
 test('--init-format supports all formats', () => {
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
-  const formats = ['js', 'cjs', 'mjs', 'ts', 'mts', 'json'] as const;
+  const formats: readonly ['js', 'cjs', 'mjs', 'ts', 'mts', 'json'] = [
+    'js',
+    'cjs',
+    'mjs',
+    'ts',
+    'mts',
+    'json',
+  ];
   for (const fmt of formats) {
     const dir = makeTmpDir();
     const res = spawnSync(
@@ -110,8 +117,12 @@ test('CLI expands glob patterns with braces', () => {
     { encoding: 'utf8', cwd: dir },
   );
   assert.equal(res.status, 0);
-  const out = JSON.parse(res.stdout) as { filePath: string }[];
-  const files = out.map((r) => path.relative(dir, r.filePath)).sort();
+  const out = JSON.parse(res.stdout);
+  const files = Array.isArray(out)
+    ? out
+        .map((r: { filePath: string }) => path.relative(dir, r.filePath))
+        .sort()
+    : [];
   assert.deepEqual(files, ['src/a.module.css', 'src/b.module.scss']);
 });
 
@@ -968,10 +979,11 @@ test('CLI re-runs on file change in watch mode', async () => {
 });
 
 test('CLI ignores --output/--report files in watch mode', async () => {
-  for (const [flag, name] of [
+  const pairs: ReadonlyArray<[string, string]> = [
     ['--output', 'out.json'],
     ['--report', 'report.json'],
-  ] as const) {
+  ];
+  for (const [flag, name] of pairs) {
     const dir = makeTmpDir();
     fs.writeFileSync(path.join(dir, 'file.ts'), 'const a = 1;');
     fs.writeFileSync(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -240,19 +240,17 @@ test('loads config with multi-theme tokens', async () => {
     }),
   );
   const loaded = await loadConfig(tmp);
-  assert.equal(
-    (loaded.tokens as { light?: { colors?: { primary?: string } } })?.light
-      ?.colors?.primary,
-    '#fff',
-  );
+  const hasLight = (
+    tokens: unknown,
+  ): tokens is { light?: { colors?: { primary?: string } } } =>
+    typeof tokens === 'object' && tokens !== null && 'light' in tokens;
+  const light = hasLight(loaded.tokens) ? loaded.tokens.light : undefined;
+  assert.equal(light?.colors?.primary, '#fff');
 });
 
 test('surfaces errors thrown by ts config', async () => {
   const tmp = makeTmpDir();
   const configPath = path.join(tmp, 'designlint.config.ts');
-  fs.writeFileSync(
-    configPath,
-    "throw new Error('boom'); export default {} as const;",
-  );
+  fs.writeFileSync(configPath, "throw new Error('boom'); export default {};");
   await assert.rejects(loadConfig(tmp), /boom/);
 });

--- a/tests/core/cache-service.test.ts
+++ b/tests/core/cache-service.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { CacheService } from '../../src/core/cache-service.ts';
-import type { CacheManager } from '../../src/core/cache-manager.ts';
+import { CacheManager } from '../../src/core/cache-manager.ts';
 
 test('CacheService.prune removes cache entries not in file list', () => {
   const removed: string[] = [];
@@ -14,12 +14,16 @@ test('CacheService.prune removes cache entries not in file list', () => {
 });
 
 test('CacheService.save delegates to CacheManager.save', () => {
-  let saved = false;
-  const manager = {
-    save: (loc?: string) => {
-      if (loc === 'cache') saved = true;
-    },
-  } as unknown as CacheManager;
+  class TestManager extends CacheManager {
+    saved = false;
+    constructor() {
+      super(undefined, false);
+    }
+    override save(loc?: string): void {
+      if (loc === 'cache') this.saved = true;
+    }
+  }
+  const manager = new TestManager();
   CacheService.save(manager, 'cache');
-  assert.ok(saved);
+  assert.ok(manager.saved);
 });

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -1,17 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
-import type { LintResult } from '../../src/core/types.ts';
 
 test('Linter integrates registry, parser and trackers', async () => {
   const linter = new Linter({
     tokens: {},
     rules: { 'design-token/colors': 'error' },
   });
-  type Internal = { lintText: (t: string, f: string) => Promise<LintResult> };
-  const res = await (linter as unknown as Internal).lintText(
-    'a{color:#fff;}',
-    'file.css',
-  );
+  const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
+  const file = path.join(dir, 'file.css');
+  await fs.writeFile(file, 'a{color:#fff;}');
+  const res = await linter.lintFile(file);
   assert.equal(res.messages.length, 1);
 });

--- a/tests/fixtures/invalid-rule-plugin.ts
+++ b/tests/fixtures/invalid-rule-plugin.ts
@@ -1,12 +1,10 @@
-import type { PluginModule } from '../../src/core/types.ts';
-
-const plugin: PluginModule = {
+const plugin = {
   rules: [
     {
       name: '',
-      meta: {} as any,
-      create: 42 as any,
-    } as any,
+      meta: {},
+      create: 42,
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary
- allow rules to define typed options via generic RuleContext and RuleModule
- type component-usage, component-prefix, no-inline-styles, import-path, token-border-radius, token-border-width, token-blur, token-duration, token-spacing, icon-usage, color, and variant-prop rule options, removing runtime casts
- adjust rule registry to store typed rules without assertions, using bivariant RuleModule#create
- type CLI environment options to eliminate casts
- merge cosmiconfig results using a type guard instead of an `as` assertion
- type execute options to remove casts
- remove cache-manager error casts and import fs/promises directly
- type watch mode options so output and report paths don't need casts
- type token tracker rule options to drop option casts when tracking unused tokens
- type Zod token schema generically to avoid casting
- type linter config tokens to avoid casts when normalizing and reading completions
- type token loader normalization and merging without assertions
- load plugins with type guards so modules and rules are resolved without casting
- guard dynamic formatter imports to return functions without `as` assertions
- type CLI package.json parsing to avoid casts
- type parser-service option parsing and AST traversal to remove remaining casts
- eliminate CacheManager test casting by subclassing in CacheService tests
- drop casts in invalid plugin fixture
- remove remaining test casts by using typed helpers and guards
- drop const assertion in config error test fixture
- guard parser-service and sarif formatter to avoid non-null assertions
- replace boolean casts with explicit checks in cache manager and no-inline-styles rule

## Testing
- `npm run format src/core/cache-manager.ts .changeset/no-fs-alias.md`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bd59204e2c83288117f0ab4632b38f