### PR TITLE
chore(changeset): detect all packages

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,9 +1,19 @@
 # Changesets
 
-This project uses [Changesets](https://github.com/changesets/changesets) to manage versioning and releases.
+This project uses [Changesets](https://github.com/changesets/changesets) to manage versioning and releases across all packages in the `packages/` directory.
 
-To create a changeset, run:
+## Creating a changeset
 
+Create a markdown file under the `.changeset` folder that lists the packages affected:
+
+```md
+---
+'@lapidist/design-lint-core': patch
+---
+
+describe your change
 ```
-npm run changeset
-```
+
+Each file should use a descriptive kebab-case filename and list every package that needs a version bump. The `packages` option in `.changeset/config.json` is set to `"packages/*"` so Changesets can detect all packages.
+
+Do not run the Changesets CLI; just add the file to the repository.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,5 +3,6 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "access": "public",
-  "baseBranch": "main"
+  "baseBranch": "main",
+  "packages": ["packages/*"]
 }

--- a/.changeset/detect-all-packages.md
+++ b/.changeset/detect-all-packages.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint-core': patch
+---
+
+configure changesets to detect all packages
+


### PR DESCRIPTION
## Summary
- configure Changesets to detect packages/*
- document multi-package workflow
- add changeset for core package

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68bf1d74a9648328abd281bd36e85c96