### PR TITLE
feat(core): add pluggable document sources

### DIFF
--- a/.changeset/document-source-refactor.md
+++ b/.changeset/document-source-refactor.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+allow injecting custom document sources and expose default file-based implementation

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,7 @@ A typical control flow when using the library directly:
 import {
   loadConfig,
   Linter,
+  FileSource,
   getFormatter,
   applyFixes,
 } from '@lapidist/design-lint';
@@ -19,7 +20,7 @@ async function main() {
   const config = await loadConfig(process.cwd());
 
   // 2. Create a linter instance
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
 
   // 3. Lint files and optionally apply automatic fixes
   const { results } = await linter.lintFiles(['src/**/*.{ts,tsx}'], true);
@@ -70,10 +71,11 @@ Helper to define a configuration object with type checking.
 
 Lints files using built-in and plugin-provided rules.
 
-#### `new Linter(config)`
+#### `new Linter(config, source?)`
 
 - **Parameters**
   - `config: Config` – resolved configuration.
+  - `source: DocumentSource = new FileSource()` – document source used to resolve lint targets.
 - **Returns** `Linter` instance.
 
 #### `lintFiles(targets, fix?, cache?, additionalIgnorePaths?, cacheLocation?)`
@@ -132,6 +134,7 @@ Executes linting tasks with concurrency control.
     - `config: Config`
     - `tokenTracker: TokenTracker`
     - `lintText: (text: string, filePath: string) => Promise<LintResult>`
+    - `source: DocumentSource`
 
 #### `run(targets, fix?, cache?, additionalIgnorePaths?, cacheLocation?)`
 
@@ -194,7 +197,7 @@ export const noFooRule: RuleModule = {
 ### Dynamic configuration
 
 ```ts
-import { Linter } from '@lapidist/design-lint';
+import { Linter, FileSource } from '@lapidist/design-lint';
 import type { Config } from '@lapidist/design-lint';
 
 const config: Config = {
@@ -202,7 +205,7 @@ const config: Config = {
   rules: { 'token-colors': 'error' },
 };
 
-const linter = new Linter(config);
+const linter = new Linter(config, new FileSource());
 ```
 
 These types allow you to build custom integrations and tooling on top of Design Lint.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ Starting with **file discovery**, glob patterns expand to concrete paths and res
 
 ### File discovery
 
-Resolves the working set of files using glob patterns and ignore rules. See [`src/core/file-service.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/file-service.ts).
+Resolves the working set of files using glob patterns and ignore rules. See [`src/core/file-source.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/file-source.ts).
 
 ### Parser adapters
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -76,7 +76,7 @@ Tests run against the `Linter` API:
 // test/acme-plugin.test.ts
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '@lapidist/design-lint';
+import { Linter, FileSource } from '@lapidist/design-lint';
 import plugin from '../index.js';
 
 void test('reports raw colors and px units', async () => {
@@ -86,7 +86,7 @@ void test('reports raw colors and px units', async () => {
       'acme/no-raw-colors': 'error',
       'acme/no-px': 'warn'
     }
-  });
+  }, new FileSource());
   const res = await linter.lintText('h1 { color: #fff; margin: 4px; }', 'file.css');
   assert.equal(res.messages.length, 2);
 });

--- a/src/core/document-source.ts
+++ b/src/core/document-source.ts
@@ -1,0 +1,11 @@
+import type { Config } from './linter.js';
+
+export type LintTarget = string;
+
+export interface DocumentSource {
+  scan(
+    targets: string[],
+    config: Config,
+    additionalIgnorePaths?: string[],
+  ): Promise<LintTarget[]>;
+}

--- a/src/core/file-source.ts
+++ b/src/core/file-source.ts
@@ -3,12 +3,13 @@ import { performance } from 'node:perf_hooks';
 import { realpathIfExists } from '../utils/paths.js';
 import { getIgnorePatterns } from './ignore.js';
 import type { Config } from './linter.js';
+import type { DocumentSource } from './document-source.js';
 
 const defaultPatterns = [
   '**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs,css,scss,sass,less,svelte,vue}',
 ];
 
-export const FileService = {
+export class FileSource implements DocumentSource {
   async scan(
     targets: string[],
     config: Config,
@@ -34,5 +35,5 @@ export const FileService = {
       );
     }
     return files;
-  },
-} as const;
+  }
+}

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -11,6 +11,8 @@ import type { Cache } from './cache.js';
 import { RuleRegistry } from './rule-registry.js';
 import { TokenTracker } from './token-tracker.js';
 import { Runner } from './runner.js';
+import type { DocumentSource } from './document-source.js';
+import { FileSource } from './file-source.js';
 import { parserRegistry } from './parser-registry.js';
 import path from 'node:path';
 
