### PR TITLE
feat(core): add document-based linting

### DIFF
--- a/.changeset/lint-document-apis.md
+++ b/.changeset/lint-document-apis.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add lintDocument and lintDocuments APIs and update cache processing

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -9,7 +9,7 @@ export class CacheManager {
     private fix: boolean,
   ) {}
 
-  async processFile(
+  async processDocument(
     doc: LintDocument,
     lintFn: (
       text: string,

--- a/tests/core/cache-manager.test.ts
+++ b/tests/core/cache-manager.test.ts
@@ -31,7 +31,7 @@ void test('CacheManager applies fixes when enabled', async () => {
   };
   const manager = new CacheManager(undefined, true);
   const doc = createFileDocument(file);
-  await manager.processFile(doc, lintFn);
+  await manager.processDocument(doc, lintFn);
   const updated = await fs.readFile(file, 'utf8');
   assert.equal(updated, 'good');
 });

--- a/tests/core/runner.test.ts
+++ b/tests/core/runner.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Runner } from '../../src/index.ts';
 import { TokenTracker } from '../../src/core/token-tracker.ts';
-import { FileSource } from '../../src/index.ts';
+import { createFileDocument } from '../../src/node/file-document.ts';
 
 interface CacheEntry {
   mtime: number;
@@ -39,10 +39,10 @@ void test('Runner handles non-positive concurrency values', async () => {
   const runner = new Runner({
     config: { concurrency: 0, tokens: {} },
     tokenTracker: new TokenTracker({}),
-    lintText: (text, filePath) => Promise.resolve({ filePath, messages: [] }),
-    source: new FileSource(),
+    lintDocument: (text, filePath) =>
+      Promise.resolve({ filePath, messages: [] }),
   });
-  const res = await runner.run([file]);
+  const res = await runner.run([createFileDocument(file)]);
   assert.equal(res.results[0]?.filePath, file);
   await fs.rm(dir, { recursive: true, force: true });
 });
@@ -56,10 +56,10 @@ void test('Runner prunes cache and saves results', async () => {
   const runner = new Runner({
     config: { tokens: {} },
     tokenTracker: new TokenTracker({}),
-    lintText: (text, filePath) => Promise.resolve({ filePath, messages: [] }),
-    source: new FileSource(),
+    lintDocument: (text, filePath) =>
+      Promise.resolve({ filePath, messages: [] }),
   });
-  await runner.run([file], false, cache, [], 'cache');
+  await runner.run([createFileDocument(file)], false, cache, 'cache');
   assert.deepEqual(cache.keys(), [file]);
   assert.ok(cache.saved);
   await fs.rm(dir, { recursive: true, force: true });

--- a/tests/lint-file.test.ts
+++ b/tests/lint-file.test.ts
@@ -4,23 +4,26 @@ import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { Linter } from '../src/core/linter.ts';
 import { FileSource } from '../src/core/file-source.ts';
+import { createFileDocument } from '../src/node/file-document.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');
 
-void test('lintFile delegates to lintFiles', async () => {
+void test('lintDocument matches lintFile wrapper', async () => {
   const config = await loadConfig(fixtureDir);
   const linter = new Linter(config, new FileSource());
   const file = path.join(fixtureDir, 'src', 'App.svelte');
-  const res1 = await linter.lintFile(file);
-  const { results: res2 } = await linter.lintFiles([file]);
-  assert.deepEqual(res1, res2[0]);
+  const doc = createFileDocument(file);
+  const res1 = await linter.lintDocument(doc);
+  const res2 = await linter.lintFile(file);
+  assert.deepEqual(res1, res2);
 });
 
-void test('lintFile reports unreadable file', async () => {
+void test('lintDocument reports unreadable file', async () => {
   const config = await loadConfig(fixtureDir);
   const linter = new Linter(config, new FileSource());
   const file = path.join(fixtureDir, 'src', 'App.svelte');
+  const doc = createFileDocument(file);
   const original = fs.readFile;
   const stub = mock.method(
     fs,
@@ -34,7 +37,7 @@ void test('lintFile reports unreadable file', async () => {
     },
   );
   try {
-    const res = await linter.lintFile(file);
+    const res = await linter.lintDocument(doc);
     assert.equal(res.messages.length, 1);
     const msg = res.messages[0];
     assert.equal(msg.ruleId, 'parse-error');


### PR DESCRIPTION
## Summary
- support linting pre-loaded documents and document arrays
- rename cache manager processing to `processDocument`
- adjust runner to handle `LintDocument` items directly

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c00300ecf08328b6e6607be07df0d9