### PR TITLE
feat(cli): wire node providers and cache

### DIFF
--- a/.changeset/cli-cache-provider.md
+++ b/.changeset/cli-cache-provider.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+initialize linter with file source, plugin loader, and optional cache provider

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,30 +74,30 @@ Helper to define a configuration object with type checking.
 
 Lints files using built-in and plugin-provided rules.
 
-#### `new Linter(config, source, loader?)`
+#### `new Linter(config, source, loader?, cacheProvider?)`
 
 - **Parameters**
   - `config: Config` – resolved configuration.
   - `source: DocumentSource` – document source used to resolve lint targets.
   - `loader?: PluginLoader` – optional plugin loader.
+  - `cacheProvider?: CacheProvider` – optional cache provider.
 - **Returns** `Linter` instance.
 
-#### `lintFiles(targets, fix?, cache?, additionalIgnorePaths?, cacheLocation?)`
+#### `lintFiles(targets, fix?, additionalIgnorePaths?)`
 
 - **Parameters**
   - `targets: string[]` – file paths or glob patterns to lint.
   - `fix = false` – whether to apply automatic fixes.
-  - `cache?: Cache` – optional file cache.
   - `additionalIgnorePaths: string[] = []` – extra ignore globs.
-  - `cacheLocation?: string` – path where cache data is stored.
 - **Returns** `Promise<{ results: LintResult[]; ignoreFiles: string[]; warning?: string; }>`
 - **Throws** if reading or parsing files fails.
 
-#### `lintFile(path, fix?, cache?, ignorePaths?, cacheLocation?)`
+#### `lintFile(path, fix?, ignorePaths?)`
 
 - **Parameters**
   - `path: string` – path to a single file.
-  - Other parameters mirror `lintFiles`.
+  - `fix = false` – whether to apply automatic fixes.
+  - `ignorePaths: string[] = []` – extra ignore globs.
 - **Returns** `Promise<LintResult>`
 - **Throws** if the file cannot be processed.
 
@@ -140,14 +140,12 @@ Executes linting tasks with concurrency control.
     - `lintText: (text: string, filePath: string, metadata?: Record<string, unknown>) => Promise<LintResult>`
     - `source: DocumentSource`
 
-#### `run(targets, fix?, cache?, additionalIgnorePaths?, cacheLocation?)`
+#### `run(documents, fix?, cache?)`
 
 - **Parameters**
-  - `targets: string[]`
+  - `documents: LintDocument[]`
   - `fix = false`
