### PR TITLE
fix: bundle workspace outputs for smoke tests

### DIFF
--- a/.changeset/ci-smoke-tests-monorepo.md
+++ b/.changeset/ci-smoke-tests-monorepo.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix CI smoke tests by bundling workspace builds into dist

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,11 +1,48 @@
 #!/usr/bin/env node
-import { chmodSync, existsSync } from 'node:fs';
+import { chmodSync, existsSync, cpSync, rmSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const root = join(__dirname, '..');
+const dist = join(root, 'dist');
 
-const cli = join(__dirname, '..', 'dist', 'cli', 'index.js');
+rmSync(dist, { recursive: true, force: true });
 
+function copyPackage(pkg, target, options = {}) {
+  const { withPkgJson = false, nestedDist = false } = options;
+  const dest = nestedDist ? join(target, 'dist') : target;
+  mkdirSync(dest, { recursive: true });
+  cpSync(join(root, 'packages', pkg, 'dist'), dest, { recursive: true });
+  if (withPkgJson) {
+    mkdirSync(target, { recursive: true });
+    const pkgJsonPath = join(root, 'packages', pkg, 'package.json');
+    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+    if (pkg === 'core') {
+      delete pkgJson.main;
+      delete pkgJson.module;
+      pkgJson.exports = './dist/index.js';
+    }
+    writeFileSync(join(target, 'package.json'), JSON.stringify(pkgJson, null, 2));
+  }
+}
+
+// core provides the library API
+copyPackage('core', dist);
+// CLI sources
+copyPackage('cli', join(dist, 'cli'));
+// bundle internal packages for runtime resolution
+copyPackage('core', join(dist, 'node_modules', '@lapidist', 'design-lint-core'), {
+  withPkgJson: true,
+  nestedDist: true,
+});
+copyPackage('shared', join(dist, 'node_modules', '@lapidist', 'design-lint-shared'), {
+  withPkgJson: true,
+  nestedDist: true,
+});
+
+const cli = join(dist, 'cli', 'index.js');
 if (existsSync(cli)) chmodSync(cli, 0o755);
+// include root package.json for runtime version checks
+cpSync(join(root, 'package.json'), join(dist, 'package.json'));


### PR DESCRIPTION
## Summary
- bundle core, shared, and CLI builds into root dist and copy package.json
- record the fix in a changeset

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npx --yes ./lapidist-design-lint-4.10.0.tgz --help`

------
https://chatgpt.com/codex/tasks/task_e_68bf29b5a5d883289f79f47e398d59e4