### PR TITLE
feat: expose core and node entry points

### DIFF
--- a/.changeset/core-node-split.md
+++ b/.changeset/core-node-split.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add core entry point and move node helpers under new node namespace

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,9 @@
 
 Design Lint exposes a small set of functions and classes for programmatic use in Node.js or browser environments.
 
+The framework ships a "core" build with no Node-specific helpers that can be imported via `@lapidist/design-lint/core`.
+Environment-specific utilities like `FileSource` or `NodePluginLoader` live under `@lapidist/design-lint/node`.
+
 ## Programmatic overview
 
 A typical control flow when using the library directly:
@@ -71,11 +74,12 @@ Helper to define a configuration object with type checking.
 
 Lints files using built-in and plugin-provided rules.
 
-#### `new Linter(config, source?)`
+#### `new Linter(config, source, loader?)`
 
 - **Parameters**
   - `config: Config` – resolved configuration.
-  - `source: DocumentSource = new FileSource()` – document source used to resolve lint targets.
+  - `source: DocumentSource` – document source used to resolve lint targets.
+  - `loader?: PluginLoader` – optional plugin loader.
 - **Returns** `Linter` instance.
 
 #### `lintFiles(targets, fix?, cache?, additionalIgnorePaths?, cacheLocation?)`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ Starting with **file discovery**, glob patterns expand to concrete paths and res
 
 ### File discovery
 
