### PR TITLE
docs(rules): standardize rule documentation

### DIFF
--- a/docs/rules/design-system/component-prefix.md
+++ b/docs/rules/design-system/component-prefix.md
@@ -1,10 +1,10 @@
 # design-system/component-prefix
 
-Enforces a prefix for design system component names.
-
-Works with React, Vue, Svelte, and Web Components.
+## Summary
+Enforces a prefix for design system component names. Works with React, Vue, Svelte, and Web Components.
 
 ## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 ```json
 {
@@ -17,9 +17,10 @@ Works with React, Vue, Svelte, and Web Components.
 }
 ```
 
-### Options
-
+## Options
 - `prefix` (`string`, default: `"DS"`): required prefix for component names.
+
+*This rule is auto-fixable.*
 
 ## Examples
 
@@ -34,3 +35,10 @@ Works with React, Vue, Svelte, and Web Components.
 ```tsx
 <DSButton />
 ```
+
+## When Not To Use
+If your project does not enforce a component prefix, disable this rule.
+
+## Related Rules
+- [design-system/component-usage](./component-usage.md)
+- [design-system/import-path](./import-path.md)

--- a/docs/rules/design-system/component-usage.md
+++ b/docs/rules/design-system/component-usage.md
@@ -1,8 +1,10 @@
 # design-system/component-usage
 
+## Summary
 Disallows raw HTML elements when a design system component should be used instead.
 
 ## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 ```json
 {
@@ -15,9 +17,10 @@ Disallows raw HTML elements when a design system component should be used instea
 }
 ```
 
-### Options
-
+## Options
 - `substitutions` (`Record<string, string>`): map of disallowed HTML tags to their design system components. Tag names are matched case-insensitively.
+
+*This rule is auto-fixable.*
 
 ## Examples
 
@@ -32,3 +35,10 @@ Disallows raw HTML elements when a design system component should be used instea
 ```tsx
 <DSButton>Save</DSButton>
 ```
+
+## When Not To Use
+If you allow raw HTML elements or lack a component library, disable this rule.
+
+## Related Rules
+- [design-system/component-prefix](./component-prefix.md)
+- [design-system/import-path](./import-path.md)

--- a/docs/rules/design-system/deprecation.md
+++ b/docs/rules/design-system/deprecation.md
@@ -1,8 +1,10 @@
 # design-system/deprecation
 
+## Summary
 Flags deprecated tokens or components defined in `tokens.deprecations`. If a replacement is provided, running the linter with `--fix` will automatically substitute the new value.
 
 ## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 ```json
 {
@@ -13,7 +15,10 @@ Flags deprecated tokens or components defined in `tokens.deprecations`. If a rep
 }
 ```
 
+## Options
 No additional options.
+
+*This rule is auto-fixable.*
 
 ## Examples
 
@@ -36,3 +41,11 @@ No additional options.
 ```tsx
 <NewButton>Click</NewButton>
 ```
+
+## When Not To Use
+If you do not track deprecated tokens or components, disable this rule.
+
+## Related Rules
+- [design-system/component-prefix](./component-prefix.md)
+- [design-system/component-usage](./component-usage.md)
+

--- a/docs/rules/design-system/icon-usage.md
+++ b/docs/rules/design-system/icon-usage.md
@@ -1,8 +1,10 @@
 # design-system/icon-usage
 
+## Summary
 Reports raw `<svg>` elements or non-design system icon components.
 
 ## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 ```json
 {
@@ -15,9 +17,10 @@ Reports raw `<svg>` elements or non-design system icon components.
 }
 ```
 
-### Options
-
+## Options
 - `substitutions` (`Record<string, string>`): map of disallowed icon element or component names to their design system replacements. Keys are matched case-insensitively. Defaults to `{ "svg": "Icon" }`.
+
+*This rule is auto-fixable.*
 
 ## Examples
 
@@ -33,3 +36,10 @@ Reports raw `<svg>` elements or non-design system icon components.
 ```tsx
 <Icon />
 ```
+
+## When Not To Use
+If raw SVGs or third-party icons are acceptable in your project, disable this rule.
+
+## Related Rules
+- [design-system/component-usage](./component-usage.md)
+- [design-system/variant-prop](./variant-prop.md)

--- a/docs/rules/design-system/import-path.md
+++ b/docs/rules/design-system/import-path.md
@@ -1,10 +1,10 @@
 # design-system/import-path
 
-Ensures design system components are imported from specific packages.
-
-Works with React, Vue, Svelte, and Web Components.
+## Summary
+Ensures design system components are imported from specific packages. Works with React, Vue, Svelte, and Web Components.
 
 ## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 ```json
 {
@@ -17,10 +17,11 @@ Works with React, Vue, Svelte, and Web Components.
 }
 ```
 
-### Options
-
+## Options
 - `packages` (`string[]`): allowed package names for design system components.
 - `components` (`string[]`): component names that must come from the specified packages.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -35,3 +36,10 @@ import { Button } from 'other-package';
 ```ts
 import { Button } from '@acme/design-system';
 ```
+
+## When Not To Use
+If component import sources are not enforced, disable this rule.
+
+## Related Rules
+- [design-system/component-prefix](./component-prefix.md)
+- [design-system/component-usage](./component-usage.md)

--- a/docs/rules/design-system/no-inline-styles.md
+++ b/docs/rules/design-system/no-inline-styles.md
@@ -1,10 +1,10 @@
 # design-system/no-inline-styles
 
-Disallows inline `style` and `className` (or `class`) attributes on design system components.
-
-Works with React, Vue, Svelte, and Web Components.
+## Summary
+Disallows inline `style` and `className` (or `class`) attributes on design system components. Works with React, Vue, Svelte, and Web Components.
 
 ## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 ```json
 {
@@ -17,9 +17,10 @@ Works with React, Vue, Svelte, and Web Components.
 }
 ```
 
-### Options
-
+## Options
 - `ignoreClassName` (`boolean`, default: `false`): if `true`, `className`/`class` attributes are ignored.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -43,3 +44,10 @@ Works with React, Vue, Svelte, and Web Components.
 <Button className="custom" />
 // when ignoreClassName is true
 ```