-  - `cache?: Cache`
-  - `additionalIgnorePaths: string[] = []`
-  - `cacheLocation?: string`
+  - `cache?: CacheProvider`
 - **Returns** `Promise<{ results: LintResult[]; ignoreFiles: string[]; warning?: string; }>`
 
 ### `builtInRules`

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -51,17 +51,21 @@ export async function prepareEnvironment(
   if (config.configPath) {
     config.configPath = realpathIfExists(config.configPath);
   }
-  const linterRef = {
-    current: new Linter(config, new FileSource(), new NodePluginLoader()),
-  };
-  const pluginPaths = await linterRef.current.getPluginPaths();
-
   const cacheLocation = options.cache
     ? path.resolve(process.cwd(), options.cacheLocation ?? '.designlintcache')
     : undefined;
   const cache = cacheLocation
     ? new NodeCacheProvider(cacheLocation)
     : undefined;
+  const linterRef = {
+    current: new Linter(
+      config,
+      new FileSource(),
+      new NodePluginLoader(),
+      cache,
+    ),
+  };
+  const pluginPaths = await linterRef.current.getPluginPaths();
 
   let ignorePath: string | undefined;
   if (options.ignorePath) {

--- a/src/cli/execute.ts
+++ b/src/cli/execute.ts
@@ -2,7 +2,6 @@ import { performance } from 'node:perf_hooks';
 import chalk from 'chalk';
 import writeFileAtomic from 'write-file-atomic';
 import type { LintResult } from '../core/types.js';
-import type { CacheProvider } from '../core/cache-provider.js';
 import type { Linter } from '../core/linter.js';
 
 export interface ExecuteOptions {
@@ -17,8 +16,6 @@ export interface ExecuteOptions {
 export interface ExecuteServices {
   formatter: (results: LintResult[], useColor?: boolean) => string;
   linterRef: { current: Linter };
-  cache?: CacheProvider;
-  cacheLocation?: string;
   ignorePath?: string;
   state: { pluginPaths: string[]; ignoreFilePaths: string[] };
   useColor: boolean;
@@ -37,9 +34,7 @@ export async function executeLint(
   } = await services.linterRef.current.lintFiles(
     targets,
     opts.fix,
-    services.cache,
     services.ignorePath ? [services.ignorePath] : [],
-    services.cacheLocation,
   );
   const duration = performance.now() - start;
   if (warning && !opts.quiet) console.warn(warning);

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -51,6 +51,8 @@ export interface WatchServices extends ExecuteServices {
   gitIgnore: string;
   state: WatchState;
   getIg: () => Ignore;
+  cache?: CacheProvider;
+  cacheLocation?: string;
 }
 
 export async function watchMode(
@@ -181,6 +183,7 @@ export async function startWatch(ctx: WatchOptions) {
         config,
         new FileSource(),
         new NodePluginLoader(),
+        cache,
       );
       await refreshIgnore();
       if (cache) {

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -71,8 +71,8 @@ export class CacheManager {
     }
   }
 
-  async save(cacheLocation?: string): Promise<void> {
-    if (cacheLocation && this.cache) {
+  async save(): Promise<void> {
+    if (this.cache) {
       await this.cache.save();
     }
   }

--- a/src/core/cache-service.ts
+++ b/src/core/cache-service.ts
@@ -17,7 +17,7 @@ export const CacheService = {
     return new CacheManager(cache, fix);
   },
 
-  async save(manager: CacheManager, cacheLocation?: string): Promise<void> {
-    await manager.save(cacheLocation);
+  async save(manager: CacheManager): Promise<void> {
+    await manager.save();
   },
 } as const;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -38,7 +38,6 @@ export class Runner {
     documents: LintDocument[],
     fix = false,
     cache?: CacheProvider,
-    cacheLocation?: string,
   ): Promise<{
     results: LintResult[];
     ignoreFiles: string[];
@@ -71,7 +70,7 @@ export class Runner {
         this.config.configPath ?? 'designlint.config',
       ),
     );
-    await CacheService.save(cacheManager, cacheLocation);
+    await CacheService.save(cacheManager);
     return { results, ignoreFiles };
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1062,7 +1062,6 @@ void test('CLI cache updates after --fix run', async () => {
     tokens: { deprecations: { old: { replacement: 'new' } } },
     rules: { 'design-system/deprecation': 'error' },
   };
-  const linter = new Linter(config, new FileSource());
   const store = new Map<
     string,
     {
@@ -1097,8 +1096,9 @@ void test('CLI cache updates after --fix run', async () => {
       return Promise.resolve();
     },
   };
-  const { results: res1 } = await linter.lintFiles([file], true, cache);
-  const { results: res2 } = await linter.lintFiles([file], false, cache);
+  const linter = new Linter(config, new FileSource(), undefined, cache);
+  const { results: res1 } = await linter.lintFiles([file], true);
+  const { results: res2 } = await linter.lintFiles([file], false);
   assert.equal(res1[0].messages.length, 0);
   assert.strictEqual(res1[0], res2[0]);
 });

--- a/tests/core/cache-service.test.ts
+++ b/tests/core/cache-service.test.ts
@@ -25,12 +25,12 @@ void test('CacheService.save delegates to CacheManager.save', async () => {
     constructor() {
       super(undefined, false);
     }
-    override save(loc?: string): Promise<void> {
-      if (loc === 'cache') this.saved = true;
+    override save(): Promise<void> {
+      this.saved = true;
       return Promise.resolve();
     }
   }
   const manager = new TestManager();
-  await CacheService.save(manager, 'cache');
+  await CacheService.save(manager);
   assert.ok(manager.saved);
 });

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -211,9 +211,7 @@ void test('additional ignore file is respected', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.'], false, undefined, [
-      extra,
-    ]);
+    const { results } = await linter.lintFiles(['.'], false, [extra]);
     const files = results.map((r) => path.relative(dir, r.filePath)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {


### PR DESCRIPTION
## Summary
- pass Node-specific FileSource, PluginLoader, and optional NodeCacheProvider to Linter
- simplify Linter API to accept cache provider via constructor and drop cache args
- update CLI tests and docs for new initialization

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c023798ff8832886058874745a7f16