### PR TITLE
feat(core): add metadata to rule context

### DIFF
--- a/.changeset/add-rule-context-metadata.md
+++ b/.changeset/add-rule-context-metadata.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+feat: add optional metadata field to rule context

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ Executes linting tasks with concurrency control.
   - `options` – object containing:
     - `config: Config`
     - `tokenTracker: TokenTracker`
-    - `lintText: (text: string, filePath: string) => Promise<LintResult>`
+    - `lintText: (text: string, filePath: string, metadata?: Record<string, unknown>) => Promise<LintResult>`
     - `source: DocumentSource`
 
 #### `run(targets, fix?, cache?, additionalIgnorePaths?, cacheLocation?)`
@@ -171,6 +171,8 @@ import type {
 
 ### Custom rule example
 
+Rules receive a `RuleContext` with available design tokens, configuration options, the file path, and optional `metadata` supplied when linting.
+
 ```ts
 import type { RuleModule } from '@lapidist/design-lint';
 
@@ -178,6 +180,7 @@ export const noFooRule: RuleModule = {
   name: 'no-foo',
   meta: { description: 'disallow the value "foo"', recommended: 'warn' },
   create(ctx) {
+    // ctx.metadata contains optional information passed to lintText
     return {
       Declaration(node) {
         if (node.value === 'foo') {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -87,7 +87,12 @@ void test('reports raw colors and px units', async () => {
       'acme/no-px': 'warn'
     }
   }, new FileSource());
-  const res = await linter.lintText('h1 { color: #fff; margin: 4px; }', 'file.css');
+  // Optional metadata can be provided as the third argument
+  const res = await linter.lintText(
+    'h1 { color: #fff; margin: 4px; }',
+    'file.css',
+    { from: 'test' }
+  );
   assert.equal(res.messages.length, 2);
 });
 ```

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -10,7 +10,11 @@ export class CacheManager {
 
   async processFile(
     filePath: string,
-    lintFn: (text: string, filePath: string) => Promise<LintResult>,
+    lintFn: (
+      text: string,
+      filePath: string,
+      metadata?: Record<string, unknown>,
+    ) => Promise<LintResult>,
   ): Promise<LintResult> {
     try {
       const statResult = await stat(filePath);

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -124,6 +124,7 @@ export class Linter {
   private async lintText(
     text: string,
     filePath = 'unknown',
+    metadata?: Record<string, unknown>,
   ): Promise<LintResult> {
     await this.ruleRegistry.load();
     const enabled = this.ruleRegistry.getEnabledRules();
@@ -145,6 +146,7 @@ export class Linter {
         filePath,
         tokens,
         options,
+        metadata,
         report: (m) => messages.push({ ...m, severity, ruleId: rule.name }),
       };
       return rule.create(ctx);

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -10,14 +10,22 @@ import { TokenTracker } from './token-tracker.js';
 export interface RunnerOptions {
   config: Config;
   tokenTracker: TokenTracker;
-  lintText: (text: string, filePath: string) => Promise<LintResult>;
+  lintText: (
+    text: string,
+    filePath: string,
+    metadata?: Record<string, unknown>,
+  ) => Promise<LintResult>;
   source: DocumentSource;
 }
 
 export class Runner {
   private config: Config;
   private tokenTracker: TokenTracker;
-  private lintText: (text: string, filePath: string) => Promise<LintResult>;
+  private lintText: (
+    text: string,
+    filePath: string,
+    metadata?: Record<string, unknown>,
+  ) => Promise<LintResult>;
   private source: DocumentSource;
 
   constructor(options: RunnerOptions) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -61,6 +61,7 @@ export interface RuleContext<TOptions = unknown> {
   report: (msg: Omit<LintMessage, 'ruleId' | 'severity'>) => void;
   tokens: DesignTokens;
   options?: TOptions;
+  metadata?: Record<string, unknown>;
   filePath: string;
 }
 


### PR DESCRIPTION
## Summary
- allow rules to access optional `metadata` via `RuleContext`
- propagate metadata through linter and runner
- document metadata usage for rule authors and plugin developers

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68be251afc38832884d5c92a22fb3c32