### PR TITLE
chore(eslint): forbid type assertions

### DIFF
--- a/.changeset/disable-casting-lint-rule.md
+++ b/.changeset/disable-casting-lint-rule.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+enforce consistent-type-assertions rule to ban type casting

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -12,6 +12,10 @@ module.exports = [
     rules: {
       ...tsPlugin.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-assertions': [
+        'error',
+        { assertionStyle: 'never' },
+      ],
       '@typescript-eslint/no-require-imports': 'off',
     },
   },


### PR DESCRIPTION
## Summary
- enforce `@typescript-eslint/consistent-type-assertions` rule to disallow type casting

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdbf2bb36083289fcb56f97b9ceec9