### PR TITLE
docs: expand architecture overview and roadmap

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,10 +41,4 @@ Streams lint results through built‑in or custom formatters. See [`src/formatte
 Caching avoids repeated work across runs by storing file metadata and parsed ASTs. The runner processes files concurrently, dis
 tributing parsing and rule evaluation across available CPU cores.
 
-## Roadmap
-
-- Incremental linting with persistent caches.
-- Pluggable concurrency strategies, including worker threads.
-- Enhanced formatter API for streaming large reports.
-
 See the [Plugin guide](plugins.md) for extending the engine beyond the core modules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,8 @@
 # Architecture
 
-Design Lint processes files in three stages: discovery, linting and formatting.
+Design Lint orchestrates a pipeline that moves from file discovery to result formatting. It walks the filesystem, parses source
+content into abstract syntax trees (ASTs), evaluates registered rules and emits a report through the selected formatter. The fl
+ow below shows how data advances through each stage.
 
 ```mermaid
 flowchart LR
@@ -9,9 +11,40 @@ flowchart LR
   C --> D[Format results]
 ```
 
-1. **Scanning** – glob patterns resolve to a list of files. Ignore files and configuration influence the set.
-2. **Parsing** – language specific parsers convert sources to ASTs. CSS is handled with PostCSS; JS/TS uses the TypeScript compiler. Vue and Svelte files are compiled before linting.
-3. **Linting** – each rule receives nodes and reports messages. Rules may provide fix functions.
-4. **Formatting** – results are written using the selected formatter.
+Starting with **file discovery**, glob patterns expand to concrete paths and respect ignore files or configuration. Each file i
+s then **parsed** by language‑specific adapters: CSS uses PostCSS, JavaScript and TypeScript rely on the TypeScript compiler, an
+d Vue/Svelte single‑file components compile before analysis. The **rule engine** traverses the ASTs and records messages, optio
+nally providing fixes. Finally, the **formatter pipeline** transforms collected results into human‑ or machine‑readable output.
 
-See the [source code](../src) for module implementations and the [Plugin guide](plugins.md) for extending the engine.
+## Core modules
+
+### File discovery
+
+Resolves the working set of files using glob patterns and ignore rules. See [`src/core/file-service.ts`](../src/core/file-servi
+ce.ts).
+
+### Parser adapters
+
+Normalise different language parsers behind a common interface. See [`src/core/parsers`](../src/core/parsers).
+
+### Rule engine
+
+Registers rules and coordinates their execution over AST nodes. See [`src/core/linter.ts`](../src/core/linter.ts) and [`src/core
+/rule-registry.ts`](../src/core/rule-registry.ts).
+
+### Formatter pipeline
+
+Streams lint results through built‑in or custom formatters. See [`src/formatters`](../src/formatters).
+
+## Performance considerations
+
+Caching avoids repeated work across runs by storing file metadata and parsed ASTs. The runner processes files concurrently, dis
+tributing parsing and rule evaluation across available CPU cores.
+
+## Roadmap
+
+- Incremental linting with persistent caches.
+- Pluggable concurrency strategies, including worker threads.
+- Enhanced formatter API for streaming large reports.
+
+See the [Plugin guide](plugins.md) for extending the engine beyond the core modules.


### PR DESCRIPTION
## Summary
- detail the linting pipeline from discovery through formatting
- document core modules with links to source directories
- note caching/concurrency considerations and outline future enhancements

## Testing
- `npm install`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68be0cab4a8c8328aa9ca8916f511fe3