+
+## When Not To Use
+If inline styles or custom class names are permitted, disable this rule.
+
+## Related Rules
+- [design-system/component-usage](./component-usage.md)
+- [design-system/variant-prop](./variant-prop.md)

--- a/docs/rules/design-system/no-unused-tokens.md
+++ b/docs/rules/design-system/no-unused-tokens.md
@@ -1,18 +1,15 @@
 # design-system/no-unused-tokens
 
-Reports design tokens defined in your configuration that never appear in any
-linted file. This keeps the token set focused and helps uncover stale values
-left behind after refactors.
+## Summary
+Reports design tokens defined in your configuration that never appear in any linted file. This keeps the token set focused and helps uncover stale values left behind after refactors.
 
-The rule scans each file for raw values like hex colors, numeric spacing values
-and `var(--token)` references. Hex codes are matched case‑insensitively and both
-CSS variables and literal values are detected.
+The rule scans each file for raw values like hex colors, numeric spacing values and `var(--token)` references. Hex codes are matched case‑insensitively and both CSS variables and literal values are detected.
 
 > [!NOTE]
-> Run the linter on the full project to avoid false positives. Tokens referenced
-> in files that are excluded from the run will be reported as unused.
+> Run the linter on the full project to avoid false positives. Tokens referenced in files that are excluded from the run will be reported as unused.
 
-## Examples
+## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 Given this configuration:
 
@@ -47,7 +44,6 @@ A CSS variable can also be ignored:
 ## Options
 
 ### ignore
-
 Type: `string[]`
 
 Array of token values or CSS variable names to exclude from usage reporting.
