### PR TITLE
fix(formatters): resolve modules from cwd and extract init config helpers

### DIFF
--- a/.changeset/raise-coverage-thresholds.md
+++ b/.changeset/raise-coverage-thresholds.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+increase coverage thresholds and add loadIgnore tests

--- a/.changeset/robust-formatter-resolution.md
+++ b/.changeset/robust-formatter-resolution.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+use import.meta.resolve for formatter modules and extract init config utilities

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
     "check-coverage": true,
     "branches": 75,
     "functions": 75,
-    "lines": 60,
-    "statements": 60
+    "lines": 80,
+    "statements": 80
   },
   "types": "dist/index.d.ts",
   "files": [

--- a/src/cli/init-config.ts
+++ b/src/cli/init-config.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import writeFileAtomic from 'write-file-atomic';
+
+const supported = new Set(['json', 'js', 'cjs', 'mjs', 'ts', 'mts']);
+
+export function detectInitFormat(initFormat?: string): string {
+  if (initFormat && !supported.has(initFormat)) {
+    throw new Error(
+      `Unsupported init format: "${initFormat}". Supported formats: ${[...supported].join(', ')}`,
+    );
+  }
+  let format = initFormat;
+  if (!format) {
+    const tsconfigPath = path.resolve(process.cwd(), 'tsconfig.json');
+    if (fs.existsSync(tsconfigPath)) {
+      format = 'ts';
+    } else {
+      const pkgPath = path.resolve(process.cwd(), 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        try {
+          const pkgText = fs.readFileSync(pkgPath, 'utf8');
+          const pkg = JSON.parse(pkgText) as unknown as {
+            dependencies?: Record<string, unknown>;
+            devDependencies?: Record<string, unknown>;
+          };
+          if (pkg.dependencies?.typescript || pkg.devDependencies?.typescript) {
+            format = 'ts';
+          }
+        } catch {}
+      }
+    }
+    format ??= 'json';
+  }
+  return format;
+}
+
+export function renderConfigTemplate(format: string): string {
+  switch (format) {
+    case 'json':
+      return `${JSON.stringify({ tokens: {}, rules: {} }, null, 2)}\n`;
+    case 'js':
+    case 'cjs':
+      return `module.exports = {\n  tokens: {},\n  rules: {},\n};\n`;
+    case 'mjs':
+      return `export default {\n  tokens: {},\n  rules: {},\n};\n`;
+    case 'ts':
+    case 'mts':
+      return `import { defineConfig } from '@lapidist/design-lint';\n\nexport default defineConfig({\n  tokens: {},\n  rules: {},\n});\n`;
+    default:
+      throw new Error(`Unsupported format: ${format}`);
+  }
+}
+
+export function initConfig(initFormat?: string) {
+  let format: string;
+  try {
+    format = detectInitFormat(initFormat);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(message);
+    process.exitCode = 1;
+    return;
+  }
+  const configPath = path.resolve(process.cwd(), `designlint.config.${format}`);
+  if (fs.existsSync(configPath)) {
+    console.log(`designlint.config.${format} already exists`);
+    return;
+  }
+  const contents = renderConfigTemplate(format);
+  writeFileAtomic.sync(configPath, contents);
+  console.log(`Created designlint.config.${format}`);
+}

--- a/tests/cli/init-config.test.ts
+++ b/tests/cli/init-config.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  detectInitFormat,
+  renderConfigTemplate,
+} from '../../src/cli/init-config.ts';
+import { makeTmpDir } from '../../src/utils/tmp.ts';
+
+void test('detectInitFormat infers ts when tsconfig exists', () => {
+  const dir = makeTmpDir();
+  fs.writeFileSync(path.join(dir, 'tsconfig.json'), '{}');
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    assert.equal(detectInitFormat(), 'ts');
+  } finally {
+    process.chdir(cwd);
+  }
+});
+
+void test('detectInitFormat defaults to json without indicators', () => {
+  const dir = makeTmpDir();
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    assert.equal(detectInitFormat(), 'json');
+  } finally {
+    process.chdir(cwd);
+  }
+});
+
+void test('detectInitFormat throws for unsupported format', () => {
+  assert.throws(() => detectInitFormat('yaml'), /Unsupported init format/);
+});
+
+void test('renderConfigTemplate emits defineConfig for ts', () => {
+  const tpl = renderConfigTemplate('ts');
+  assert.ok(tpl.includes('defineConfig'));
+});

--- a/tests/core/load-ignore.test.ts
+++ b/tests/core/load-ignore.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { makeTmpDir } from '../../src/utils/tmp.ts';
+import { loadIgnore } from '../../src/core/ignore.ts';
+
+void test('loadIgnore returns defaults when files missing', async () => {
+  const dir = makeTmpDir();
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const { patterns } = await loadIgnore();
+    assert.ok(patterns.includes('**/node_modules/**'));
+  } finally {
+    process.chdir(cwd);
+  }
+});
+
+void test('loadIgnore merges patterns from files and extra paths', async () => {
+  const dir = makeTmpDir();
+  fs.writeFileSync(path.join(dir, '.gitignore'), 'src/skip.ts');
+  fs.writeFileSync(
+    path.join(dir, '.designlintignore'),
+    '!node_modules/**\ncustom',
+  );
+  const extra = path.join(dir, '.customignore');
+  fs.writeFileSync(extra, 'extra.ts');
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const { patterns } = await loadIgnore(undefined, [extra]);
+    assert.ok(patterns.includes('src/skip.ts'));
+    assert.ok(patterns.includes('!node_modules/**'));
+    assert.ok(patterns.includes('custom'));
+    assert.ok(patterns.includes('extra.ts'));
+  } finally {
+    process.chdir(cwd);
+  }
+});

--- a/tests/formatters/formatters.test.ts
+++ b/tests/formatters/formatters.test.ts
@@ -192,12 +192,18 @@ void test('getFormatter returns formatter for valid name', async () => {
   assert.equal(await getFormatter('json'), jsonFormatter);
 });
 
-void test('getFormatter loads formatter from path', async () => {
+void test('getFormatter resolves formatter relative to cwd', async () => {
   const __dirname = fileURLToPath(new URL('.', import.meta.url));
-  const formatterPath = join(__dirname, 'fixtures', 'custom-formatter.ts');
-  const formatter = await getFormatter(formatterPath);
-  const out = formatter([{ filePath: 'a', messages: [] }]);
-  assert.equal(out, 'custom:1');
+  const fixtureDir = join(__dirname, 'fixtures');
+  const prev = process.cwd();
+  process.chdir(fixtureDir);
+  try {
+    const formatter = await getFormatter('./custom-formatter.ts');
+    const out = formatter([{ filePath: 'a', messages: [] }]);
+    assert.equal(out, 'custom:1');
+  } finally {
+    process.chdir(prev);
+  }
 });
 
 void test('getFormatter throws for invalid name', async () => {


### PR DESCRIPTION
## Summary
- increase c8 line and statement coverage thresholds to 80%
- add tests for `loadIgnore` covering missing files and additional ignore paths
- resolve formatter modules via `import.meta.resolve` with cwd-based fallback
- extract init config detection and template rendering into utilities with tests
- shorten CLI watch-mode tests by using shared timeouts and file mtime checks

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run test:coverage`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdf5ab56b08328a86593182f16f2f9