### PR TITLE
build: integrate turborepo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "markdownlint-cli": "0.45.0",
         "prettier": "3.6.2",
         "tsx": "4.20.5",
+        "turbo": "^2.5.6",
         "vitepress": "1.6.4"
       },
       "engines": {
@@ -7437,6 +7438,108 @@
         "@esbuild/win32-ia32": "0.25.9",
         "@esbuild/win32-x64": "0.25.9"
       }
+    },
+    "node_modules/turbo": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.6.tgz",
+      "integrity": "sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "2.5.6",
+        "turbo-darwin-arm64": "2.5.6",
+        "turbo-linux-64": "2.5.6",
+        "turbo-linux-arm64": "2.5.6",
+        "turbo-windows-64": "2.5.6",
+        "turbo-windows-arm64": "2.5.6"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.6.tgz",
+      "integrity": "sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-LyiG+rD7JhMfYwLqB6k3LZQtYn8CQQUePbpA8mF/hMLPAekXdJo1g0bUPw8RZLwQXUIU/3BU7tXENvhSGz5DPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.6.tgz",
+      "integrity": "sha512-GOcUTT0xiT/pSnHL4YD6Yr3HreUhU8pUcGqcI2ksIF9b2/r/kRHwGFcsHgpG3+vtZF/kwsP0MV8FTlTObxsYIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.6.tgz",
+      "integrity": "sha512-10Tm15bruJEA3m0V7iZcnQBpObGBcOgUcO+sY7/2vk1bweW34LMhkWi8svjV9iDF68+KJDThnYDlYE/bc7/zzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.6.tgz",
+      "integrity": "sha512-FyRsVpgaj76It0ludwZsNN40ytHN+17E4PFJyeliBEbxrGTc5BexlXVpufB7XlAaoaZVxbS6KT8RofLfDRyEPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.6.tgz",
+      "integrity": "sha512-j/tWu8cMeQ7HPpKri6jvKtyXg9K1gRyhdK4tKrrchH8GNHscPX/F71zax58yYtLRWTiK04zNzPcUJuoS0+v/+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "packages/figma-connector"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.base.json --outDir dist",
+    "build": "turbo run build",
     "postbuild": "node scripts/postbuild.js",
-    "lint": "eslint 'packages/*/src/**/*.ts' 'tests/**/*.ts'",
+    "lint": "turbo run lint",
     "format": "prettier --write 'packages/*/src/**/*.ts' 'tests/**/*.ts'",
-    "format:check": "prettier --check 'packages/*/src/**/*.ts' 'tests/**/*.ts'",
-    "test": "tsx --test tests/**/*.test.ts",
+    "format:check": "turbo run format:check",
+    "test": "turbo run test",
     "test:coverage": "c8 --reporter=lcov --reporter=text --reporter=json-summary tsx --test tests/**/*.test.ts",
     "changeset": "changeset",
     "release": "npm run build && changeset publish",
@@ -57,6 +57,7 @@
   },
   "homepage": "https://design-lint.lapidist.net",
   "license": "MIT",
+  "packageManager": "npm@11.4.2",
   "dependencies": {
     "@vue/compiler-sfc": "3.5.21",
     "chalk": "5.6.0",
@@ -69,13 +70,13 @@
     "flat-cache": "6.1.13",
     "globby": "14.1.0",
     "ignore": "7.0.5",
+    "leven": "4.0.0",
     "p-limit": "7.1.1",
     "picomatch": "4.0.3",
     "postcss": "8.5.6",
     "postcss-less": "6.0.0",
     "postcss-scss": "4.0.9",
     "postcss-value-parser": "4.2.0",
-    "leven": "4.0.0",
     "svelte": "5.38.7",
     "tempy": "3.1.0",
     "typescript": "5.9.2",
@@ -96,6 +97,7 @@
     "markdownlint-cli": "0.45.0",
     "prettier": "3.6.2",
     "tsx": "4.20.5",
+    "turbo": "^2.5.6",
     "vitepress": "1.6.4"
   },
   "c8": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,8 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json && cp dist/index.js dist/cli.js",
+    "lint": "eslint 'src/**/*.ts'",
+    "format:check": "prettier --check 'src/**/*.ts'",
     "test": "tsx --test ../../tests/**/*.test.ts"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b tsconfig.json && cp dist/index.js dist/index.cjs",
+    "lint": "eslint 'src/**/*.ts'",
+    "format:check": "prettier --check 'src/**/*.ts'",
     "test": "tsx --test ../../tests/**/*.test.ts"
   },
   "dependencies": {

--- a/packages/figma-connector/package.json
+++ b/packages/figma-connector/package.json
@@ -1,5 +1,11 @@
 {
   "name": "@lapidist/design-lint-figma-connector",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "build": "echo 'no build'",
+    "lint": "echo 'no lint'",
+    "test": "echo 'no test'",
+    "format:check": "echo 'no format'"
+  }
 }

--- a/packages/figma-plugin/package.json
+++ b/packages/figma-plugin/package.json
@@ -1,5 +1,11 @@
 {
   "name": "@lapidist/design-lint-figma-plugin",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  "scripts": {
+    "build": "echo 'no build'",
+    "lint": "echo 'no lint'",
+    "test": "echo 'no test'",
+    "format:check": "echo 'no format'"
+  }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "lint": "eslint 'src/**/*.ts'",
+    "format:check": "prettier --check 'src/**/*.ts'",
     "test": "tsx --test ../../tests/**/*.test.ts"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "build": { "outputs": ["dist/**"] },
+    "lint": {},
+    "test": { "dependsOn": ["build"] },
+    "format:check": {}
+  }
+}


### PR DESCRIPTION
## Summary
- add turbo task runner with monorepo pipeline
- route build, lint, test and format:check through turborepo
- expose build/lint/test scripts in each package

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf08e1a47083289336e46e6a18d91a