### PR TITLE
docs(frameworks): document Angular and other integrations

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -30,4 +30,62 @@ npx design-lint src/routes
 npx design-lint src/components
 ```
 
+## Angular
+Component templates (`.html`) and styles (`.scss`/`.css`) live alongside TypeScript files. Inline `template` and `styles` fields on `@Component` are checked automatically.
+
+```bash
+npx design-lint "src/**/*.component.{ts,html,scss}"
+```
+
+```json
+{
+  "scripts": {
+    "lint:design": "design-lint \"src/**/*.component.{ts,html,scss}\""
+  }
+}
+```
+
+## Astro
+`.astro` files mix markup and scripts. `<style>` tags and inline styles are linted without extra setup.
+
+```bash
+npx design-lint src/pages src/components
+```
+
+```json
+{
+  "scripts": {
+    "lint:design": "design-lint src/pages src/components"
+  }
+}
+```
+
+## HTML
+Static HTML files with inline `<style>` blocks or `style` attributes can be linted directly.
+
+```bash
+npx design-lint "public/**/*.html"
+```
+
+```json
+{
+  "scripts": {
+    "lint:design": "design-lint \"public/**/*.html\""
+  }
+}
+```
+
 Other frameworks using standard file extensions work without extra configuration.
+
+## ESLint and Stylelint
+Design Lint focuses on design token usage and component conventions, so keep existing linters for syntax rules. Run them side by side:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint . && stylelint \"**/*.css\" && design-lint src"
+  }
+}
+```
+
+When migrating, disable overlapping token or naming checks in ESLint or Stylelint to avoid duplicate warnings, and share ignore files to skip build outputs.


### PR DESCRIPTION
## Summary
- document Angular component template and style patterns with command snippets
- add Astro and static HTML examples with npm script suggestions
- note interoperability with ESLint and Stylelint

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68be0c8f9844832898739e8533f61c0e