-Resolves the working set of files using glob patterns and ignore rules. See [`src/core/file-source.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/file-source.ts).
+Resolves the working set of files using glob patterns and ignore rules. See [`src/node/file-source.ts`](https://github.com/bylapidist/design-lint/blob/main/src/node/file-source.ts).
 
 ### Parser adapters
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "./cli": {
       "types": "./dist/cli/index.d.ts",
       "default": "./dist/cli/index.js"
+    },
+    "./core": {
+      "types": "./dist/core/index.d.ts",
+      "default": "./dist/core/index.js"
     }
   },
   "engines": {

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -5,6 +5,7 @@ import { getFormatter } from '../formatters/index.js';
 import { relFromCwd, realpathIfExists } from '../utils/paths.js';
 import type { CacheProvider } from '../core/cache-provider.js';
 import { NodeCacheProvider } from '../node/node-cache-provider.js';
+import { FileSource } from '../node/file-source.js';
 import type { Config, Linter } from '../core/linter.js';
 import type { LintResult } from '../core/types.js';
 import { NodePluginLoader } from '../node/plugin-loader.js';
@@ -51,7 +52,7 @@ export async function prepareEnvironment(
     config.configPath = realpathIfExists(config.configPath);
   }
   const linterRef = {
-    current: new Linter(config, undefined, new NodePluginLoader()),
+    current: new Linter(config, new FileSource(), new NodePluginLoader()),
   };
   const pluginPaths = await linterRef.current.getPluginPaths();
 

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -8,6 +8,7 @@ import { relFromCwd, realpathIfExists } from '../utils/paths.js';
 import { loadConfig } from '../config/loader.js';
 import { Linter } from '../core/linter.js';
 import type { Config } from '../core/linter.js';
+import { FileSource } from '../node/file-source.js';
 import { NodePluginLoader } from '../node/plugin-loader.js';
 import type { CacheProvider } from '../core/cache-provider.js';
 import type { Ignore } from 'ignore';
@@ -176,7 +177,11 @@ export async function startWatch(ctx: WatchOptions) {
         : createRequire(import.meta.url);
       for (const p of pluginPaths) Reflect.deleteProperty(req.cache, p);
       config = await loadConfig(process.cwd(), options.config);
-      linterRef.current = new Linter(config, undefined, new NodePluginLoader());
+      linterRef.current = new Linter(
+        config,
+        new FileSource(),
+        new NodePluginLoader(),
+      );
       await refreshIgnore();
       if (cache) {
         const keys = await cache.keys();

--- a/src/core/apply-fixes.ts
+++ b/src/core/apply-fixes.ts
@@ -1,0 +1,21 @@
+import type { LintMessage, Fix } from './types.js';
+
+export function applyFixes(text: string, messages: LintMessage[]): string {
+  const fixes: Fix[] = messages
+    .filter((m): m is LintMessage & { fix: Fix } => m.fix !== undefined)
+    .map((m) => m.fix);
+  if (fixes.length === 0) return text;
+  fixes.sort((a, b) => a.range[0] - b.range[0]);
+  const filtered: Fix[] = [];
+  let lastEnd = -1;
+  for (const f of fixes) {
+    if (f.range[0] < lastEnd) continue;
+    filtered.push(f);
+    lastEnd = f.range[1];
+  }
+  for (let i = filtered.length - 1; i >= 0; i--) {
+    const f = filtered[i];
+    text = text.slice(0, f.range[0]) + f.text + text.slice(f.range[1]);
+  }
+  return text;
+}

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -1,7 +1,8 @@
 import { stat, writeFile } from 'node:fs/promises';
 import type { CacheProvider } from './cache-provider.js';
-import type { LintResult, LintMessage, Fix } from './types.js';
+import type { LintResult } from './types.js';
 import type { LintDocument } from './document-source.js';
+import { applyFixes } from './apply-fixes.js';
 
 export class CacheManager {
   constructor(
@@ -75,24 +76,4 @@ export class CacheManager {
       await this.cache.save();
     }
   }
-}
-
-export function applyFixes(text: string, messages: LintMessage[]): string {
-  const fixes: Fix[] = messages
-    .filter((m): m is LintMessage & { fix: Fix } => m.fix !== undefined)
-    .map((m) => m.fix);
-  if (fixes.length === 0) return text;
-  fixes.sort((a, b) => a.range[0] - b.range[0]);
-  const filtered: Fix[] = [];
-  let lastEnd = -1;
-  for (const f of fixes) {
-    if (f.range[0] < lastEnd) continue;
-    filtered.push(f);
-    lastEnd = f.range[1];
-  }
-  for (let i = filtered.length - 1; i >= 0; i--) {
-    const f = filtered[i];
-    text = text.slice(0, f.range[0]) + f.text + text.slice(f.range[1]);
-  }
-  return text;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,26 @@
+export { Linter, type Config } from './linter.js';
+export { applyFixes } from './apply-fixes.js';
+export { Runner } from './runner.js';
+export type { DocumentSource, LintDocument } from './document-source.js';
+export type { PluginLoader, LoadedPlugin } from './plugin-loader.js';
+export type { CacheProvider, CacheEntry } from './cache-provider.js';
+export type {
+  LintResult,
+  LintMessage,
+  RuleModule,
+  RuleContext,
+  RuleListener,
+  DesignTokens,
+  PluginModule,
+  CSSDeclaration,
+  Fix,
+} from './types.js';
+export {
+  matchToken,
+  closestToken,
+  extractVarName,
+  mergeTokens,
+  normalizeTokens,
+  type TokenPattern,
+  type NormalizedTokens,
+} from './token-utils.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,6 @@
-export { Linter, type Config, applyFixes } from './core/linter.js';
-export { Runner } from './core/runner.js';
-export type { DocumentSource, LintDocument } from './core/document-source.js';
-export { FileSource } from './core/file-source.js';
+export * from './core/index.js';
+export * from './node/index.js';
 export { loadConfig } from './config/loader.js';
 export { defineConfig } from './config/define-config.js';
 export { getFormatter } from './formatters/index.js';
 export { builtInRules } from './rules/index.js';
-export type {
-  LintResult,
-  LintMessage,
-  RuleModule,
-  RuleContext,
-  RuleListener,
-  DesignTokens,
-  PluginModule,
-  CSSDeclaration,
-  Fix,
-} from './core/types.js';
-export type { PluginLoader, LoadedPlugin } from './core/plugin-loader.js';
-export { NodePluginLoader } from './node/plugin-loader.js';
-export {
-  matchToken,
-  closestToken,
-  extractVarName,
-  mergeTokens,
-  normalizeTokens,
-  type TokenPattern,
-  type NormalizedTokens,
-} from './core/token-utils.js';

--- a/src/node/file-source.ts
+++ b/src/node/file-source.ts
@@ -1,10 +1,10 @@
 import { globby } from 'globby';
 import { performance } from 'node:perf_hooks';
 import { realpathIfExists } from '../utils/paths.js';
-import { getIgnorePatterns } from './ignore.js';
-import type { Config } from './linter.js';
-import type { DocumentSource } from './document-source.js';
-import { createFileDocument } from '../node/file-document.js';
+import { getIgnorePatterns } from '../core/ignore.js';
+import type { Config } from '../core/linter.js';
+import type { DocumentSource } from '../core/document-source.js';
+import { createFileDocument } from './file-document.js';
 
 const defaultPatterns = [
   '**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs,css,scss,sass,less,svelte,vue}',

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,0 +1,4 @@
+export { FileSource } from './file-source.js';
+export { createFileDocument } from './file-document.js';
+export { NodePluginLoader } from './plugin-loader.js';
+export { NodeCacheProvider } from './node-cache-provider.js';

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -5,7 +5,7 @@ import { makeTmpDir } from '../src/utils/tmp.ts';
 import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('returns default config when none found', async () => {
   const tmp = makeTmpDir();

--- a/tests/core/glob-ignore.test.ts
+++ b/tests/core/glob-ignore.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 import { makeTmpDir } from '../../src/utils/tmp.ts';
 import type { Config } from '../../src/core/linter.ts';
 

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('Linter integrates registry, parser and trackers', async () => {
   const linter = new Linter(

--- a/tests/core/profile.test.ts
+++ b/tests/core/profile.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../../src/utils/tmp.ts';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 import type { Config } from '../../src/core/linter.ts';
 
 // Ensure FileSource.scan logs when profiling is enabled

--- a/tests/glob.test.ts
+++ b/tests/glob.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('lintFiles expands glob patterns with globby', async () => {
   const dir = makeTmpDir();

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('lintFiles ignores common directories by default', async () => {
   const dir = makeTmpDir();

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('inline directives disable linting', async () => {
   const dir = makeTmpDir();

--- a/tests/lint-file.test.ts
+++ b/tests/lint-file.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 import { createFileDocument } from '../src/node/file-document.ts';
 import { loadConfig } from '../src/config/loader.ts';
 

--- a/tests/patterns.test.ts
+++ b/tests/patterns.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('lintFiles uses patterns option to include custom extensions', async () => {
   const tmp = makeTmpDir();

--- a/tests/performance.test.ts
+++ b/tests/performance.test.ts
@@ -5,7 +5,7 @@ import { makeTmpDir } from '../src/utils/tmp.ts';
 import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('lints large projects without crashing', async () => {
   const dir = path.join(__dirname, 'fixtures', 'large-project');

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 import { NodePluginLoader } from '../src/node/plugin-loader.ts';
 import type { PluginLoader } from '../src/core/plugin-loader.ts';

--- a/tests/rules/animation.test.ts
+++ b/tests/rules/animation.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/animation reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/blur.test.ts
+++ b/tests/rules/blur.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/blur reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/border-color.test.ts
+++ b/tests/rules/border-color.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/border-color reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/border-radius.test.ts
+++ b/tests/rules/border-radius.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/border-radius reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/border-width.test.ts
+++ b/tests/rules/border-width.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/border-width reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/box-shadow.test.ts
+++ b/tests/rules/box-shadow.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/box-shadow reports disallowed value', async () => {
   const linter = new Linter(

--- a/tests/rules/colors.test.ts
+++ b/tests/rules/colors.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/colors reports disallowed hex', async () => {
   const linter = new Linter(

--- a/tests/rules/component-prefix.test.ts
+++ b/tests/rules/component-prefix.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-prefix enforces prefix on components', async () => {

--- a/tests/rules/component-usage.test.ts
+++ b/tests/rules/component-usage.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-usage suggests substitutions', async () => {

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-system/deprecation flags deprecated token', async () => {
   const linter = new Linter(

--- a/tests/rules/duration.test.ts
+++ b/tests/rules/duration.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/duration reports invalid transition duration', async () => {
   const linter = new Linter(

--- a/tests/rules/font-family.test.ts
+++ b/tests/rules/font-family.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/font-family reports invalid font-family', async () => {
   const linter = new Linter(

--- a/tests/rules/font-size.test.ts
+++ b/tests/rules/font-size.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/font-size reports invalid font-size', async () => {
   const linter = new Linter(

--- a/tests/rules/font-weight.test.ts
+++ b/tests/rules/font-weight.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/font-weight reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/icon-usage.test.ts
+++ b/tests/rules/icon-usage.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/icon-usage reports raw svg', async () => {

--- a/tests/rules/import-path.test.ts
+++ b/tests/rules/import-path.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-system/import-path flags components from wrong package', async () => {
   const linter = new Linter(

--- a/tests/rules/letter-spacing.test.ts
+++ b/tests/rules/letter-spacing.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/letter-spacing reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/line-height.test.ts
+++ b/tests/rules/line-height.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/line-height reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/no-inline-styles.test.ts
+++ b/tests/rules/no-inline-styles.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-system/no-inline-styles flags style attribute on components', async () => {
   const linter = new Linter(

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 async function tempFile(content: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'tmp-'));

--- a/tests/rules/opacity.test.ts
+++ b/tests/rules/opacity.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/opacity reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/outline.test.ts
+++ b/tests/rules/outline.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/outline reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/parse-error.test.ts
+++ b/tests/rules/parse-error.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('reports CSS parse errors', async () => {
   const linter = new Linter({}, new FileSource());

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/spacing enforces multiples', async () => {
   const linter = new Linter(

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 const config = {
   tokens: {

--- a/tests/rules/token-colors.test.ts
+++ b/tests/rules/token-colors.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/colors reports disallowed hwb', async () => {
   const linter = new Linter(

--- a/tests/rules/token-suggestion.test.ts
+++ b/tests/rules/token-suggestion.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('suggests closest token name', async () => {
   const linter = new Linter(

--- a/tests/rules/variant-prop.test.ts
+++ b/tests/rules/variant-prop.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-system/variant-prop flags invalid variant', async () => {
   const linter = new Linter(

--- a/tests/rules/z-index.test.ts
+++ b/tests/rules/z-index.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/core/file-source.ts';
+import { FileSource } from '../../src/node/file-source.ts';
 
 void test('design-token/z-index reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/svelte-style-bindings.test.ts
+++ b/tests/svelte-style-bindings.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');

--- a/tests/tagged-template.test.ts
+++ b/tests/tagged-template.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'tagged-template');

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('getTokenCompletions returns token names', () => {
   const linter = new Linter(

--- a/tests/token-patterns.test.ts
+++ b/tests/token-patterns.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 const rule = { 'design-token/colors': 'error' };
 

--- a/tests/token-utils.test.ts
+++ b/tests/token-utils.test.ts
@@ -7,7 +7,7 @@ import {
   extractVarName,
 } from '../src/core/token-utils.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 
 void test('normalizeTokens wraps values with var when enabled', () => {
   const tokens = { colors: { primary: '--color-primary' } };

--- a/tests/vue-style-bindings.test.ts
+++ b/tests/vue-style-bindings.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/core/file-source.ts';
+import { FileSource } from '../src/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'vue');


### PR DESCRIPTION
## Summary
- add environment-agnostic core entry with linter, runner and types
- relocate node helpers and provide node-specific entry point
- document core usage and export `./core` in package.json

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c01eaff49483288d3a0469763a3681