### PR TITLE
docs: enable local search in VitePress

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
   sitemap: { hostname: 'https://design-lint.lapidist.net' },
   themeConfig: {
     logo: '/logo.svg',
+    search: {
+      provider: 'local',
+    },
     nav: [
       { text: 'GitHub', link: 'https://github.com/bylapidist/design-lint' },
       { text: 'Author', link: 'https://lapidist.net' },


### PR DESCRIPTION
## Summary
- enable local search in the VitePress documentation

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68be12d53a7083289e5f5f2facc1eb2e