### PR TITLE
docs: clarify tokens and rule configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,14 @@ export default defineConfig({
 
 Tokens describe the design system values available to rules. Supported groups include `colors`, `spacing`, `borderRadius`, `fontSizes`, `zIndex` and more.
 
+The `colors` group lists the palette available to your application. Rules like [`design-token/colors`](rules/design-token/colors.md) compare CSS color values against this palette to prevent unapproved shades.
+
+Spacing scales are represented by the `spacing` group. The [`design-token/spacing`](rules/design-token/spacing.md) rule checks margin and padding declarations so layouts stick to the scale.
+
+Use `borderRadius` to define consistent corner rounding for buttons, cards and other surfaces. [`design-token/border-radius`](rules/design-token/border-radius.md) warns when arbitrary radii are used.
+
+Layering concerns can be expressed with `zIndex` tokens. [`design-token/z-index`](rules/design-token/z-index.md) ensures components only use approved stacking levels.
+
 Tokens may be defined as key–value maps or as pattern arrays for matching CSS variables. Set `wrapTokensWithVar: true` when your tokens already map to custom properties.
 
 ```json
@@ -32,7 +40,9 @@ Tokens may be defined as key–value maps or as pattern arrays for matching CSS 
 
 ## Rule configuration
 
-Rules are enabled in the `rules` section using either a severity string or an array with options.
+Each entry in the `rules` section begins with a severity: `'off'` (or `0`) disables a rule, `'warn'` (or `1`) reports a warning, and `'error'` (or `2`) fails the lint run.
+
+To configure rule-specific options, supply an array: `[severity, options]`.
 
 ```js
 module.exports = {
@@ -42,9 +52,20 @@ module.exports = {
 };
 ```
 
+### Design goals
+
+| Goal | Rule |
+| --- | --- |
+| Enforce brand palette | [`design-token/colors`](rules/design-token/colors.md) |
+| Maintain spacing scale | [`design-token/spacing`](rules/design-token/spacing.md) |
+| Restrict stacking levels | [`design-token/z-index`](rules/design-token/z-index.md) |
+| Standardize rounded corners | [`design-token/border-radius`](rules/design-token/border-radius.md) |
+
+Additional rules may be supplied by plugins; see [Plugins](plugins.md).
+
 ## Plugins
 
-Plugins supply additional rule modules. List plugin packages under `plugins` and then reference their rules:
+Plugins supply additional rule modules. See [Plugins](plugins.md) for details. List plugin packages under `plugins` and then reference their rules:
 
 ```js
 module.exports = {


### PR DESCRIPTION
## Summary
- expand Tokens section with common groups and examples
- document rule severity levels and option arrays with goal-to-rule table
- cross-link rule docs and plugin guide

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68be0c6c4cc48328a00230586a9037a1