@@ -59,3 +55,22 @@ Array of token values or CSS variable names to exclude from usage reporting.
   }
 }
 ```
+
+This rule is not auto-fixable.
+
+## Examples
+
+### Invalid
+
+Any token defined but not used in the project is reported.
+
+### Valid
+
+All defined tokens are referenced at least once.
+
+## When Not To Use
+If unused tokens are acceptable or token usage is tracked elsewhere, disable this rule.
+
+## Related Rules
+- [design-system/deprecation](./deprecation.md)
+- [design-token/colors](../design-token/colors.md)

--- a/docs/rules/design-system/variant-prop.md
+++ b/docs/rules/design-system/variant-prop.md
@@ -1,10 +1,10 @@
 # design-system/variant-prop
 
-Ensures that specified components use only allowed values for their variant prop.
-
-Works with React, Vue, Svelte, and Web Components.
+## Summary
+Ensures that specified components use only allowed values for their variant prop. Works with React, Vue, Svelte, and Web Components.
 
 ## Configuration
+Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
 
 ```json
 {
@@ -17,10 +17,11 @@ Works with React, Vue, Svelte, and Web Components.
 }
 ```
 
-### Options
-
+## Options
 - `components` (`Record<string, string[]>`): map of component names to their allowed variant values.
 - `prop` (`string`, default: `"variant"`): prop name to validate.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -52,3 +53,10 @@ Works with React, Vue, Svelte, and Web Components.
 ```tsx
 <Alert tone="info" />
 ```
+
+## When Not To Use
+If components freely accept any variant values, disable this rule.
+
+## Related Rules
+- [design-system/component-usage](./component-usage.md)
+- [design-system/component-prefix](./component-prefix.md)

--- a/docs/rules/design-token/animation.md
+++ b/docs/rules/design-token/animation.md
@@ -1,8 +1,10 @@
 # design-token/animation
 
+## Summary
 Enforces `animation` values to match the animation tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -12,6 +14,11 @@ Enforces `animation` values to match the animation tokens defined in your config
   "rules": { "design-token/animation": "error" }
 }
 ```
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -26,3 +33,10 @@ Enforces `animation` values to match the animation tokens defined in your config
 ```css
 .box { animation: spin 1s linear infinite; }
 ```
+
+## When Not To Use
+If your project does not enforce animation tokens, disable this rule.
+
+## Related Rules
+- [design-token/duration](./duration.md)
+- [design-token/colors](./colors.md)

--- a/docs/rules/design-token/blur.md
+++ b/docs/rules/design-token/blur.md
@@ -1,8 +1,10 @@
 # design-token/blur
 
+## Summary
 Enforces `blur()` values in `filter` or `backdrop-filter` to match the blur tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -12,6 +14,11 @@ Enforces `blur()` values in `filter` or `backdrop-filter` to match the blur toke
   "rules": { "design-token/blur": "error" }
 }
 ```
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -26,3 +33,10 @@ Enforces `blur()` values in `filter` or `backdrop-filter` to match the blur toke
 ```css
 .box { filter: blur(4px); }
 ```
+
+## When Not To Use
+If enforcing blur tokens is unnecessary, disable this rule.
+
+## Related Rules
+- [design-token/colors](./colors.md)
+- [design-token/spacing](./spacing.md)

--- a/docs/rules/design-token/border-color.md
+++ b/docs/rules/design-token/border-color.md
@@ -1,8 +1,10 @@
 # design-token/border-color
 
+## Summary
 Enforces `border-color` values to match the border color tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -12,6 +14,11 @@ Enforces `border-color` values to match the border color tokens defined in your 
   "rules": { "design-token/border-color": "error" }
 }
 ```
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -26,3 +33,10 @@ Enforces `border-color` values to match the border color tokens defined in your 
 ```css
 .box { border-color: #ffffff; }
 ```
+
+## When Not To Use
+If border colors aren't standardized through tokens, disable this rule.
+
+## Related Rules
+- [design-token/colors](./colors.md)
+- [design-token/border-width](./border-width.md)

--- a/docs/rules/design-token/border-radius.md
+++ b/docs/rules/design-token/border-radius.md
@@ -1,8 +1,10 @@
 # design-token/border-radius
 
+## Summary
 Enforces `border-radius` values to match the tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -14,6 +16,11 @@ Enforces `border-radius` values to match the tokens defined in your configuratio
 ```
 
 Border radius tokens are defined under `tokens.borderRadius`. Numbers are treated as pixel values; strings may use `px`, `rem`, or `em` units.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -29,3 +36,10 @@ Border radius tokens are defined under `tokens.borderRadius`. Numbers are treate
 .box { border-radius: 4px; }
 .box { border-radius: md; }
 ```
