### PR TITLE
refactor: use document types for parser registry

### DIFF
--- a/.changeset/parser-registry-doc-types.md
+++ b/.changeset/parser-registry-doc-types.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+use document types for parser registry

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -14,6 +14,7 @@ export class CacheManager {
     lintFn: (
       text: string,
       filePath: string,
+      docType: string,
       metadata?: Record<string, unknown>,
     ) => Promise<LintResult>,
   ): Promise<LintResult> {
@@ -35,14 +36,14 @@ export class CacheManager {
         return cached.result;
       }
       const text = await doc.getText();
-      let result = await lintFn(text, doc.id, doc.metadata);
+      let result = await lintFn(text, doc.id, doc.type, doc.metadata);
       let mtime = statResult?.mtimeMs ?? Date.now();
       let size = statResult?.size ?? text.length;
       if (this.fix && statResult) {
         const output = applyFixes(text, result.messages);
         if (output !== text) {
           await writeFile(doc.id, output, 'utf8');
-          result = await lintFn(output, doc.id, doc.metadata);
+          result = await lintFn(output, doc.id, doc.type, doc.metadata);
           const newStat = await stat(doc.id);
           mtime = newStat.mtimeMs;
           size = newStat.size;

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -14,7 +14,6 @@ import type { DocumentSource, LintDocument } from './document-source.js';
 import { FileSource } from './file-source.js';
 import { createFileDocument } from '../node/file-document.js';
 import { parserRegistry } from './parser-registry.js';
-import path from 'node:path';
 
 export interface Config {
   tokens?: DesignTokens | Record<string, DesignTokens>;
@@ -144,6 +143,7 @@ export class Linter {
   private async lintText(
     text: string,
     filePath = 'unknown',
+    docType = '',
     metadata?: Record<string, unknown>,
   ): Promise<LintResult> {
     await this.ruleRegistry.load();
@@ -171,8 +171,8 @@ export class Linter {
       };
       return rule.create(ctx);
     });
-    const ext = path.extname(filePath).toLowerCase();
-    const parser = parserRegistry[ext];
+    const type = docType || createFileDocument(filePath).type;
+    const parser = parserRegistry[type];
     if (parser) {
       await parser(text, filePath, listeners, messages);
     }

--- a/src/core/parser-registry.ts
+++ b/src/core/parser-registry.ts
@@ -12,18 +12,8 @@ export type ParserStrategy = (
 ) => Promise<void> | void;
 
 export const parserRegistry: Partial<Record<string, ParserStrategy>> = {
-  '.vue': lintVue,
-  '.svelte': lintSvelte,
-  '.ts': lintTS,
-  '.tsx': lintTS,
-  '.mts': lintTS,
-  '.cts': lintTS,
-  '.js': lintTS,
-  '.jsx': lintTS,
-  '.mjs': lintTS,
-  '.cjs': lintTS,
-  '.css': lintCSS,
-  '.scss': lintCSS,
-  '.sass': lintCSS,
-  '.less': lintCSS,
+  vue: lintVue,
+  svelte: lintSvelte,
+  ts: lintTS,
+  css: lintCSS,
 };

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -13,6 +13,7 @@ export interface RunnerOptions {
   lintDocument: (
     text: string,
     filePath: string,
+    docType: string,
     metadata?: Record<string, unknown>,
   ) => Promise<LintResult>;
 }
@@ -23,6 +24,7 @@ export class Runner {
   private lintDocumentFn: (
     text: string,
     filePath: string,
+    docType: string,
     metadata?: Record<string, unknown>,
   ) => Promise<LintResult>;
 

--- a/src/node/file-document.ts
+++ b/src/node/file-document.ts
@@ -5,9 +5,26 @@ import type { LintDocument } from '../core/document-source.js';
 export function createFileDocument(filePath: string): LintDocument {
   const absPath = path.resolve(filePath);
   const ext = path.extname(absPath).slice(1).toLowerCase();
+  const typeMap: Record<string, string> = {
+    ts: 'ts',
+    tsx: 'ts',
+    mts: 'ts',
+    cts: 'ts',
+    js: 'ts',
+    jsx: 'ts',
+    mjs: 'ts',
+    cjs: 'ts',
+    css: 'css',
+    scss: 'css',
+    sass: 'css',
+    less: 'css',
+    vue: 'vue',
+    svelte: 'svelte',
+  };
+  const type = typeMap[ext] ?? ext;
   return {
     id: absPath,
-    type: ext,
+    type,
     async getText() {
       return readFile(absPath, 'utf8');
     },

--- a/tests/core/parser-registry.test.ts
+++ b/tests/core/parser-registry.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { parserRegistry } from '../../src/core/parser-registry.ts';
+import { createFileDocument } from '../../src/node/file-document.ts';
 import type {
   RuleModule,
   RuleContext,
@@ -26,23 +27,22 @@ const rule: RuleModule = {
 };
 
 const cases = [
-  { ext: '.css', filePath: 'a.css', text: 'a{color:red;}' },
-  { ext: '.ts', filePath: 'a.ts', text: 'css`color:red;`' },
+  { filePath: 'a.css', text: 'a{color:red;}' },
+  { filePath: 'a.ts', text: 'css`color:red;`' },
   {
-    ext: '.vue',
     filePath: 'a.vue',
     text: '<template></template><style>a{color:red;}</style>',
   },
   {
-    ext: '.svelte',
     filePath: 'a.svelte',
     text: '<div class="a"></div><style>.a{color:red;}</style>',
   },
 ];
 
 for (const c of cases) {
-  void test(`parser ${c.ext} dispatches CSS declarations`, async () => {
-    const parser = parserRegistry[c.ext];
+  void test(`parser ${c.filePath} dispatches CSS declarations`, async () => {
+    const doc = createFileDocument(c.filePath);
+    const parser = parserRegistry[doc.type];
     assert.ok(parser, 'parser exists');
     const messages: LintMessage[] = [];
     const ctx: RuleContext = {


### PR DESCRIPTION
## Summary
- reference parsers by document type instead of file extension
- derive document types from file extensions when creating file documents
- select parsers in the linter using document type

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c007dac3dc83288a424af2a1412dcd