### PR TITLE
feat(core): add plugin loader abstraction

### DIFF
--- a/.changeset/add-plugin-loader.md
+++ b/.changeset/add-plugin-loader.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add plugin loader abstraction and Node implementation

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -6,6 +6,7 @@ import { relFromCwd, realpathIfExists } from '../utils/paths.js';
 import { loadCache, type Cache } from '../core/cache.js';
 import type { Config, Linter } from '../core/linter.js';
 import type { LintResult } from '../core/types.js';
+import { NodePluginLoader } from '../node/plugin-loader.js';
 
 export interface Environment {
   formatter: (results: LintResult[], useColor?: boolean) => string;
@@ -48,7 +49,9 @@ export async function prepareEnvironment(
   if (config.configPath) {
     config.configPath = realpathIfExists(config.configPath);
   }
-  const linterRef = { current: new Linter(config) };
+  const linterRef = {
+    current: new Linter(config, undefined, new NodePluginLoader()),
+  };
   const pluginPaths = await linterRef.current.getPluginPaths();
 
   const cacheLocation = options.cache

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -8,6 +8,7 @@ import { relFromCwd, realpathIfExists } from '../utils/paths.js';
 import { loadConfig } from '../config/loader.js';
 import { Linter } from '../core/linter.js';
 import type { Config } from '../core/linter.js';
+import { NodePluginLoader } from '../node/plugin-loader.js';
 import type { Cache } from '../core/cache.js';
 import type { Ignore } from 'ignore';
 import {
@@ -175,7 +176,7 @@ export async function startWatch(ctx: WatchOptions) {
         : createRequire(import.meta.url);
       for (const p of pluginPaths) Reflect.deleteProperty(req.cache, p);
       config = await loadConfig(process.cwd(), options.config);
-      linterRef.current = new Linter(config);
+      linterRef.current = new Linter(config, undefined, new NodePluginLoader());
       await refreshIgnore();
       cache?.clear();
       if (cacheLocation) {

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -8,6 +8,7 @@ import { normalizeTokens, mergeTokens, extractVarName } from './token-utils.js';
 export { defaultIgnore } from './ignore.js';
 import type { Cache } from './cache.js';
 import { RuleRegistry } from './rule-registry.js';
+import type { PluginLoader } from './plugin-loader.js';
 import { TokenTracker } from './token-tracker.js';
 import { Runner } from './runner.js';
 import type { DocumentSource, LintDocument } from './document-source.js';
@@ -40,14 +41,18 @@ export class Linter {
   private tokenTracker: TokenTracker;
   private source: DocumentSource;
 
-  constructor(config: Config, source: DocumentSource = new FileSource()) {
+  constructor(
+    config: Config,
+    source: DocumentSource = new FileSource(),
+    loader?: PluginLoader,
+  ) {
     const normalized = normalizeTokens(
       config.tokens,
       config.wrapTokensWithVar ?? false,
     );
     this.tokensByTheme = normalized.themes;
     this.config = { ...config, tokens: normalized.merged };
-    this.ruleRegistry = new RuleRegistry(this.config);
+    this.ruleRegistry = new RuleRegistry(this.config, loader);
     this.tokenTracker = new TokenTracker(this.config.tokens);
     this.source = source;
   }

--- a/src/core/plugin-loader.ts
+++ b/src/core/plugin-loader.ts
@@ -1,0 +1,10 @@
+import type { PluginModule } from './types.js';
+
+export interface LoadedPlugin {
+  path: string;
+  plugin: PluginModule;
+}
+
+export interface PluginLoader {
+  load(path: string, configPath?: string): Promise<LoadedPlugin>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export type {
   CSSDeclaration,
   Fix,
 } from './core/types.js';
+export type { PluginLoader, LoadedPlugin } from './core/plugin-loader.js';
+export { NodePluginLoader } from './node/plugin-loader.js';
 export {
   matchToken,
   closestToken,

--- a/src/node/plugin-loader.ts
+++ b/src/node/plugin-loader.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+import { realpathIfExists, relFromCwd } from '../utils/paths.js';
+import type { PluginModule } from '../core/types.js';
+import type { PluginLoader, LoadedPlugin } from '../core/plugin-loader.js';
+import { createEngineError } from '../core/plugin-manager.js';
+
+export class NodePluginLoader implements PluginLoader {
+  async load(p: string, configPath?: string): Promise<LoadedPlugin> {
+    const req = configPath
+      ? createRequire(configPath)
+      : createRequire(import.meta.url);
+    let resolved: string;
+    try {
+      resolved = realpathIfExists(req.resolve(p));
+    } catch {
+      resolved = realpathIfExists(path.resolve(p));
+    }
+    if (!fs.existsSync(resolved)) {
+      throw createEngineError({
+        message: `Plugin not found: "${relFromCwd(resolved)}"`,
+        context: `Plugin "${p}"`,
+        remediation: 'Ensure the plugin is installed and resolvable.',
+      });
+    }
+    let mod: unknown;
+    try {
+      if (resolved.endsWith('.mjs')) {
+        mod = await import(
+          `${pathToFileURL(resolved).href}?t=${String(Date.now())}`
+        );
+      } else {
+        mod = req(resolved);
+      }
+    } catch (e: unknown) {
+      if (getErrorCode(e) === 'ERR_REQUIRE_ESM') {
+        mod = await import(
+          `${pathToFileURL(resolved).href}?t=${String(Date.now())}`
+        );
+      } else {
+        throw createEngineError({
+          message: `Failed to load plugin "${p}": ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+          context: `Plugin "${p}"`,
+          remediation: 'Ensure the plugin is installed and resolvable.',
+        });
+      }
+    }
+    const plugin = resolvePlugin(mod);
+    return { path: resolved, plugin: plugin as PluginModule };
+  }
+}
+
+function resolvePlugin(mod: unknown): unknown {
+  if (isRecord(mod)) return mod.default ?? mod.plugin ?? mod;
+  return mod;
+}
+
+function getErrorCode(e: unknown): string | undefined {
+  return isRecord(e) && typeof e.code === 'string' ? e.code : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -4,6 +4,9 @@ import path from 'path';
 import { Linter } from '../src/core/linter.ts';
 import { FileSource } from '../src/core/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
+import { NodePluginLoader } from '../src/node/plugin-loader.ts';
+import type { PluginLoader } from '../src/core/plugin-loader.ts';
+import type { PluginModule, RuleModule } from '../src/core/types.ts';
 
 void test('external plugin rules execute', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin.ts');
@@ -13,6 +16,7 @@ void test('external plugin rules execute', async () => {
       rules: { 'plugin/test': 'error' },
     },
     new FileSource(),
+    new NodePluginLoader(),
   );
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
@@ -22,7 +26,7 @@ void test('external plugin rules execute', async () => {
 void test('plugins resolve relative to config file', async () => {
   const dir = path.join(__dirname, 'fixtures', 'plugin-relative');
   const config = await loadConfig(dir);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, new FileSource(), new NodePluginLoader());
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].ruleId, 'plugin/test');
@@ -36,6 +40,7 @@ void test('loads ESM plugin modules', async () => {
       rules: { 'plugin/esm': 'error' },
     },
     new FileSource(),
+    new NodePluginLoader(),
   );
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
@@ -44,7 +49,11 @@ void test('loads ESM plugin modules', async () => {
 
 void test('throws for invalid plugin modules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
+  const linter = new Linter(
+    { plugins: [pluginPath] },
+    new FileSource(),
+    new NodePluginLoader(),
+  );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /Invalid plugin/,
@@ -53,7 +62,11 @@ void test('throws for invalid plugin modules', async () => {
 
 void test('throws for invalid plugin rules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-rule-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
+  const linter = new Linter(
+    { plugins: [pluginPath] },
+    new FileSource(),
+    new NodePluginLoader(),
+  );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /Invalid rule/,
@@ -62,7 +75,11 @@ void test('throws for invalid plugin rules', async () => {
 
 void test('throws when plugin module missing', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'missing-plugin.js');
-  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
+  const linter = new Linter(
+    { plugins: [pluginPath] },
+    new FileSource(),
+    new NodePluginLoader(),
+  );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /Failed to load plugin/,
@@ -71,7 +88,11 @@ void test('throws when plugin module missing', async () => {
 
 void test('throws when plugin rule conflicts with existing rule', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'conflict-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
+  const linter = new Linter(
+    { plugins: [pluginPath] },
+    new FileSource(),
+    new NodePluginLoader(),
+  );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     /conflicts with an existing rule/,
@@ -81,7 +102,11 @@ void test('throws when plugin rule conflicts with existing rule', async () => {
 void test('throws when two plugins define the same rule name', async () => {
   const pluginA = path.join(__dirname, 'fixtures', 'test-plugin.ts');
   const pluginB = path.join(__dirname, 'fixtures', 'duplicate-rule-plugin.ts');
-  const linter = new Linter({ plugins: [pluginA, pluginB] }, new FileSource());
+  const linter = new Linter(
+    { plugins: [pluginA, pluginB] },
+    new FileSource(),
+    new NodePluginLoader(),
+  );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
     (err) => {
@@ -95,8 +120,38 @@ void test('throws when two plugins define the same rule name', async () => {
 
 void test('getPluginPaths returns resolved plugin paths', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin.ts');
-  const linter = new Linter({ plugins: [pluginPath] }, new FileSource());
+  const linter = new Linter(
+    { plugins: [pluginPath] },
+    new FileSource(),
+    new NodePluginLoader(),
+  );
   await linter.lintText('const a = 1;', 'file.ts');
   const paths = await linter.getPluginPaths();
   assert.deepEqual(paths, [pluginPath]);
+});
+
+void test('supports custom plugin loaders', async () => {
+  class MockLoader implements PluginLoader {
+    load(
+      _p: string,
+      _c?: string,
+    ): Promise<{ path: string; plugin: PluginModule }> {
+      void _p;
+      void _c;
+      const rule: RuleModule = {
+        name: 'mock/rule',
+        meta: { description: 'mock rule' },
+        create: () => ({}),
+      };
+      return Promise.resolve({ path: 'mock', plugin: { rules: [rule] } });
+    }
+  }
+  const linter = new Linter(
+    { plugins: ['mock'], rules: { 'mock/rule': 'error' } },
+    new FileSource(),
+    new MockLoader(),
+  );
+  const res = await linter.lintText('const a = 1;', 'file.ts');
+  assert.equal(res.messages.length, 1);
+  assert.equal(res.messages[0].ruleId, 'mock/rule');
 });


### PR DESCRIPTION
## Summary
- add PluginLoader interface and Node implementation
- refactor plugin management to use injected loader
- update CLI to supply NodePluginLoader and test custom loaders

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c00dace2408328bb13d0d6db039488