+
+## When Not To Use
+If border radius values are not standardized, disable this rule.
+
+## Related Rules
+- [design-token/border-width](./border-width.md)
+- [design-token/colors](./colors.md)

--- a/docs/rules/design-token/border-width.md
+++ b/docs/rules/design-token/border-width.md
@@ -1,8 +1,10 @@
 # design-token/border-width
 
+## Summary
 Enforces `border-width` values to match the border width tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -14,6 +16,11 @@ Enforces `border-width` values to match the border width tokens defined in your 
 ```
 
 Border width tokens are defined under `tokens.borderWidths`. Numbers are treated as pixel values; strings may use `px`, `rem`, or `em` units.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -29,3 +36,10 @@ Border width tokens are defined under `tokens.borderWidths`. Numbers are treated
 .box { border-width: 1px; }
 .box { border-width: sm; }
 ```
+
+## When Not To Use
+If border widths are not standardized with tokens, disable this rule.
+
+## Related Rules
+- [design-token/border-radius](./border-radius.md)
+- [design-token/colors](./colors.md)

--- a/docs/rules/design-token/box-shadow.md
+++ b/docs/rules/design-token/box-shadow.md
@@ -1,8 +1,10 @@
 # design-token/box-shadow
 
+## Summary
 Enforces `box-shadow` values to match the shadows tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -12,6 +14,11 @@ Enforces `box-shadow` values to match the shadows tokens defined in your configu
 ```
 
 Shadow tokens must be strings representing complete `box-shadow` declarations. Each declaration should include all required lengths and color values; no default units are assumed.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -27,3 +34,10 @@ Shadow tokens must be strings representing complete `box-shadow` declarations. E
 .box { box-shadow: 0 1px 2px rgba(0,0,0,0.1); }
 .box { box-shadow: 0 1px 2px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.2); }
 ```
+
+## When Not To Use
+If box shadows are not tokenized, disable this rule.
+
+## Related Rules
+- [design-token/colors](./colors.md)
+- [design-token/border-radius](./border-radius.md)

--- a/docs/rules/design-token/colors.md
+++ b/docs/rules/design-token/colors.md
@@ -1,10 +1,10 @@
 # design-token/colors
 
+## Summary
 Disallows raw color values and enforces the color tokens defined in your configuration.
 
 ## Configuration
-
-Enable the rule in `designlint.config.*`:
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -15,12 +15,12 @@ Enable the rule in `designlint.config.*`:
 }
 ```
 
-### Options
-
+## Options
 - `allow` (`"hex" | "rgb" | "rgba" | "hsl" | "hsla" | "hwb" | "lab" | "lch" | "color" | "named"`[]): formats that may appear as raw values. Defaults to `[]`.
 
-### Supported formats
+This rule is not auto-fixable.
 
+### Supported formats
 The rule detects and blocks the following color formats unless they are defined as tokens or explicitly allowed:
 
 - Hexadecimal values (e.g., `#ff0000`)
@@ -42,3 +42,10 @@ Token values and matched color strings are normalized to lowercase before compar
 ```css
 .button { color: #ff0000; }
 ```
+
+## When Not To Use
+If raw color values are allowed in your project, disable this rule.
+
+## Related Rules
+- [design-token/spacing](./spacing.md)
+- [design-token/font-size](./font-size.md)

--- a/docs/rules/design-token/duration.md
+++ b/docs/rules/design-token/duration.md
@@ -1,8 +1,10 @@
 # design-token/duration
 
+## Summary
 Enforces transition and animation duration values to match the duration tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -14,6 +16,11 @@ Enforces transition and animation duration values to match the duration tokens d
 ```
 
 Duration tokens may be numbers (milliseconds) or strings with `ms` or `s` units. String values are normalized for comparison.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -30,3 +37,10 @@ Duration tokens may be numbers (milliseconds) or strings with `ms` or `s` units.
 .box { transition: all 100ms ease; }
 .box { animation-duration: 250ms; }
 ```
+
+## When Not To Use
+If timing durations are not standardized, disable this rule.
+
+## Related Rules
+- [design-token/animation](./animation.md)
+- [design-token/opacity](./opacity.md)

