### PR TITLE
feat: add variables token group

### DIFF
--- a/.changeset/variables-token-group.md
+++ b/.changeset/variables-token-group.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add variables token group to track custom property values

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,18 @@ Tokens may be defined as key–value maps or as pattern arrays for matching CSS 
 }
 ```
 
+The optional `variables` group defines CSS custom property values directly. Each entry supplies an `id` and `value` for the variable.
+
+```json
+{
+  "tokens": {
+    "variables": {
+      "primary-color": { "id": "--color-primary", "value": "#ff0000" }
+    }
+  }
+}
+```
+
 ## Rule configuration
 
 Each entry in the `rules` section begins with a severity: `'off'` (or `0`) disables a rule, `'warn'` (or `1`) reports a warning, and `'error'` (or `2`) fails the lint run.

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -126,10 +126,18 @@ export class Linter {
     const tokens = this.config.tokens;
     const completions: Record<string, string[]> = {};
     for (const [group, defs] of Object.entries(tokens)) {
+      if (group === 'variables' && isRecord(defs)) {
+        const names: string[] = [];
+        for (const v of Object.values(defs)) {
+          if (isRecord(v) && typeof v.id === 'string') names.push(v.id);
+        }
+        if (names.length) completions[group] = names;
+        continue;
+      }
       if (Array.isArray(defs)) {
         const names = defs.filter((t): t is string => typeof t === 'string');
         if (names.length) completions[group] = names;
-      } else if (defs && typeof defs === 'object') {
+      } else if (isRecord(defs)) {
         const names: string[] = [];
         for (const val of Object.values(defs)) {
           const v = typeof val === 'string' ? extractVarName(val) : null;

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -95,6 +95,12 @@ function collectTokenValues(tokens?: DesignTokens): Set<string> {
   if (!tokens) return values;
   for (const [group, defs] of Object.entries(tokens)) {
     if (group === 'deprecations') continue;
+    if (group === 'variables' && isRecord(defs)) {
+      for (const v of Object.values(defs)) {
+        if (isRecord(v) && typeof v.id === 'string') values.add(v.id);
+      }
+      continue;
+    }
     if (Array.isArray(defs)) {
       for (const t of defs) {
         if (typeof t === 'string' && !t.includes('*')) values.add(t);

--- a/src/core/token-utils.ts
+++ b/src/core/token-utils.ts
@@ -27,6 +27,7 @@ const TOKEN_GROUPS = [
   'lineHeights',
   'fontWeights',
   'letterSpacings',
+  'variables',
   'deprecations',
 ];
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -35,6 +35,8 @@ export interface DesignTokens {
   fontWeights?: Record<string, number | string> | (string | RegExp)[];
   /** Letter spacing tokens. */
   letterSpacings?: Record<string, number | string> | (string | RegExp)[];
+  /** Variable definitions. */
+  variables?: Record<string, { id: string; value: string | number }>;
   /** Deprecated tokens and their replacements. */
   deprecations?: Record<string, { replacement?: string }>;
   /** Allow additional custom token groups. */

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -7,6 +7,10 @@ void test('getTokenCompletions returns token names', () => {
   const linter = new Linter(
     {
       tokens: {
+        variables: {
+          primary: { id: '--color-primary', value: '#fff' },
+          accent: { id: '--color-accent', value: '#000' },
+        },
         spacing: ['--space-scale-100'],
         colors: {
           primary: 'var(--color-primary)',
@@ -19,6 +23,7 @@ void test('getTokenCompletions returns token names', () => {
     new FileSource(),
   );
   const comps = linter.getTokenCompletions();
+  assert.deepEqual(comps.variables, ['--color-primary', '--color-accent']);
   assert.deepEqual(comps.spacing, ['--space-scale-100']);
   assert.deepEqual(comps.colors, [
     '--color-primary',

--- a/tests/token-utils.test.ts
+++ b/tests/token-utils.test.ts
@@ -17,14 +17,27 @@ void test('normalizeTokens wraps values with var when enabled', () => {
 
 void test('normalizeTokens merges tokens across themes', () => {
   const tokens = {
-    base: { colors: { primary: '#000' } },
-    light: { colors: { secondary: '#fff' } },
+    base: {
+      colors: { primary: '#000' },
+      variables: { primary: { id: '--color-primary', value: '#000' } },
+    },
+    light: {
+      colors: { secondary: '#fff' },
+      variables: { secondary: { id: '--color-secondary', value: '#fff' } },
+    },
   };
   const normalized = normalizeTokens(tokens);
   assert.equal(normalized.themes.base.colors.primary, '#000');
   assert.equal(normalized.themes.light.colors.secondary, '#fff');
   assert.equal(normalized.merged.colors.primary, '#000');
   assert.equal(normalized.merged.colors.secondary, '#fff');
+  assert.equal(normalized.themes.base.variables.primary.id, '--color-primary');
+  assert.equal(
+    normalized.themes.light.variables.secondary.id,
+    '--color-secondary',
+  );
+  assert.equal(normalized.merged.variables.primary.id, '--color-primary');
+  assert.equal(normalized.merged.variables.secondary.id, '--color-secondary');
 });
 
 void test('matchToken handles regexp and glob patterns and missing matches', () => {


### PR DESCRIPTION
## Summary
- allow `variables` in design tokens
- surface variable ids in token utils, completions and tracker
- document and test variables token group

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c018f0811c8328a4f291acc2939aaf