### PR TITLE
build(eslint): reference package tsconfigs

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -3,14 +3,14 @@ const tsParser = require('@typescript-eslint/parser');
 
 module.exports = [
   {
-    ignores: ['tests/fixtures/**'],
+    ignores: ['tests/fixtures/**', 'packages/**/dist/**', 'packages/figma-*'],
   },
   {
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: './tsconfig.eslint.json',
+        project: ['./tsconfig.eslint.json', './packages/*/tsconfig.json'],
         tsconfigRootDir: __dirname,
       },
     },

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,7 +2,14 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@lapidist/design-lint-core": ["packages/core/src/index.ts"],
+      "@lapidist/design-lint-core/*": ["packages/core/src/*"],
+      "@lapidist/design-lint-shared": ["packages/shared/src/index.ts"],
+      "@lapidist/design-lint-shared/*": ["packages/shared/src/*"]
+    }
   },
   "include": ["src/**/*", "tests/**/*", "packages/*/src/**/*"]
 }


### PR DESCRIPTION
## Summary
- expand eslint ignores to cover package build outputs and figma placeholders
- load each package's tsconfig for type-aware linting
- map workspace package paths so eslint can resolve cross-package imports

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0bb48da08328ae296b824ac28340