--- a/docs/rules/design-token/font-family.md
+++ b/docs/rules/design-token/font-family.md
@@ -1,8 +1,10 @@
 # design-token/font-family
 
+## Summary
 Ensures `font-family` declarations use values from your `fonts` tokens.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -13,6 +15,11 @@ Ensures `font-family` declarations use values from your `fonts` tokens.
   "rules": { "design-token/font-family": "error" }
 }
 ```
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -27,3 +34,10 @@ Ensures `font-family` declarations use values from your `fonts` tokens.
 ```css
 .title { font-family: "Inter, sans-serif"; }
 ```
+
+## When Not To Use
+If arbitrary font families are allowed, disable this rule.
+
+## Related Rules
+- [design-token/font-size](./font-size.md)
+- [design-token/font-weight](./font-weight.md)

--- a/docs/rules/design-token/font-size.md
+++ b/docs/rules/design-token/font-size.md
@@ -1,8 +1,10 @@
 # design-token/font-size
 
+## Summary
 Ensures `font-size` declarations use values from your `fontSizes` tokens.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -14,9 +16,12 @@ Ensures `font-size` declarations use values from your `fontSizes` tokens.
 }
 ```
 
-Font-size tokens may be defined as numbers (interpreted as `px`) or strings
-with `px`, `rem`, or `em` units. These units are converted to pixel values for
-comparison.
+Font-size tokens may be defined as numbers (interpreted as `px`) or strings with `px`, `rem`, or `em` units. These units are converted to pixel values for comparison.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -32,3 +37,10 @@ comparison.
 .title { font-size: 1rem; }
 .title { font-size: 20px; }
 ```
+
+## When Not To Use
+If font sizes are not managed via tokens, disable this rule.
+
+## Related Rules
+- [design-token/font-family](./font-family.md)
+- [design-token/line-height](./line-height.md)

--- a/docs/rules/design-token/font-weight.md
+++ b/docs/rules/design-token/font-weight.md
@@ -1,8 +1,10 @@
 # design-token/font-weight
 
+## Summary
 Enforces `font-weight` values to match the font weight tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -12,6 +14,11 @@ Enforces `font-weight` values to match the font weight tokens defined in your co
 ```
 
 Font-weight tokens may be numbers or strings (e.g., `"bold"`). Numeric tokens allow equivalent numeric CSS values and JavaScript numeric literals.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -27,3 +34,10 @@ Font-weight tokens may be numbers or strings (e.g., `"bold"`). Numeric tokens al
 .text { font-weight: 400; }
 .text { font-weight: bold; }
 ```
+
+## When Not To Use
+If arbitrary font weights are allowed, disable this rule.
+
+## Related Rules
+- [design-token/font-family](./font-family.md)
+- [design-token/font-size](./font-size.md)

--- a/docs/rules/design-token/letter-spacing.md
+++ b/docs/rules/design-token/letter-spacing.md
@@ -1,8 +1,10 @@
 # design-token/letter-spacing
 
+## Summary
 Enforces `letter-spacing` values to match the letter-spacing tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -14,6 +16,11 @@ Enforces `letter-spacing` values to match the letter-spacing tokens defined in y
 ```
 
 Letter-spacing tokens may be numbers (interpreted as `px`) or strings with `px`, `rem`, or `em` units. String values are normalized for comparison.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -29,3 +36,10 @@ Letter-spacing tokens may be numbers (interpreted as `px`) or strings with `px`,
 .text { letter-spacing: -0.05em; }
 .text { letter-spacing: 0; }
 ```
+
+## When Not To Use
+If letter spacing is not standardized, disable this rule.
+
+## Related Rules
+- [design-token/font-size](./font-size.md)
+- [design-token/line-height](./line-height.md)

--- a/docs/rules/design-token/line-height.md
+++ b/docs/rules/design-token/line-height.md
@@ -1,8 +1,10 @@
 # design-token/line-height
 
+## Summary
 Enforces `line-height` values to match the line-height tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -14,6 +16,11 @@ Enforces `line-height` values to match the line-height tokens defined in your co
 ```
 
 Line-height tokens may be numbers (unitless) or strings with `px`, `rem`, `em`, or `%` units. String values are normalized for comparison.
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -29,3 +36,10 @@ Line-height tokens may be numbers (unitless) or strings with `px`, `rem`, `em`, 
 .text { line-height: 1.5; }
 .text { line-height: 20px; }
 ```
+
+## When Not To Use
+If line heights are not standardized, disable this rule.
+
+## Related Rules
+- [design-token/font-size](./font-size.md)
+- [design-token/letter-spacing](./letter-spacing.md)

--- a/docs/rules/design-token/opacity.md
+++ b/docs/rules/design-token/opacity.md
@@ -1,8 +1,10 @@
 # design-token/opacity
 
+## Summary
 Enforces `opacity` values to match the opacity tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -12,6 +14,11 @@ Enforces `opacity` values to match the opacity tokens defined in your configurat
   "rules": { "design-token/opacity": "error" }
 }
 ```
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -26,3 +33,10 @@ Enforces `opacity` values to match the opacity tokens defined in your configurat
 ```css
 .box { opacity: 0.2; }
 ```
