### PR TITLE
fix: handle non-numeric coverage percentages in coverage comment script

### DIFF
--- a/.changeset/handle-unknown-coverage.md
+++ b/.changeset/handle-unknown-coverage.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix generate-coverage-comment to handle unknown percentages

--- a/scripts/generate-coverage-comment.mjs
+++ b/scripts/generate-coverage-comment.mjs
@@ -14,13 +14,14 @@ async function main() {
   ];
   const rows = metrics
     .map(([name, data, threshold]) => {
+      const pct = Number(data.pct) || 0;
       const status =
         typeof threshold === 'number'
-          ? data.pct >= threshold
+          ? pct >= threshold
             ? '✅'
             : '❌'
           : '';
-      return `| ${name} | ${data.pct.toFixed(2)}% (${data.covered}/${data.total}) | ${
+      return `| ${name} | ${pct.toFixed(2)}% (${data.covered}/${data.total}) | ${
         threshold ?? 'n/a'
       }% | ${status} |`;
     })


### PR DESCRIPTION
## Summary
- parse coverage percentages as numbers in `generate-coverage-comment`
- add changeset for bug fix

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run test:coverage`
- `node scripts/generate-coverage-comment.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bf2e17adcc8328b31db44040705a0e