@@ -37,8 +39,9 @@ export class Linter {
   private tokensByTheme: Record<string, DesignTokens> = {};
   private ruleRegistry: RuleRegistry;
   private tokenTracker: TokenTracker;
+  private source: DocumentSource;
 
-  constructor(config: Config) {
+  constructor(config: Config, source: DocumentSource = new FileSource()) {
     const normalized = normalizeTokens(
       config.tokens,
       config.wrapTokensWithVar ?? false,
@@ -47,6 +50,7 @@ export class Linter {
     this.config = { ...config, tokens: normalized.merged };
     this.ruleRegistry = new RuleRegistry(this.config);
     this.tokenTracker = new TokenTracker(this.config.tokens);
+    this.source = source;
   }
 
   async lintFile(
@@ -83,6 +87,7 @@ export class Linter {
       config: this.config,
       tokenTracker: this.tokenTracker,
       lintText: this.lintText.bind(this),
+      source: this.source,
     });
     return runner.run(
       targets,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import type { Config } from './linter.js';
 import type { Cache } from './cache.js';
 import type { LintResult } from './types.js';
-import { FileService } from './file-service.js';
+import type { DocumentSource } from './document-source.js';
 import { CacheService } from './cache-service.js';
 import { TokenTracker } from './token-tracker.js';
 
@@ -11,17 +11,20 @@ export interface RunnerOptions {
   config: Config;
   tokenTracker: TokenTracker;
   lintText: (text: string, filePath: string) => Promise<LintResult>;
+  source: DocumentSource;
 }
 
 export class Runner {
   private config: Config;
   private tokenTracker: TokenTracker;
   private lintText: (text: string, filePath: string) => Promise<LintResult>;
+  private source: DocumentSource;
 
   constructor(options: RunnerOptions) {
     this.config = options.config;
     this.tokenTracker = options.tokenTracker;
     this.lintText = options.lintText;
+    this.source = options.source;
   }
 
   async run(
@@ -35,7 +38,7 @@ export class Runner {
     ignoreFiles: string[];
     warning?: string;
   }> {
-    const files = await FileService.scan(
+    const files = await this.source.scan(
       targets,
       this.config,
       additionalIgnorePaths,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export { Linter, type Config, applyFixes } from './core/linter.js';
 export { Runner } from './core/runner.js';
+export type { DocumentSource } from './core/document-source.js';
+export { FileSource } from './core/file-source.js';
 export { loadConfig } from './config/loader.js';
 export { defineConfig } from './config/define-config.js';
 export { getFormatter } from './formatters/index.js';

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { readWhenReady } from './helpers/fs.ts';
 import { Linter } from '../src/index.ts';
+import { FileSource } from '../src/index.ts';
 import type { LintResult } from '../src/core/types.ts';
 
 const tsxLoader = require.resolve('tsx/esm');
@@ -1061,7 +1062,7 @@ void test('CLI cache updates after --fix run', async () => {
     tokens: { deprecations: { old: { replacement: 'new' } } },
     rules: { 'design-system/deprecation': 'error' },
   };
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const cache = new Map<
     string,
     {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -5,6 +5,7 @@ import { makeTmpDir } from '../src/utils/tmp.ts';
 import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('returns default config when none found', async () => {
   const tmp = makeTmpDir();
@@ -209,7 +210,7 @@ void test("rule configured as 'off' is ignored", async () => {
     }),
   );
   const config = await loadConfig(tmp);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const res = await linter.lintText('const c = "#fff";', 'file.ts');
   assert.equal(res.messages.length, 0);
 });
@@ -222,7 +223,7 @@ void test('throws on unknown rule name', async () => {
     JSON.stringify({ rules: { 'unknown/rule': 'error' } }),
   );
   const config = await loadConfig(tmp);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   await assert.rejects(
     () => linter.lintText('const x = 1;', 'file.ts'),
     /Unknown rule\(s\): unknown\/rule/,

--- a/tests/core/glob-ignore.test.ts
+++ b/tests/core/glob-ignore.test.ts
@@ -2,11 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { FileService } from '../../src/core/file-service.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 import { makeTmpDir } from '../../src/utils/tmp.ts';
 import type { Config } from '../../src/core/linter.ts';
 
-void test('FileService.scan applies nested ignore files for glob targets', async () => {
+void test('FileSource.scan applies nested ignore files for glob targets', async () => {
   const dir = makeTmpDir();
   fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'src', 'keep.ts'), '');
@@ -17,7 +17,7 @@ void test('FileService.scan applies nested ignore files for glob targets', async
   process.chdir(dir);
   try {
     const config: Config = { tokens: {}, rules: {} };
-    const files = await FileService.scan(['**/*.ts'], config);
+    const files = await new FileSource().scan(['**/*.ts'], config);
     const rels = files.map((f) => path.relative(dir, f)).sort();
     assert.deepEqual(rels, ['src/keep.ts']);
   } finally {

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -3,12 +3,16 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('Linter integrates registry, parser and trackers', async () => {
-  const linter = new Linter({
-    tokens: {},
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: {},
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
   const file = path.join(dir, 'file.css');
   await fs.writeFile(file, 'a{color:#fff;}');

--- a/tests/core/profile.test.ts
+++ b/tests/core/profile.test.ts
@@ -4,18 +4,18 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../../src/utils/tmp.ts';
 import { Linter } from '../../src/core/linter.ts';
-import { FileService } from '../../src/core/file-service.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 import type { Config } from '../../src/core/linter.ts';
 
-// Ensure FileService.scan logs when profiling is enabled
+// Ensure FileSource.scan logs when profiling is enabled
 // This also covers the catch branch for missing files by passing a non-existent target
 
 // Use separate test for profiling
 
-void test('FileService.scan logs when DESIGNLINT_PROFILE is set', async () => {
+void test('FileSource.scan logs when DESIGNLINT_PROFILE is set', async () => {
   const dir = makeTmpDir();
   fs.writeFileSync(path.join(dir, 'file.ts'), '');
-  const linter = new Linter({ tokens: {}, rules: {} });
+  const linter = new Linter({ tokens: {}, rules: {} }, new FileSource());
   const cwd = process.cwd();
   process.chdir(dir);
   process.env.DESIGNLINT_PROFILE = '1';
@@ -35,14 +35,14 @@ void test('FileService.scan logs when DESIGNLINT_PROFILE is set', async () => {
   assert.ok(logs.some((l) => l.includes('Scanned 1 files in')));
 });
 
-void test('FileService.scan collects files from directory targets', async () => {
+void test('FileSource.scan collects files from directory targets', async () => {
   const dir = makeTmpDir();
   fs.writeFileSync(path.join(dir, 'a.ts'), '');
   const config: Config = { tokens: {}, rules: {} };
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const files = await FileService.scan(['.'], config);
+    const files = await new FileSource().scan(['.'], config);
     const rels = files.map((f) => path.relative(dir, f));
     assert.deepEqual(rels, ['a.ts']);
   } finally {

--- a/tests/core/runner.test.ts
+++ b/tests/core/runner.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Runner } from '../../src/index.ts';
 import { TokenTracker } from '../../src/core/token-tracker.ts';
+import { FileSource } from '../../src/index.ts';
 
 interface CacheEntry {
   mtime: number;
@@ -39,6 +40,7 @@ void test('Runner handles non-positive concurrency values', async () => {
     config: { concurrency: 0, tokens: {} },
     tokenTracker: new TokenTracker({}),
     lintText: (text, filePath) => Promise.resolve({ filePath, messages: [] }),
+    source: new FileSource(),
   });
   const res = await runner.run([file]);
   assert.equal(res.results[0]?.filePath, file);
@@ -55,6 +57,7 @@ void test('Runner prunes cache and saves results', async () => {
     config: { tokens: {} },
     tokenTracker: new TokenTracker({}),
     lintText: (text, filePath) => Promise.resolve({ filePath, messages: [] }),
+    source: new FileSource(),
   });
   await runner.run([file], false, cache, [], 'cache');
   assert.deepEqual(cache.keys(), [file]);

--- a/tests/glob.test.ts
+++ b/tests/glob.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('lintFiles expands glob patterns with globby', async () => {
   const dir = makeTmpDir();
@@ -13,7 +14,7 @@ void test('lintFiles expands glob patterns with globby', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({ tokens: {}, rules: {} });
+    const linter = new Linter({ tokens: {}, rules: {} }, new FileSource());
     const { results, warning } = await linter.lintFiles([
       '**/*.module.{css,scss}',
     ]);

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('lintFiles ignores common directories by default', async () => {
   const dir = makeTmpDir();
@@ -20,10 +21,13 @@ void test('lintFiles ignores common directories by default', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath));
     assert.deepEqual(files, ['src/file.ts']);
@@ -42,10 +46,13 @@ void test('lintFiles respects .gitignore via globby', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
@@ -68,10 +75,13 @@ void test('.designlintignore can unignore paths', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['node_modules/pkg/index.ts', 'src/file.ts']);
@@ -90,10 +100,13 @@ void test('.designlintignore overrides .gitignore', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['src/file.ts']);
@@ -115,10 +128,13 @@ void test('.designlintignore supports negative patterns', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['src/file.ts']);
@@ -137,10 +153,13 @@ void test('.designlintignore supports Windows paths', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
@@ -158,11 +177,14 @@ void test('config ignoreFiles are respected', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-      ignoreFiles: ['src/skip.ts'],
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+        ignoreFiles: ['src/skip.ts'],
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
@@ -182,10 +204,13 @@ void test('additional ignore file is respected', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.'], false, undefined, [
       extra,
     ]);
@@ -206,10 +231,13 @@ void test('lintFiles respects nested .gitignore', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['nested/keep.ts']);
@@ -229,10 +257,13 @@ void test('nested .designlintignore overrides parent patterns', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({
-      tokens: { deprecations: { old: { replacement: 'new' } } },
-      rules: { 'design-system/deprecation': 'error' },
-    });
+    const linter = new Linter(
+      {
+        tokens: { deprecations: { old: { replacement: 'new' } } },
+        rules: { 'design-system/deprecation': 'error' },
+      },
+      new FileSource(),
+    );
     const { results } = await linter.lintFiles(['.']);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['src/keep.ts', 'src/skip.ts']);

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('inline directives disable linting', async () => {
   const dir = makeTmpDir();
@@ -20,10 +21,13 @@ void test('inline directives disable linting', async () => {
       '/* design-lint-enable */\n' +
       "const f = 'old';\n",
   );
-  const linter = new Linter({
-    tokens: { deprecations: { old: { replacement: 'new' } } },
-    rules: { 'design-system/deprecation': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { deprecations: { old: { replacement: 'new' } } },
+      rules: { 'design-system/deprecation': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintFile(file);
   const lines = res.messages.map((m) => m.line).sort();
   assert.deepEqual(lines, [1, 9]);
@@ -36,10 +40,13 @@ void test('strings resembling directives do not disable next line', async () => 
     file,
     "const a = 'design-lint-disable-next-line';\n" + "const b = 'old';\n",
   );
-  const linter = new Linter({
-    tokens: { deprecations: { old: { replacement: 'new' } } },
-    rules: { 'design-system/deprecation': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { deprecations: { old: { replacement: 'new' } } },
+      rules: { 'design-system/deprecation': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintFile(file);
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].line, 2);

--- a/tests/lint-file.test.ts
+++ b/tests/lint-file.test.ts
@@ -3,13 +3,14 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');
 
 void test('lintFile delegates to lintFiles', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const res1 = await linter.lintFile(file);
   const { results: res2 } = await linter.lintFiles([file]);
@@ -18,7 +19,7 @@ void test('lintFile delegates to lintFiles', async () => {
 
 void test('lintFile reports unreadable file', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const original = fs.readFile;
   const stub = mock.method(
@@ -45,7 +46,7 @@ void test('lintFile reports unreadable file', async () => {
 
 void test('lintFiles reports unreadable file', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const original = fs.readFile;
   const stub = mock.method(

--- a/tests/patterns.test.ts
+++ b/tests/patterns.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('lintFiles uses patterns option to include custom extensions', async () => {
   const tmp = makeTmpDir();
@@ -13,10 +14,13 @@ void test('lintFiles uses patterns option to include custom extensions', async (
     tokens: { colors: { primary: '#000000' } },
     rules: { 'design-token/colors': 'error' },
   };
-  const defaultLinter = new Linter(baseConfig);
+  const defaultLinter = new Linter(baseConfig, new FileSource());
   const { results: defaultResults } = await defaultLinter.lintFiles([tmp]);
   assert.equal(defaultResults.length, 0);
-  const customLinter = new Linter({ ...baseConfig, patterns: ['**/*.foo'] });
+  const customLinter = new Linter(
+    { ...baseConfig, patterns: ['**/*.foo'] },
+    new FileSource(),
+  );
   const { results: customResults } = await customLinter.lintFiles([tmp]);
   assert.equal(customResults.length, 1);
   assert.equal(customResults[0].filePath, file);

--- a/tests/performance.test.ts
+++ b/tests/performance.test.ts
@@ -5,11 +5,12 @@ import { makeTmpDir } from '../src/utils/tmp.ts';
 import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('lints large projects without crashing', async () => {
   const dir = path.join(__dirname, 'fixtures', 'large-project');
   const config = await loadConfig(dir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const { results } = await linter.lintFiles([dir]);
   assert.equal(results.length, 200);
 });
@@ -25,7 +26,7 @@ void test('lints very large projects without EMFILE', async () => {
     );
   }
   const config = await loadConfig(tmp);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const { results } = await linter.lintFiles([tmp]);
   assert.equal(results.length, count);
   fs.rmSync(tmp, { recursive: true, force: true });
@@ -74,7 +75,7 @@ void test('respects configured concurrency limit', async () => {
   fsp.stat = trackedStat;
 
   const config = await loadConfig(tmp);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const { results } = await linter.lintFiles([tmp]);
   assert.equal(results.length, count);
   assert.ok(max <= 2);

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -2,14 +2,18 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 void test('external plugin rules execute', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin.ts');
-  const linter = new Linter({
-    plugins: [pluginPath],
-    rules: { 'plugin/test': 'error' },
-  });
+  const linter = new Linter(
+    {
+      plugins: [pluginPath],
+      rules: { 'plugin/test': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].ruleId, 'plugin/test');
@@ -18,7 +22,7 @@ void test('external plugin rules execute', async () => {
 void test('plugins resolve relative to config file', async () => {
   const dir = path.join(__dirname, 'fixtures', 'plugin-relative');
   const config = await loadConfig(dir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].ruleId, 'plugin/test');
@@ -26,10 +30,13 @@ void test('plugins resolve relative to config file', async () => {
 
 void test('loads ESM plugin modules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin-esm.mjs');
-  const linter = new Linter({
-    plugins: [pluginPath],
-    rules: { 'plugin/esm': 'error' },
-  });
+  const linter = new Linter(
+    {
+      plugins: [pluginPath],
+      rules: { 'plugin/esm': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].ruleId, 'plugin/esm');
@@ -37,7 +44,7 @@ void test('loads ESM plugin modules', async () => {
 
 void test('throws for invalid plugin modules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] });
+  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /Invalid plugin/,
@@ -46,7 +53,7 @@ void test('throws for invalid plugin modules', async () => {
 
 void test('throws for invalid plugin rules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-rule-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] });
+  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /Invalid rule/,
@@ -55,7 +62,7 @@ void test('throws for invalid plugin rules', async () => {
 
 void test('throws when plugin module missing', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'missing-plugin.js');
-  const linter = new Linter({ plugins: [pluginPath] });
+  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /Failed to load plugin/,
@@ -64,7 +71,7 @@ void test('throws when plugin module missing', async () => {
 
 void test('throws when plugin rule conflicts with existing rule', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'conflict-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] });
+  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /conflicts with an existing rule/,
@@ -74,7 +81,7 @@ void test('throws when plugin rule conflicts with existing rule', async () => {
 void test('throws when two plugins define the same rule name', async () => {
   const pluginA = path.join(__dirname, 'fixtures', 'test-plugin.ts');
   const pluginB = path.join(__dirname, 'fixtures', 'duplicate-rule-plugin.ts');
-  const linter = new Linter({ plugins: [pluginA, pluginB] });
+  const linter = new Linter({ plugins: [pluginA, pluginB] }, new FileSource());
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     (err) => {
@@ -88,7 +95,7 @@ void test('throws when two plugins define the same rule name', async () => {
 
 void test('getPluginPaths returns resolved plugin paths', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] });
+  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
   await linter.lintText('const a = 1;', 'file.ts');
   const paths = await linter.getPluginPaths();
   assert.deepEqual(paths, [pluginPath]);

--- a/tests/rules/animation.test.ts
+++ b/tests/rules/animation.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/animation reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { animations: { spin: 'spin 1s linear infinite' } },
-    rules: { 'design-token/animation': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { animations: { spin: 'spin 1s linear infinite' } },
+      rules: { 'design-token/animation': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{animation: wiggle 2s ease-in-out;}',
     'file.css',
@@ -15,10 +19,13 @@ void test('design-token/animation reports invalid value', async () => {
 });
 
 void test('design-token/animation accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { animations: { spin: 'spin 1s linear infinite' } },
-    rules: { 'design-token/animation': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { animations: { spin: 'spin 1s linear infinite' } },
+      rules: { 'design-token/animation': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{animation: spin 1s linear infinite;}',
     'file.css',
@@ -27,9 +34,12 @@ void test('design-token/animation accepts valid values', async () => {
 });
 
 void test('design-token/animation warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/animation': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/animation': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('animations'));

--- a/tests/rules/blur.test.ts
+++ b/tests/rules/blur.test.ts
@@ -1,29 +1,39 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/blur reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { blurs: { sm: '4px' } },
-    rules: { 'design-token/blur': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { blurs: { sm: '4px' } },
+      rules: { 'design-token/blur': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{filter:blur(2px);}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/blur accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { blurs: { sm: '4px' } },
-    rules: { 'design-token/blur': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { blurs: { sm: '4px' } },
+      rules: { 'design-token/blur': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{filter:blur(4px);}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/blur warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/blur': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/blur': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('blurs'));

--- a/tests/rules/border-color.test.ts
+++ b/tests/rules/border-color.test.ts
@@ -1,29 +1,39 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/border-color reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { borderColors: { primary: '#ffffff' } },
-    rules: { 'design-token/border-color': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderColors: { primary: '#ffffff' } },
+      rules: { 'design-token/border-color': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{border-color:#000000;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/border-color accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { borderColors: { primary: '#ffffff' } },
-    rules: { 'design-token/border-color': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderColors: { primary: '#ffffff' } },
+      rules: { 'design-token/border-color': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{border-color:#ffffff;}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/border-color warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/border-color': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/border-color': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('borderColors'));

--- a/tests/rules/border-radius.test.ts
+++ b/tests/rules/border-radius.test.ts
@@ -1,31 +1,41 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/border-radius reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { borderRadius: { sm: 2, md: 4 } },
-    rules: { 'design-token/border-radius': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderRadius: { sm: 2, md: 4 } },
+      rules: { 'design-token/border-radius': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{border-radius:3px;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/border-radius accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { borderRadius: { sm: 2, md: 4 } },
-    rules: { 'design-token/border-radius': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderRadius: { sm: 2, md: 4 } },
+      rules: { 'design-token/border-radius': 'error' },
+    },
+    new FileSource(),
+  );
   const css = '.a{border-radius:4px;} .b{border-radius:2px;}';
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/border-radius reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { borderRadius: { sm: 2, md: 4 } },
-    rules: { 'design-token/border-radius': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderRadius: { sm: 2, md: 4 } },
+      rules: { 'design-token/border-radius': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const r = <div style={{ borderRadius: 3 }} />;',
     'file.tsx',
@@ -34,19 +44,25 @@ void test('design-token/border-radius reports numeric literals', async () => {
 });
 
 void test('design-token/border-radius ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { borderRadius: { sm: 2, md: 4 } },
-    rules: { 'design-token/border-radius': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderRadius: { sm: 2, md: 4 } },
+      rules: { 'design-token/border-radius': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/border-radius warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/border-radius': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/border-radius': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('borderRadius'));

--- a/tests/rules/border-width.test.ts
+++ b/tests/rules/border-width.test.ts
@@ -1,31 +1,41 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/border-width reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { borderWidths: { sm: 1, md: 2 } },
-    rules: { 'design-token/border-width': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderWidths: { sm: 1, md: 2 } },
+      rules: { 'design-token/border-width': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{border-width:3px;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/border-width accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { borderWidths: { sm: 1, md: 2 } },
-    rules: { 'design-token/border-width': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderWidths: { sm: 1, md: 2 } },
+      rules: { 'design-token/border-width': 'error' },
+    },
+    new FileSource(),
+  );
   const css = '.a{border-width:1px;} .b{border-width:2px;}';
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/border-width reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { borderWidths: { sm: 1, md: 2 } },
-    rules: { 'design-token/border-width': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderWidths: { sm: 1, md: 2 } },
+      rules: { 'design-token/border-width': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const w = <div style={{ borderWidth: 3 }} />;',
     'file.tsx',
@@ -34,10 +44,13 @@ void test('design-token/border-width reports numeric literals', async () => {
 });
 
 void test('design-token/border-width reports template literal', async () => {
-  const linter = new Linter({
-    tokens: { borderWidths: { sm: 1, md: 2 } },
-    rules: { 'design-token/border-width': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderWidths: { sm: 1, md: 2 } },
+      rules: { 'design-token/border-width': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const w = <div style={{ borderWidth: `3` }} />;',
     'file.tsx',
@@ -46,10 +59,13 @@ void test('design-token/border-width reports template literal', async () => {
 });
 
 void test('design-token/border-width reports template expression', async () => {
-  const linter = new Linter({
-    tokens: { borderWidths: { sm: 1, md: 2 } },
-    rules: { 'design-token/border-width': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderWidths: { sm: 1, md: 2 } },
+      rules: { 'design-token/border-width': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const w = <div style={{ borderWidth: `3${"px"}` }} />;',
     'file.tsx',
@@ -58,10 +74,13 @@ void test('design-token/border-width reports template expression', async () => {
 });
 
 void test('design-token/border-width reports prefix unary', async () => {
-  const linter = new Linter({
-    tokens: { borderWidths: { sm: 1, md: 2 } },
-    rules: { 'design-token/border-width': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderWidths: { sm: 1, md: 2 } },
+      rules: { 'design-token/border-width': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const w = <div style={{ borderWidth: -3 }} />;',
     'file.tsx',
@@ -70,19 +89,25 @@ void test('design-token/border-width reports prefix unary', async () => {
 });
 
 void test('design-token/border-width ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { borderWidths: { sm: 1, md: 2 } },
-    rules: { 'design-token/border-width': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { borderWidths: { sm: 1, md: 2 } },
+      rules: { 'design-token/border-width': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/border-width warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/border-width': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/border-width': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('borderWidths'));

--- a/tests/rules/box-shadow.test.ts
+++ b/tests/rules/box-shadow.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/box-shadow reports disallowed value', async () => {
-  const linter = new Linter({
-    tokens: { shadows: { sm: '0 1px 2px rgba(0,0,0,0.1)' } },
-    rules: { 'design-token/box-shadow': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { shadows: { sm: '0 1px 2px rgba(0,0,0,0.1)' } },
+      rules: { 'design-token/box-shadow': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{box-shadow:0 2px 4px rgba(0,0,0,0.1);}',
     'file.css',
@@ -15,15 +19,18 @@ void test('design-token/box-shadow reports disallowed value', async () => {
 });
 
 void test('design-token/box-shadow allows configured tokens', async () => {
-  const linter = new Linter({
-    tokens: {
-      shadows: {
-        sm: '0 1px 2px rgba(0,0,0,0.1)',
-        lg: '0 2px 4px rgba(0,0,0,0.2)',
+  const linter = new Linter(
+    {
+      tokens: {
+        shadows: {
+          sm: '0 1px 2px rgba(0,0,0,0.1)',
+          lg: '0 2px 4px rgba(0,0,0,0.2)',
+        },
       },
+      rules: { 'design-token/box-shadow': 'error' },
     },
-    rules: { 'design-token/box-shadow': 'error' },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{box-shadow:0 1px 2px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.2);}',
     'file.css',
@@ -32,9 +39,12 @@ void test('design-token/box-shadow allows configured tokens', async () => {
 });
 
 void test('design-token/box-shadow warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/box-shadow': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/box-shadow': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.shadows'));

--- a/tests/rules/colors.test.ts
+++ b/tests/rules/colors.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/colors reports disallowed hex', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "#AaBbCc" }} />;',
     'file.tsx',
@@ -16,10 +20,13 @@ void test('design-token/colors reports disallowed hex', async () => {
 });
 
 void test('design-token/colors ignores hex case', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#FFFFFF' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#FFFFFF' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "#ffffff" }} />;',
     'file.tsx',
@@ -28,10 +35,13 @@ void test('design-token/colors ignores hex case', async () => {
 });
 
 void test('design-token/colors ignores invalid hex lengths', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#fff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#fff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "#12345" }} />;',
     'file.tsx',
@@ -40,10 +50,13 @@ void test('design-token/colors ignores invalid hex lengths', async () => {
 });
 
 void test('design-token/colors reports disallowed rgb', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "rgb(0, 0, 0)" }} />;',
     'file.tsx',
@@ -52,10 +65,13 @@ void test('design-token/colors reports disallowed rgb', async () => {
 });
 
 void test('design-token/colors reports disallowed rgba', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "rgba(0,0,0,0.5)" }} />;',
     'file.tsx',
@@ -64,10 +80,13 @@ void test('design-token/colors reports disallowed rgba', async () => {
 });
 
 void test('design-token/colors reports disallowed hsl', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "hsl(0, 0%, 0%)" }} />;',
     'file.tsx',
@@ -76,10 +95,13 @@ void test('design-token/colors reports disallowed hsl', async () => {
 });
 
 void test('design-token/colors reports disallowed hsla', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "hsla(0, 0%, 0%, 0.5)" }} />;',
     'file.tsx',
@@ -88,10 +110,13 @@ void test('design-token/colors reports disallowed hsla', async () => {
 });
 
 void test('design-token/colors reports disallowed named color', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "red" }} />;',
     'file.tsx',
@@ -100,10 +125,13 @@ void test('design-token/colors reports disallowed named color', async () => {
 });
 
 void test('design-token/colors reports correct column for mid-string color', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "abc #000" }} />;',
     'file.tsx',
@@ -113,10 +141,13 @@ void test('design-token/colors reports correct column for mid-string color', asy
 });
 
 void test('design-token/colors reports various named colors', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <div style={{ color: "papayawhip" }} />; const b = <div style={{ color: "rebeccapurple" }} />;',
     'file.tsx',
@@ -125,20 +156,26 @@ void test('design-token/colors reports various named colors', async () => {
 });
 
 void test('design-token/colors reports correct column for css declarations', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('background:url(foo) #000;', 'file.css');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].column, 10);
 });
 
 void test('design-token/colors allows configured formats', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': ['error', { allow: ['named'] }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': ['error', { allow: ['named'] }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "red" }} />;',
     'file.tsx',
@@ -147,29 +184,38 @@ void test('design-token/colors allows configured formats', async () => {
 });
 
 void test('design-token/colors handles gradients', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const css = `.a{\n  background: linear-gradient(\n    #ffffff,\n    #000000\n  );\n}`;
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/colors warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/colors': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/colors': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.colors'));
 });
 
 void test('design-token/colors ignores non-style jsx attributes', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <div aria-label="Pause audio" style={{ color: "#000" }} />;',
     'file.tsx',

--- a/tests/rules/component-prefix.test.ts
+++ b/tests/rules/component-prefix.test.ts
@@ -1,35 +1,45 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-prefix enforces prefix on components', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-prefix': ['error', { prefix: 'DS' }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = <Button/>;', 'file.tsx');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('DS'));
 });
 
 void test('design-system/component-prefix ignores lowercase tags', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-prefix': ['error', { prefix: 'DS' }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = <div/>;', 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-system/component-prefix fixes self-closing tags', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-prefix': ['error', { prefix: 'DS' }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const code = 'const a = <Button/>';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 1);
@@ -39,11 +49,14 @@ void test('design-system/component-prefix fixes self-closing tags', async () => 
 });
 
 void test('design-system/component-prefix fixes opening and closing tags', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-prefix': ['error', { prefix: 'DS' }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const code = 'const a = <Button></Button>';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 2);
@@ -53,11 +66,14 @@ void test('design-system/component-prefix fixes opening and closing tags', async
 });
 
 void test('design-system/component-prefix enforces prefix in Vue components', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-prefix': ['error', { prefix: 'DS' }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '<template><Button/></template>',
     'file.vue',
@@ -66,21 +82,27 @@ void test('design-system/component-prefix enforces prefix in Vue components', as
 });
 
 void test('design-system/component-prefix enforces prefix in Svelte components', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-prefix': ['error', { prefix: 'DS' }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-prefix': ['error', { prefix: 'DS' }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText('<Button/>', 'file.svelte');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-system/component-prefix enforces prefix on custom elements', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-prefix': ['error', { prefix: 'ds-' }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-prefix': ['error', { prefix: 'ds-' }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const code = 'const a = <my-button></my-button>';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 2);

--- a/tests/rules/component-usage.test.ts
+++ b/tests/rules/component-usage.test.ts
@@ -1,59 +1,72 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-usage suggests substitutions', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-usage': [
-        'error',
-        { substitutions: { button: 'DSButton' } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-usage': [
+          'error',
+          { substitutions: { button: 'DSButton' } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = <button/>;', 'file.tsx');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('DSButton'));
 });
 
 void test('design-system/component-usage matches mixed-case tags', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-usage': [
-        'error',
-        { substitutions: { button: 'DSButton' } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-usage': [
+          'error',
+          { substitutions: { button: 'DSButton' } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = <Button/>;', 'file.tsx');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('DSButton'));
 });
 
 void test('design-system/component-usage matches mixed-case substitution keys', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-usage': [
-        'error',
-        { substitutions: { Button: 'DSButton' } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-usage': [
+          'error',
+          { substitutions: { Button: 'DSButton' } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = <button/>;', 'file.tsx');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('DSButton'));
 });
 
 void test('design-system/component-usage fixes self-closing tags', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-usage': [
-        'error',
-        { substitutions: { button: 'DSButton' } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-usage': [
+          'error',
+          { substitutions: { button: 'DSButton' } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const code = 'const a = <button/>;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 1);
@@ -63,14 +76,17 @@ void test('design-system/component-usage fixes self-closing tags', async () => {
 });
 
 void test('design-system/component-usage fixes opening and closing tags', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/component-usage': [
-        'error',
-        { substitutions: { button: 'DSButton' } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/component-usage': [
+          'error',
+          { substitutions: { button: 'DSButton' } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const code = 'const a = <button></button>;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 2);

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-system/deprecation flags deprecated token', async () => {
-  const linter = new Linter({
-    tokens: { deprecations: { old: { replacement: 'new' } } },
-    rules: { 'design-system/deprecation': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { deprecations: { old: { replacement: 'new' } } },
+      rules: { 'design-system/deprecation': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('const a = "old";', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('new'));
@@ -17,10 +21,13 @@ void test('design-system/deprecation flags deprecated token', async () => {
 });
 
 void test('design-system/deprecation ignores tokens in non-style jsx attributes', async () => {
-  const linter = new Linter({
-    tokens: { deprecations: { old: { replacement: 'new' } } },
-    rules: { 'design-system/deprecation': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { deprecations: { old: { replacement: 'new' } } },
+      rules: { 'design-system/deprecation': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <div aria-label="old" />;',
     'file.tsx',
@@ -29,9 +36,12 @@ void test('design-system/deprecation ignores tokens in non-style jsx attributes'
 });
 
 void test('design-system/deprecation warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/deprecation': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/deprecation': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.deprecations'));

--- a/tests/rules/duration.test.ts
+++ b/tests/rules/duration.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/duration reports invalid transition duration', async () => {
-  const linter = new Linter({
-    tokens: { durations: { fast: '200ms' } },
-    rules: { 'design-token/duration': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { durations: { fast: '200ms' } },
+      rules: { 'design-token/duration': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{transition: all 300ms ease;}',
     'file.css',
@@ -15,10 +19,13 @@ void test('design-token/duration reports invalid transition duration', async () 
 });
 
 void test('design-token/duration reports invalid animation duration', async () => {
-  const linter = new Linter({
-    tokens: { durations: { fast: '200ms' } },
-    rules: { 'design-token/duration': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { durations: { fast: '200ms' } },
+      rules: { 'design-token/duration': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{animation: fade 300ms linear;}',
     'file.css',
@@ -27,10 +34,13 @@ void test('design-token/duration reports invalid animation duration', async () =
 });
 
 void test('design-token/duration accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { durations: { fast: '200ms', slow: 400 } },
-    rules: { 'design-token/duration': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { durations: { fast: '200ms', slow: 400 } },
+      rules: { 'design-token/duration': 'error' },
+    },
+    new FileSource(),
+  );
   const css =
     '.a{transition: all 200ms ease;} .b{animation: fade 400ms linear;}';
   const res = await linter.lintText(css, 'file.css');
@@ -38,10 +48,13 @@ void test('design-token/duration accepts valid values', async () => {
 });
 
 void test('design-token/duration reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { durations: { fast: '200ms' } },
-    rules: { 'design-token/duration': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { durations: { fast: '200ms' } },
+      rules: { 'design-token/duration': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const d = <div style={{ animationDuration: 300 }} />;',
     'file.tsx',
@@ -50,19 +63,25 @@ void test('design-token/duration reports numeric literals', async () => {
 });
 
 void test('design-token/duration ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { durations: { fast: '200ms' } },
-    rules: { 'design-token/duration': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { durations: { fast: '200ms' } },
+      rules: { 'design-token/duration': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/duration warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/duration': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/duration': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('durations'));

--- a/tests/rules/font-family.test.ts
+++ b/tests/rules/font-family.test.ts
@@ -1,24 +1,31 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/font-family reports invalid font-family', async () => {
-  const linter = new Linter({
-    tokens: {
-      fontSizes: { base: 16 },
-      fonts: { sans: 'Inter' },
+  const linter = new Linter(
+    {
+      tokens: {
+        fontSizes: { base: 16 },
+        fonts: { sans: 'Inter' },
+      },
+      rules: { 'design-token/font-family': 'error' },
     },
-    rules: { 'design-token/font-family': 'error' },
-  });
+    new FileSource(),
+  );
   const css = `.a{\n  font-family:\n    'Inter',\n    Arial;\n}`;
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/font-family warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/font-family': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/font-family': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.css');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.fonts'));

--- a/tests/rules/font-size.test.ts
+++ b/tests/rules/font-size.test.ts
@@ -1,28 +1,35 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/font-size reports invalid font-size', async () => {
-  const linter = new Linter({
-    tokens: {
-      fontSizes: { base: 16 },
-      fonts: { sans: 'Inter' },
+  const linter = new Linter(
+    {
+      tokens: {
+        fontSizes: { base: 16 },
+        fonts: { sans: 'Inter' },
+      },
+      rules: { 'design-token/font-size': 'error' },
     },
-    rules: { 'design-token/font-size': 'error' },
-  });
+    new FileSource(),
+  );
   const css = '.a{font-size:20px;}';
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/font-size accepts unit-based font-sizes', async () => {
-  const linter = new Linter({
-    tokens: {
-      fontSizes: { base: '1rem', lg: '2rem' },
-      fonts: { sans: 'Inter' },
+  const linter = new Linter(
+    {
+      tokens: {
+        fontSizes: { base: '1rem', lg: '2rem' },
+        fonts: { sans: 'Inter' },
+      },
+      rules: { 'design-token/font-size': 'error' },
     },
-    rules: { 'design-token/font-size': 'error' },
-  });
+    new FileSource(),
+  );
   const valid = await linter.lintText(
     '.a{font-size:16px;} .b{font-size:1rem;}',
     'file.css',
@@ -33,9 +40,12 @@ void test('design-token/font-size accepts unit-based font-sizes', async () => {
 });
 
 void test('design-token/font-size warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/font-size': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/font-size': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.css');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.fontSizes'));

--- a/tests/rules/font-weight.test.ts
+++ b/tests/rules/font-weight.test.ts
@@ -1,31 +1,41 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/font-weight reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { fontWeights: { regular: 400 } },
-    rules: { 'design-token/font-weight': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { fontWeights: { regular: 400 } },
+      rules: { 'design-token/font-weight': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{font-weight:500;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/font-weight accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { fontWeights: { regular: 400, bold: '700' } },
-    rules: { 'design-token/font-weight': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { fontWeights: { regular: 400, bold: '700' } },
+      rules: { 'design-token/font-weight': 'error' },
+    },
+    new FileSource(),
+  );
   const css = '.a{font-weight:400;} .b{font-weight:700;}';
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/font-weight reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { fontWeights: { regular: 400 } },
-    rules: { 'design-token/font-weight': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { fontWeights: { regular: 400 } },
+      rules: { 'design-token/font-weight': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const w = <div style={{ fontWeight: 500 }} />;',
     'file.tsx',
@@ -34,19 +44,25 @@ void test('design-token/font-weight reports numeric literals', async () => {
 });
 
 void test('design-token/font-weight ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { fontWeights: { regular: 400 } },
-    rules: { 'design-token/font-weight': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { fontWeights: { regular: 400 } },
+      rules: { 'design-token/font-weight': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/font-weight warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/font-weight': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/font-weight': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.fontWeights'));

--- a/tests/rules/icon-usage.test.ts
+++ b/tests/rules/icon-usage.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/icon-usage reports raw svg', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/icon-usage': 'error' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/icon-usage': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'const a = <svg/>;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 1);
@@ -16,14 +20,17 @@ void test('design-system/icon-usage reports raw svg', async () => {
 });
 
 void test('design-system/icon-usage matches substitutions', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/icon-usage': [
-        'error',
-        { substitutions: { fooicon: 'Icon' } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/icon-usage': [
+          'error',
+          { substitutions: { fooicon: 'Icon' } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const code = 'const a = <FooIcon></FooIcon>;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 2);
@@ -33,9 +40,12 @@ void test('design-system/icon-usage matches substitutions', async () => {
 });
 
 void test('design-system/icon-usage fixes svg opening and closing tags', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/icon-usage': 'error' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/icon-usage': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'const a = <svg></svg>;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 2);

--- a/tests/rules/import-path.test.ts
+++ b/tests/rules/import-path.test.ts
@@ -1,16 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-system/import-path flags components from wrong package', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/import-path': [
-        'error',
-        { packages: ['@acme/design-system'], components: ['Button'] },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/import-path': [
+          'error',
+          { packages: ['@acme/design-system'], components: ['Button'] },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     "import { Button } from 'other';",
     'file.tsx',
@@ -19,14 +23,17 @@ void test('design-system/import-path flags components from wrong package', async
 });
 
 void test('design-system/import-path allows configured package', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/import-path': [
-        'error',
-        { packages: ['@acme/design-system'], components: ['Button'] },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/import-path': [
+          'error',
+          { packages: ['@acme/design-system'], components: ['Button'] },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     "import { Button } from '@acme/design-system';",
     'file.tsx',
@@ -35,27 +42,33 @@ void test('design-system/import-path allows configured package', async () => {
 });
 
 void test('design-system/import-path handles default imports', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/import-path': [
-        'error',
-        { packages: ['@acme/design-system'], components: ['Button'] },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/import-path': [
+          'error',
+          { packages: ['@acme/design-system'], components: ['Button'] },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText("import Button from 'other';", 'file.ts');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-system/import-path enforces package in Vue components', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/import-path': [
-        'error',
-        { packages: ['@acme/design-system'], components: ['Button'] },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/import-path': [
+          'error',
+          { packages: ['@acme/design-system'], components: ['Button'] },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     "<script setup>import { Button } from 'other';</script>",
     'file.vue',
@@ -64,14 +77,17 @@ void test('design-system/import-path enforces package in Vue components', async 
 });
 
 void test('design-system/import-path enforces package in Svelte components', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/import-path': [
-        'error',
-        { packages: ['@acme/design-system'], components: ['Button'] },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/import-path': [
+          'error',
+          { packages: ['@acme/design-system'], components: ['Button'] },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     "<script>import { Button } from 'other';</script>",
     'file.svelte',

--- a/tests/rules/letter-spacing.test.ts
+++ b/tests/rules/letter-spacing.test.ts
@@ -1,33 +1,43 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/letter-spacing reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { letterSpacings: { tight: '-0.05em' } },
-    rules: { 'design-token/letter-spacing': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { letterSpacings: { tight: '-0.05em' } },
+      rules: { 'design-token/letter-spacing': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{letter-spacing:2px;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/letter-spacing accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: {
-      letterSpacings: { tight: '-0.05em', none: 0 },
+  const linter = new Linter(
+    {
+      tokens: {
+        letterSpacings: { tight: '-0.05em', none: 0 },
+      },
+      rules: { 'design-token/letter-spacing': 'error' },
     },
-    rules: { 'design-token/letter-spacing': 'error' },
-  });
+    new FileSource(),
+  );
   const css = '.a{letter-spacing:-0.05em;} .b{letter-spacing:0;}';
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/letter-spacing reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { letterSpacings: { none: 0 } },
-    rules: { 'design-token/letter-spacing': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { letterSpacings: { none: 0 } },
+      rules: { 'design-token/letter-spacing': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const ls = <div style={{ letterSpacing: 2 }} />;',
     'file.tsx',
@@ -36,19 +46,25 @@ void test('design-token/letter-spacing reports numeric literals', async () => {
 });
 
 void test('design-token/letter-spacing ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { letterSpacings: { none: 0 } },
-    rules: { 'design-token/letter-spacing': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { letterSpacings: { none: 0 } },
+      rules: { 'design-token/letter-spacing': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/letter-spacing warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/letter-spacing': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/letter-spacing': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.letterSpacings'));

--- a/tests/rules/line-height.test.ts
+++ b/tests/rules/line-height.test.ts
@@ -1,33 +1,43 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/line-height reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { lineHeights: { base: 1.5 } },
-    rules: { 'design-token/line-height': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { lineHeights: { base: 1.5 } },
+      rules: { 'design-token/line-height': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{line-height:2;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/line-height accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: {
-      lineHeights: { base: 1.5, tight: '20px' },
+  const linter = new Linter(
+    {
+      tokens: {
+        lineHeights: { base: 1.5, tight: '20px' },
+      },
+      rules: { 'design-token/line-height': 'error' },
     },
-    rules: { 'design-token/line-height': 'error' },
-  });
+    new FileSource(),
+  );
   const css = '.a{line-height:1.5;} .b{line-height:20px;}';
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/line-height reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { lineHeights: { base: 1.5 } },
-    rules: { 'design-token/line-height': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { lineHeights: { base: 1.5 } },
+      rules: { 'design-token/line-height': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const lh = <div style={{ lineHeight: 2 }} />;',
     'file.tsx',
@@ -36,10 +46,13 @@ void test('design-token/line-height reports numeric literals', async () => {
 });
 
 void test('design-token/line-height reports template literal', async () => {
-  const linter = new Linter({
-    tokens: { lineHeights: { base: 1.5 } },
-    rules: { 'design-token/line-height': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { lineHeights: { base: 1.5 } },
+      rules: { 'design-token/line-height': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const lh = <div style={{ lineHeight: `2` }} />;',
     'file.tsx',
@@ -48,10 +61,13 @@ void test('design-token/line-height reports template literal', async () => {
 });
 
 void test('design-token/line-height reports template expression', async () => {
-  const linter = new Linter({
-    tokens: { lineHeights: { base: 1.5 } },
-    rules: { 'design-token/line-height': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { lineHeights: { base: 1.5 } },
+      rules: { 'design-token/line-height': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const lh = <div style={{ lineHeight: `2${"px"}` }} />;',
     'file.tsx',
@@ -60,10 +76,13 @@ void test('design-token/line-height reports template expression', async () => {
 });
 
 void test('design-token/line-height reports prefix unary', async () => {
-  const linter = new Linter({
-    tokens: { lineHeights: { base: 1.5 } },
-    rules: { 'design-token/line-height': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { lineHeights: { base: 1.5 } },
+      rules: { 'design-token/line-height': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const lh = <div style={{ lineHeight: -2 }} />;',
     'file.tsx',
@@ -72,19 +91,25 @@ void test('design-token/line-height reports prefix unary', async () => {
 });
 
 void test('design-token/line-height ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { lineHeights: { base: 1.5 } },
-    rules: { 'design-token/line-height': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { lineHeights: { base: 1.5 } },
+      rules: { 'design-token/line-height': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/line-height warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/line-height': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/line-height': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.lineHeights'));

--- a/tests/rules/no-inline-styles.test.ts
+++ b/tests/rules/no-inline-styles.test.ts
@@ -1,11 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-system/no-inline-styles flags style attribute on components', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/no-inline-styles': 'error' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/no-inline-styles': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <Button style={{ color: "red" }} />;',
     'file.tsx',
@@ -14,9 +18,12 @@ void test('design-system/no-inline-styles flags style attribute on components', 
 });
 
 void test('design-system/no-inline-styles flags className attribute on components', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/no-inline-styles': 'error' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/no-inline-styles': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <Button className="foo" />;',
     'file.tsx',
@@ -25,11 +32,14 @@ void test('design-system/no-inline-styles flags className attribute on component
 });
 
 void test('design-system/no-inline-styles ignores className when configured', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/no-inline-styles': ['error', { ignoreClassName: true }],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/no-inline-styles': ['error', { ignoreClassName: true }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <Button className="foo" />;',
     'file.tsx',
@@ -38,9 +48,12 @@ void test('design-system/no-inline-styles ignores className when configured', as
 });
 
 void test('design-system/no-inline-styles flags inline styles in Vue templates', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/no-inline-styles': 'error' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/no-inline-styles': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '<template><Button style="color:red" /></template>',
     'file.vue',
@@ -49,9 +62,12 @@ void test('design-system/no-inline-styles flags inline styles in Vue templates',
 });
 
 void test('design-system/no-inline-styles flags inline styles in Svelte components', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/no-inline-styles': 'error' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/no-inline-styles': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '<Button style="color:red" />',
     'file.svelte',
@@ -60,9 +76,12 @@ void test('design-system/no-inline-styles flags inline styles in Svelte componen
 });
 
 void test('design-system/no-inline-styles flags inline styles on custom elements', async () => {
-  const linter = new Linter({
-    rules: { 'design-system/no-inline-styles': 'error' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-system/no-inline-styles': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <my-button style="color:red"></my-button>;',
     'file.tsx',

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 async function tempFile(content: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'tmp-'));
@@ -13,10 +14,13 @@ async function tempFile(content: string): Promise<string> {
 
 void test('design-system/no-unused-tokens reports unused tokens', async () => {
   const file = await tempFile('const color = "#000000";');
-  const linter = new Linter({
-    tokens: { colors: { primary: '#000000', unused: '#123456' } },
-    rules: { 'design-system/no-unused-tokens': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#000000', unused: '#123456' } },
+      rules: { 'design-system/no-unused-tokens': 'warn' },
+    },
+    new FileSource(),
+  );
   const { results } = await linter.lintFiles([file]);
   const msg = results
     .flatMap((r) => r.messages)
@@ -28,10 +32,13 @@ void test('design-system/no-unused-tokens reports unused tokens', async () => {
 
 void test('design-system/no-unused-tokens passes when tokens used', async () => {
   const file = await tempFile('const color = "#000000";');
-  const linter = new Linter({
-    tokens: { colors: { primary: '#000000' } },
-    rules: { 'design-system/no-unused-tokens': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#000000' } },
+      rules: { 'design-system/no-unused-tokens': 'error' },
+    },
+    new FileSource(),
+  );
   const { results } = await linter.lintFiles([file]);
   const has = results.some((r) =>
     r.messages.some((m) => m.ruleId === 'design-system/no-unused-tokens'),
@@ -41,12 +48,15 @@ void test('design-system/no-unused-tokens passes when tokens used', async () => 
 
 void test('design-system/no-unused-tokens can ignore tokens', async () => {
   const file = await tempFile('const color = "#000000";');
-  const linter = new Linter({
-    tokens: { colors: { primary: '#000000', unused: '#123456' } },
-    rules: {
-      'design-system/no-unused-tokens': ['warn', { ignore: ['#123456'] }],
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#000000', unused: '#123456' } },
+      rules: {
+        'design-system/no-unused-tokens': ['warn', { ignore: ['#123456'] }],
+      },
     },
-  });
+    new FileSource(),
+  );
   const { results } = await linter.lintFiles([file]);
   const has = results.some((r) =>
     r.messages.some((m) => m.ruleId === 'design-system/no-unused-tokens'),
@@ -56,10 +66,13 @@ void test('design-system/no-unused-tokens can ignore tokens', async () => {
 
 void test('design-system/no-unused-tokens matches hex case-insensitively', async () => {
   const file = await tempFile('const color = "#ABCDEF";');
-  const linter = new Linter({
-    tokens: { colors: { primary: '#abcdef' } },
-    rules: { 'design-system/no-unused-tokens': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#abcdef' } },
+      rules: { 'design-system/no-unused-tokens': 'warn' },
+    },
+    new FileSource(),
+  );
   const { results } = await linter.lintFiles([file]);
   const has = results.some((r) =>
     r.messages.some((m) => m.ruleId === 'design-system/no-unused-tokens'),

--- a/tests/rules/opacity.test.ts
+++ b/tests/rules/opacity.test.ts
@@ -1,39 +1,52 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/opacity reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { opacity: { low: 0.2 } },
-    rules: { 'design-token/opacity': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { opacity: { low: 0.2 } },
+      rules: { 'design-token/opacity': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{opacity:0.5;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/opacity reports zero value', async () => {
-  const linter = new Linter({
-    tokens: { opacity: { low: 0.2 } },
-    rules: { 'design-token/opacity': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { opacity: { low: 0.2 } },
+      rules: { 'design-token/opacity': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{opacity:0;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/opacity accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { opacity: { low: 0.2 } },
-    rules: { 'design-token/opacity': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { opacity: { low: 0.2 } },
+      rules: { 'design-token/opacity': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{opacity:0.2;}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/opacity reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { opacity: { low: 0.2 } },
-    rules: { 'design-token/opacity': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { opacity: { low: 0.2 } },
+      rules: { 'design-token/opacity': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const o = <div style={{ opacity: 0.5 }} />;',
     'file.tsx',
@@ -42,19 +55,25 @@ void test('design-token/opacity reports numeric literals', async () => {
 });
 
 void test('design-token/opacity ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { opacity: { low: 0.2 } },
-    rules: { 'design-token/opacity': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { opacity: { low: 0.2 } },
+      rules: { 'design-token/opacity': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/opacity warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/opacity': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/opacity': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('opacity'));

--- a/tests/rules/outline.test.ts
+++ b/tests/rules/outline.test.ts
@@ -1,29 +1,39 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/outline reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { outlines: { focus: '2px solid #000' } },
-    rules: { 'design-token/outline': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { outlines: { focus: '2px solid #000' } },
+      rules: { 'design-token/outline': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{outline:3px solid #000;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/outline accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { outlines: { focus: '2px solid #000' } },
-    rules: { 'design-token/outline': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { outlines: { focus: '2px solid #000' } },
+      rules: { 'design-token/outline': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{outline:2px solid #000;}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/outline warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/outline': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/outline': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('outlines'));

--- a/tests/rules/parse-error.test.ts
+++ b/tests/rules/parse-error.test.ts
@@ -1,9 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('reports CSS parse errors', async () => {
-  const linter = new Linter({});
+  const linter = new Linter({}, new FileSource());
   const res = await linter.lintText('.a { color: red;', 'bad.css');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].severity, 'error');

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/spacing enforces multiples', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const s = <div style={{ margin: 5 }} />;',
     'file.tsx',
@@ -15,10 +19,13 @@ void test('design-token/spacing enforces multiples', async () => {
 });
 
 void test('design-token/spacing reports template literal', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const s = <div style={{ margin: `5` }} />;',
     'file.tsx',
@@ -27,10 +34,13 @@ void test('design-token/spacing reports template literal', async () => {
 });
 
 void test('design-token/spacing reports template expression', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const s = <div style={{ margin: `5${"px"}` }} />;',
     'file.tsx',
@@ -39,10 +49,13 @@ void test('design-token/spacing reports template expression', async () => {
 });
 
 void test('design-token/spacing reports prefix unary', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const s = <div style={{ margin: -5 }} />;',
     'file.tsx',
@@ -51,57 +64,75 @@ void test('design-token/spacing reports prefix unary', async () => {
 });
 
 void test('design-token/spacing handles multi-line CSS', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const css = `.a{\n  margin:\n    0.5rem\n    8px\n    10vw;\n}`;
   const res = await linter.lintText(css, 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/spacing ignores unsupported units', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{margin:5.5vw 10%;}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/spacing ignores calc() values', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{margin:calc(100% - 5px);}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/spacing ignores var() fallbacks', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{margin:var(--m, 5px);}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/spacing ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/spacing ignores nested functions', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{margin:calc(var(--m, 5px) + 4px);}',
     'file.css',
@@ -110,10 +141,13 @@ void test('design-token/spacing ignores nested functions', async () => {
 });
 
 void test('design-token/spacing ignores nested var() fallbacks', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4 }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4 }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{margin:var(--m, var(--n, 5px));}',
     'file.css',
@@ -122,18 +156,24 @@ void test('design-token/spacing ignores nested var() fallbacks', async () => {
 });
 
 void test('design-token/spacing supports custom units', async () => {
-  const linter = new Linter({
-    tokens: { spacing: { sm: 4, md: 8 } },
-    rules: { 'design-token/spacing': ['error', { base: 4, units: ['vw'] }] },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: { sm: 4, md: 8 } },
+      rules: { 'design-token/spacing': ['error', { base: 4, units: ['vw'] }] },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{margin:5vw;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/spacing warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/spacing': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/spacing': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('tokens.spacing'));

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 const config = {
   tokens: {
@@ -27,14 +28,14 @@ function assertIds(messages: { ruleId: string }[]) {
 }
 
 void test('reports raw tokens in .scss files', async () => {
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const res = await linter.lintText(cssSample, 'file.scss');
   assert.equal(res.messages.length, 3);
   assertIds(res.messages);
 });
 
 void test('reports raw tokens in Vue <style lang="scss">', async () => {
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const res = await linter.lintText(
     `<template><div/></template><style lang="scss">${cssSample}</style>`,
     'Comp.vue',
@@ -44,7 +45,7 @@ void test('reports raw tokens in Vue <style lang="scss">', async () => {
 });
 
 void test('reports raw tokens in Svelte <style lang="scss">', async () => {
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const res = await linter.lintText(
     `<div></div><style lang="scss">${cssSample}</style>`,
     'Comp.svelte',
@@ -54,7 +55,7 @@ void test('reports raw tokens in Svelte <style lang="scss">', async () => {
 });
 
 void test('reports raw tokens in string style attributes', async () => {
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const res = await linter.lintText(
     `const C = () => <div style="color: #fff; margin: 5px; opacity: 0.5"></div>;`,
     'file.tsx',
@@ -64,10 +65,13 @@ void test('reports raw tokens in string style attributes', async () => {
 });
 
 void test('reports raw tokens once for single style property', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#000000' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#000000' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     `const C = () => <div style="color: #fff"></div>;`,
     'file.tsx',

--- a/tests/rules/token-colors.test.ts
+++ b/tests/rules/token-colors.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/colors reports disallowed hwb', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "hwb(0, 0%, 0%)" }} />;',
     'file.tsx',
@@ -15,10 +19,13 @@ void test('design-token/colors reports disallowed hwb', async () => {
 });
 
 void test('design-token/colors reports disallowed lab', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "lab(0% 0 0)" }} />;',
     'file.tsx',
@@ -27,10 +34,13 @@ void test('design-token/colors reports disallowed lab', async () => {
 });
 
 void test('design-token/colors reports disallowed lch', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "lch(0% 0 0)" }} />;',
     'file.tsx',
@@ -39,10 +49,13 @@ void test('design-token/colors reports disallowed lch', async () => {
 });
 
 void test('design-token/colors reports disallowed color()', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: "color(display-p3 1 0 0)" }} />;',
     'file.tsx',
@@ -51,10 +64,13 @@ void test('design-token/colors reports disallowed color()', async () => {
 });
 
 void test('design-token/colors reports template literal', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: `hwb(0, 0%, 0%)` }} />;',
     'file.tsx',
@@ -63,10 +79,13 @@ void test('design-token/colors reports template literal', async () => {
 });
 
 void test('design-token/colors reports template expression', async () => {
-  const linter = new Linter({
-    tokens: { colors: { primary: '#ffffff' } },
-    rules: { 'design-token/colors': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const c = <div style={{ color: `hwb(0, 0%, 0%) ${foo}` }} />;',
     'file.tsx',

--- a/tests/rules/token-suggestion.test.ts
+++ b/tests/rules/token-suggestion.test.ts
@@ -1,12 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('suggests closest token name', async () => {
-  const linter = new Linter({
-    tokens: { spacing: ['--space-scale-100', '--space-scale-200'] },
-    rules: { 'design-token/spacing': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { spacing: ['--space-scale-100', '--space-scale-200'] },
+      rules: { 'design-token/spacing': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'a{margin:var(--space-scale-10o);}',
     'a.css',

--- a/tests/rules/variant-prop.test.ts
+++ b/tests/rules/variant-prop.test.ts
@@ -1,16 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-system/variant-prop flags invalid variant', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { components: { Button: ['primary', 'secondary'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { components: { Button: ['primary', 'secondary'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <Button variant="danger" />;',
     'file.tsx',
@@ -20,14 +24,17 @@ void test('design-system/variant-prop flags invalid variant', async () => {
 });
 
 void test('design-system/variant-prop allows valid variant', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { components: { Button: ['primary', 'secondary'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { components: { Button: ['primary', 'secondary'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <Button variant="primary" />;',
     'file.tsx',
@@ -36,14 +43,17 @@ void test('design-system/variant-prop allows valid variant', async () => {
 });
 
 void test('design-system/variant-prop flags string literals in expressions', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { components: { Button: ['primary', 'secondary'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { components: { Button: ['primary', 'secondary'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     "const a = <Button variant={'danger'} />;",
     'file.tsx',
@@ -53,14 +63,17 @@ void test('design-system/variant-prop flags string literals in expressions', asy
 });
 
 void test('design-system/variant-prop ignores dynamic expressions', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { components: { Button: ['primary', 'secondary'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { components: { Button: ['primary', 'secondary'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <Button variant={foo} />;',
     'file.tsx',
@@ -69,14 +82,17 @@ void test('design-system/variant-prop ignores dynamic expressions', async () => 
 });
 
 void test('design-system/variant-prop supports custom prop names', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { prop: 'tone', components: { Alert: ['info', 'error'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { prop: 'tone', components: { Alert: ['info', 'error'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <Alert tone="warn" />;',
     'file.tsx',
@@ -86,14 +102,17 @@ void test('design-system/variant-prop supports custom prop names', async () => {
 });
 
 void test('design-system/variant-prop flags invalid variant in Vue components', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { components: { Button: ['primary', 'secondary'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { components: { Button: ['primary', 'secondary'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '<template><Button variant="danger" /></template>',
     'file.vue',
@@ -102,14 +121,17 @@ void test('design-system/variant-prop flags invalid variant in Vue components', 
 });
 
 void test('design-system/variant-prop flags invalid variant in Svelte components', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { components: { Button: ['primary', 'secondary'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { components: { Button: ['primary', 'secondary'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '<Button variant="danger" />',
     'file.svelte',
@@ -118,14 +140,17 @@ void test('design-system/variant-prop flags invalid variant in Svelte components
 });
 
 void test('design-system/variant-prop flags invalid variant on custom elements', async () => {
-  const linter = new Linter({
-    rules: {
-      'design-system/variant-prop': [
-        'error',
-        { components: { 'my-button': ['primary', 'secondary'] } },
-      ],
+  const linter = new Linter(
+    {
+      rules: {
+        'design-system/variant-prop': [
+          'error',
+          { components: { 'my-button': ['primary', 'secondary'] } },
+        ],
+      },
     },
-  });
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const a = <my-button variant="danger" />;',
     'file.tsx',

--- a/tests/rules/z-index.test.ts
+++ b/tests/rules/z-index.test.ts
@@ -1,30 +1,40 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/core/file-source.ts';
 
 void test('design-token/z-index reports invalid value', async () => {
-  const linter = new Linter({
-    tokens: { zIndex: { modal: 100 } },
-    rules: { 'design-token/z-index': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { zIndex: { modal: 100 } },
+      rules: { 'design-token/z-index': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{z-index:5;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 
 void test('design-token/z-index accepts valid values', async () => {
-  const linter = new Linter({
-    tokens: { zIndex: { modal: 100 } },
-    rules: { 'design-token/z-index': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { zIndex: { modal: 100 } },
+      rules: { 'design-token/z-index': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('.a{z-index:100;}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/z-index reports numeric literals', async () => {
-  const linter = new Linter({
-    tokens: { zIndex: { modal: 100 } },
-    rules: { 'design-token/z-index': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { zIndex: { modal: 100 } },
+      rules: { 'design-token/z-index': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     'const z = <div style={{ zIndex: 5 }} />;',
     'file.tsx',
@@ -33,19 +43,25 @@ void test('design-token/z-index reports numeric literals', async () => {
 });
 
 void test('design-token/z-index ignores numbers in JSX props', async () => {
-  const linter = new Linter({
-    tokens: { zIndex: { modal: 100 } },
-    rules: { 'design-token/z-index': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { zIndex: { modal: 100 } },
+      rules: { 'design-token/z-index': 'error' },
+    },
+    new FileSource(),
+  );
   const code = 'export const C = () => <Component headingLevel={2} />;';
   const res = await linter.lintText(code, 'file.tsx');
   assert.equal(res.messages.length, 0);
 });
 
 void test('design-token/z-index warns when tokens missing', async () => {
-  const linter = new Linter({
-    rules: { 'design-token/z-index': 'warn' },
-  });
+  const linter = new Linter(
+    {
+      rules: { 'design-token/z-index': 'warn' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.ok(res.messages[0].message.includes('zIndex'));

--- a/tests/svelte-style-bindings.test.ts
+++ b/tests/svelte-style-bindings.test.ts
@@ -2,13 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');
 
 async function lint(file: string) {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   return linter.lintFile(path.join(fixtureDir, 'src', file), false);
 }
 

--- a/tests/tagged-template.test.ts
+++ b/tests/tagged-template.test.ts
@@ -2,13 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'tagged-template');
 
 void test('reports CSS in tagged template literals', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const file = path.join(fixtureDir, 'src', 'styled.ts');
   const {
     results: [res],

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -1,19 +1,23 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('getTokenCompletions returns token names', () => {
-  const linter = new Linter({
-    tokens: {
-      spacing: ['--space-scale-100'],
-      colors: {
-        primary: 'var(--color-primary)',
-        secondary: '#fff',
-        accent: 'var(--color-accent, #000)',
-        spaced: 'var(  --color-spaced  )',
+  const linter = new Linter(
+    {
+      tokens: {
+        spacing: ['--space-scale-100'],
+        colors: {
+          primary: 'var(--color-primary)',
+          secondary: '#fff',
+          accent: 'var(--color-accent, #000)',
+          spaced: 'var(  --color-spaced  )',
+        },
       },
     },
-  });
+    new FileSource(),
+  );
   const comps = linter.getTokenCompletions();
   assert.deepEqual(comps.spacing, ['--space-scale-100']);
   assert.deepEqual(comps.colors, [

--- a/tests/token-loader.test.ts
+++ b/tests/token-loader.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { normalizeTokens } from '../src/core/token-loader.ts';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 void test('normalizeTokens wraps values with var when enabled', () => {
   const tokens = { colors: { primary: '--color-primary' } };
@@ -22,11 +23,14 @@ void test('normalizeTokens merges tokens across themes', () => {
 });
 
 void test('Linter applies wrapTokensWithVar option', async () => {
-  const linter = new Linter({
-    tokens: { fonts: { sans: '--font-sans' } },
-    wrapTokensWithVar: true,
-    rules: { 'design-token/font-family': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { fonts: { sans: '--font-sans' } },
+      wrapTokensWithVar: true,
+      rules: { 'design-token/font-family': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{font-family:var(--font-sans);}',
     'file.css',
@@ -35,11 +39,14 @@ void test('Linter applies wrapTokensWithVar option', async () => {
 });
 
 void test('Linter reports unknown CSS variable with wrapTokensWithVar', async () => {
-  const linter = new Linter({
-    tokens: { fonts: { sans: '--font-sans' } },
-    wrapTokensWithVar: true,
-    rules: { 'design-token/font-family': 'error' },
-  });
+  const linter = new Linter(
+    {
+      tokens: { fonts: { sans: '--font-sans' } },
+      wrapTokensWithVar: true,
+      rules: { 'design-token/font-family': 'error' },
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText(
     '.a{font-family:var(--other);}',
     'file.css',
@@ -48,13 +55,16 @@ void test('Linter reports unknown CSS variable with wrapTokensWithVar', async ()
 });
 
 void test('Rule theme filtering validates selected themes', async () => {
-  const linter = new Linter({
-    tokens: {
-      light: { colors: { primary: '#fff' } },
-      dark: { colors: { primary: '#000' } },
+  const linter = new Linter(
+    {
+      tokens: {
+        light: { colors: { primary: '#fff' } },
+        dark: { colors: { primary: '#000' } },
+      },
+      rules: { 'design-token/colors': ['error', { themes: ['dark'] }] },
     },
-    rules: { 'design-token/colors': ['error', { themes: ['dark'] }] },
-  });
+    new FileSource(),
+  );
   const ok = await linter.lintText('.a{color:#000}', 'file.css');
   assert.equal(ok.messages.length, 0);
   const bad = await linter.lintText('.a{color:#fff}', 'file.css');
@@ -62,13 +72,16 @@ void test('Rule theme filtering validates selected themes', async () => {
 });
 
 void test('Rules validate all themes by default', async () => {
-  const linter = new Linter({
-    tokens: {
-      light: { colors: { primary: '#fff' } },
-      dark: { colors: { primary: '#000' } },
+  const linter = new Linter(
+    {
+      tokens: {
+        light: { colors: { primary: '#fff' } },
+        dark: { colors: { primary: '#000' } },
+      },
+      rules: { 'design-token/colors': 'error' },
     },
-    rules: { 'design-token/colors': 'error' },
-  });
+    new FileSource(),
+  );
   const res1 = await linter.lintText('.a{color:#000}', 'file.css');
   assert.equal(res1.messages.length, 0);
   const res2 = await linter.lintText('.a{color:#fff}', 'file.css');

--- a/tests/token-patterns.test.ts
+++ b/tests/token-patterns.test.ts
@@ -1,29 +1,39 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 
 const rule = { 'design-token/colors': 'error' };
 
 void test('accepts CSS variables matching string patterns', async () => {
-  const linter = new Linter({
-    tokens: { colors: ['--colour-*'] },
-    rules: rule,
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: ['--colour-*'] },
+      rules: rule,
+    },
+    new FileSource(),
+  );
   const res = await linter.lintText('a{color:var(--colour-primary);}', 'x.css');
   assert.equal(res.messages.length, 0);
 });
 
 void test('reports variables not matching patterns', async () => {
-  const linter = new Linter({
-    tokens: { colors: ['--colour-*'] },
-    rules: rule,
-  });
+  const linter = new Linter(
+    {
+      tokens: { colors: ['--colour-*'] },
+      rules: rule,
+    },
+    new FileSource(),
+  );
   const res2 = await linter.lintText('a{color:var(--other);}', 'x.css');
   assert.equal(res2.messages[0]?.message, 'Unexpected color var(--other)');
 });
 
 void test('supports regex token patterns', async () => {
-  const linter = new Linter({ tokens: { colors: [/^--brand-/] }, rules: rule });
+  const linter = new Linter(
+    { tokens: { colors: [/^--brand-/] }, rules: rule },
+    new FileSource(),
+  );
   const res3 = await linter.lintText('a{color:var(--brand-primary);}', 'x.css');
   assert.equal(res3.messages.length, 0);
 });

--- a/tests/vue-style-bindings.test.ts
+++ b/tests/vue-style-bindings.test.ts
@@ -2,13 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
+import { FileSource } from '../src/core/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'vue');
 
 async function lint(file: string) {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config);
+  const linter = new Linter(config, new FileSource());
   const {
     results: [res],
   } = await linter.lintFiles([path.join(fixtureDir, 'src', file)]);


### PR DESCRIPTION
## Summary
- introduce DocumentSource interface for resolving lint targets
- implement FileSource and inject into Runner and Linter
- update docs and tests to use FileSource

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be21b311908328922cb665a0abd49e