+
+## When Not To Use
+If opacity values are not standardized, disable this rule.
+
+## Related Rules
+- [design-token/colors](./colors.md)
+- [design-token/duration](./duration.md)

--- a/docs/rules/design-token/outline.md
+++ b/docs/rules/design-token/outline.md
@@ -1,8 +1,10 @@
 # design-token/outline
 
+## Summary
 Enforces `outline` values to match the outline tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -12,6 +14,11 @@ Enforces `outline` values to match the outline tokens defined in your configurat
   "rules": { "design-token/outline": "error" }
 }
 ```
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -26,3 +33,10 @@ Enforces `outline` values to match the outline tokens defined in your configurat
 ```css
 .box { outline: 2px solid #000; }
 ```
+
+## When Not To Use
+If outline styles are not tokenized, disable this rule.
+
+## Related Rules
+- [design-token/border-color](./border-color.md)
+- [design-token/border-width](./border-width.md)

--- a/docs/rules/design-token/spacing.md
+++ b/docs/rules/design-token/spacing.md
@@ -1,8 +1,10 @@
 # design-token/spacing
 
+## Summary
 Enforces a spacing scale so that only configured token values or multiples of a base unit are allowed.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -13,12 +15,13 @@ Enforces a spacing scale so that only configured token values or multiples of a 
 }
 ```
 
-### Options
-
+## Options
 - `base` (`number`): values must be multiples of this number. Defaults to `4`.
 - `units` (`string[]`): CSS units to validate. Defaults to `['px', 'rem', 'em']`.
 
 Numbers that appear inside CSS functions (e.g., `calc()`, `var()`) are ignored.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -36,3 +39,10 @@ Numbers that appear inside CSS functions (e.g., `calc()`, `var()`) are ignored.
 .box { margin: calc(100% - 5px); }
 .box { margin: var(--space, 5px); }
 ```
+
+## When Not To Use
+If spacing values do not follow a scale, disable this rule.
+
+## Related Rules
+- [design-token/colors](./colors.md)
+- [design-token/font-size](./font-size.md)

--- a/docs/rules/design-token/z-index.md
+++ b/docs/rules/design-token/z-index.md
@@ -1,8 +1,10 @@
 # design-token/z-index
 
+## Summary
 Enforces `z-index` values to match the `zIndex` tokens defined in your configuration.
 
 ## Configuration
+Enable the rule in `designlint.config.*`. See [configuration](../../configuration.md) for defining tokens.
 
 ```json
 {
@@ -10,6 +12,11 @@ Enforces `z-index` values to match the `zIndex` tokens defined in your configura
   "rules": { "design-token/z-index": "error" }
 }
 ```
+
+## Options
+No additional options.
+
+This rule is not auto-fixable.
 
 ## Examples
 
@@ -32,3 +39,10 @@ const layer = 5;
 ```ts
 const layer = 1000;
 ```
+
+## When Not To Use
+If z-index values are not standardized, disable this rule.
+
+## Related Rules
+- [design-token/opacity](./opacity.md)
+- [design-token/spacing](./spacing.md)


### PR DESCRIPTION
## Summary
- apply unified template to all rule docs
- cross-link related rules and configuration references
- note default options and auto-fix behavior

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68be0c84aa38832885683c738500f9e6