### PR TITLE
docs: refine vitepress config

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,8 +1,27 @@
 import { defineConfig } from 'vitepress';
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function getRuleItems(dir: string) {
+  return readdirSync(resolve(__dirname, dir))
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => {
+      const name = f.replace(/\.md$/, '');
+      const section = dir.split('/').pop();
+      return { text: name, link: `/rules/${section}/${name}` };
+    })
+    .sort((a, b) => a.text.localeCompare(b.text));
+}
+
+const designSystemRules = getRuleItems('../rules/design-system');
+const designTokenRules = getRuleItems('../rules/design-token');
 
 export default defineConfig({
   title: 'design-lint',
   description: 'Design system linter',
+  cleanUrls: true,
+  lastUpdated: true,
+  sitemap: { hostname: 'https://design-lint.lapidist.net' },
   themeConfig: {
     logo: '/logo.svg',
     nav: [
@@ -37,68 +56,8 @@ export default defineConfig({
       {
         text: 'Rules',
         items: [
-          {
-            text: 'Design System',
-            items: [
-              {
-                text: 'component-prefix',
-                link: '/rules/design-system/component-prefix',
-              },
-              {
-                text: 'component-usage',
-                link: '/rules/design-system/component-usage',
-              },
-              { text: 'deprecation', link: '/rules/design-system/deprecation' },
-              { text: 'icon-usage', link: '/rules/design-system/icon-usage' },
-              { text: 'import-path', link: '/rules/design-system/import-path' },
-              {
-                text: 'no-inline-styles',
-                link: '/rules/design-system/no-inline-styles',
-              },
-              {
-                text: 'no-unused-tokens',
-                link: '/rules/design-system/no-unused-tokens',
-              },
-              {
-                text: 'variant-prop',
-                link: '/rules/design-system/variant-prop',
-              },
-            ],
-          },
-          {
-            text: 'Design Token',
-            items: [
-              { text: 'animation', link: '/rules/design-token/animation' },
-              { text: 'blur', link: '/rules/design-token/blur' },
-              {
-                text: 'border-color',
-                link: '/rules/design-token/border-color',
-              },
-              {
-                text: 'border-radius',
-                link: '/rules/design-token/border-radius',
-              },
-              {
-                text: 'border-width',
-                link: '/rules/design-token/border-width',
-              },
-              { text: 'box-shadow', link: '/rules/design-token/box-shadow' },
-              { text: 'colors', link: '/rules/design-token/colors' },
-              { text: 'duration', link: '/rules/design-token/duration' },
-              { text: 'font-family', link: '/rules/design-token/font-family' },
-              { text: 'font-size', link: '/rules/design-token/font-size' },
-              { text: 'font-weight', link: '/rules/design-token/font-weight' },
-              {
-                text: 'letter-spacing',
-                link: '/rules/design-token/letter-spacing',
-              },
-              { text: 'line-height', link: '/rules/design-token/line-height' },
-              { text: 'opacity', link: '/rules/design-token/opacity' },
-              { text: 'outline', link: '/rules/design-token/outline' },
-              { text: 'spacing', link: '/rules/design-token/spacing' },
-              { text: 'z-index', link: '/rules/design-token/z-index' },
-            ],
-          },
+          { text: 'Design System', items: designSystemRules },
+          { text: 'Design Token', items: designTokenRules },
         ],
       },
     ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -25,16 +25,6 @@ export default defineConfig({
   themeConfig: {
     logo: '/logo.svg',
     nav: [
-      { text: 'Usage', link: '/usage' },
-      { text: 'Configuration', link: '/configuration' },
-      { text: 'API', link: '/api' },
-      { text: 'Formatters', link: '/formatters' },
-      { text: 'Plugins', link: '/plugins' },
-      { text: 'Rules', link: '/rules/' },
-      { text: 'Architecture', link: '/architecture' },
-      { text: 'Frameworks', link: '/frameworks' },
-      { text: 'CI', link: '/ci' },
-      { text: 'Troubleshooting', link: '/troubleshooting' },
       { text: 'GitHub', link: 'https://github.com/bylapidist/design-lint' },
       { text: 'Author', link: 'https://lapidist.net' },
     ],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,6 @@
 # Architecture
 
-Design Lint orchestrates a pipeline that moves from file discovery to result formatting. It walks the filesystem, parses source
-content into abstract syntax trees (ASTs), evaluates registered rules and emits a report through the selected formatter. The fl
-ow below shows how data advances through each stage.
+Design Lint orchestrates a pipeline that moves from file discovery to result formatting. It walks the filesystem, parses source content into abstract syntax trees (ASTs), evaluates registered rules and emits a report through the selected formatter. The flow below shows how data advances through each stage.
 
 ```mermaid
 flowchart LR
@@ -11,34 +9,28 @@ flowchart LR
   C --> D[Format results]
 ```
 
-Starting with **file discovery**, glob patterns expand to concrete paths and respect ignore files or configuration. Each file i
-s then **parsed** by language‑specific adapters: CSS uses PostCSS, JavaScript and TypeScript rely on the TypeScript compiler, an
-d Vue/Svelte single‑file components compile before analysis. The **rule engine** traverses the ASTs and records messages, optio
-nally providing fixes. Finally, the **formatter pipeline** transforms collected results into human‑ or machine‑readable output.
+Starting with **file discovery**, glob patterns expand to concrete paths and respect ignore files or configuration. Each file is then **parsed** by language‑specific adapters: CSS uses PostCSS, JavaScript and TypeScript rely on the TypeScript compiler, and Vue/Svelte single‑file components compile before analysis. The **rule engine** traverses the ASTs and records messages, optionally providing fixes. Finally, the **formatter pipeline** transforms collected results into human‑ or machine‑readable output.
 
 ## Core modules
 
 ### File discovery
 
-Resolves the working set of files using glob patterns and ignore rules. See [`src/core/file-service.ts`](../src/core/file-servi
-ce.ts).
+Resolves the working set of files using glob patterns and ignore rules. See [`src/core/file-service.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/file-service.ts).
 
 ### Parser adapters
 
-Normalise different language parsers behind a common interface. See [`src/core/parsers`](../src/core/parsers).
+Normalise different language parsers behind a common interface. See [`src/core/parsers`](https://github.com/bylapidist/design-lint/tree/main/src/core/parsers).
 
 ### Rule engine
 
-Registers rules and coordinates their execution over AST nodes. See [`src/core/linter.ts`](../src/core/linter.ts) and [`src/core
-/rule-registry.ts`](../src/core/rule-registry.ts).
+Registers rules and coordinates their execution over AST nodes. See [`src/core/linter.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/linter.ts) and [`src/core/rule-registry.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/rule-registry.ts).
 
 ### Formatter pipeline
 
-Streams lint results through built‑in or custom formatters. See [`src/formatters`](../src/formatters).
+Streams lint results through built‑in or custom formatters. See [`src/formatters`](https://github.com/bylapidist/design-lint/tree/main/src/formatters).
 
 ## Performance considerations
 
-Caching avoids repeated work across runs by storing file metadata and parsed ASTs. The runner processes files concurrently, dis
-tributing parsing and rule evaluation across available CPU cores.
+Caching avoids repeated work across runs by storing file metadata and parsed ASTs. The runner processes files concurrently, distributing parsing and rule evaluation across available CPU cores.
 
 See the [Plugin guide](plugins.md) for extending the engine beyond the core modules.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,4 +83,4 @@ Ignore files via `.designlintignore` or the `ignoreFiles` array in the config. P
 - A rule requiring tokens is enabled but tokens are missing → add the token group or disable the rule.
 - Configuration file not found → run `npx design-lint init` to generate one.
 
-See [examples](examples) for sample configurations.
+See [examples](https://github.com/bylapidist/design-lint/tree/main/docs/examples) for sample configurations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # @lapidist/design-lint
 
-@lapidist/design-lint keeps JavaScript, TypeScript and style sheets aligned with your design system. These docs cover setup, rule configuration and integration examples. For background and a project overview, see the [README](../README.md).
+@lapidist/design-lint keeps JavaScript, TypeScript and style sheets aligned with your design system. These docs cover setup, rule configuration and integration examples. For background and a project overview, see the [README](https://github.com/bylapidist/design-lint/blob/main/README.md).
 
 ## Getting Started
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,7 +83,7 @@ Design Lint requires Node.js 22 or later.
 Upgrade to Node.js 22 or later.
 
 ### Related docs
-- [README](../README.md)
+- [README](https://github.com/bylapidist/design-lint/blob/main/README.md)
 
 ## Performance bottleneck
 


### PR DESCRIPTION
## Summary
- automate rules sidebar and enable clean URLs, lastUpdated, and sitemap in VitePress
- fix broken documentation links so `npm run docs:build` succeeds

## Testing
- `npm run docs:build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68be10251d908328955f3a34b0077c02