### PR TITLE
refactor(core): use environment object for linter

### DIFF
--- a/.changeset/linter-environment-refactor.md
+++ b/.changeset/linter-environment-refactor.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': major
+---
+
+refactor linter to accept environment object and delegate token normalization to token provider

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -57,13 +57,13 @@ export async function prepareEnvironment(
   const cache = cacheLocation
     ? new NodeCacheProvider(cacheLocation)
     : undefined;
+  const linterEnv = {
+    documentSource: new FileSource(),
+    pluginLoader: new NodePluginLoader(),
+    cacheProvider: cache,
+  };
   const linterRef = {
-    current: new Linter(
-      config,
-      new FileSource(),
-      new NodePluginLoader(),
-      cache,
-    ),
+    current: new Linter(config, linterEnv),
   };
   const pluginPaths = await linterRef.current.getPluginPaths();
 

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -179,12 +179,11 @@ export async function startWatch(ctx: WatchOptions) {
         : createRequire(import.meta.url);
       for (const p of pluginPaths) Reflect.deleteProperty(req.cache, p);
       config = await loadConfig(process.cwd(), options.config);
-      linterRef.current = new Linter(
-        config,
-        new FileSource(),
-        new NodePluginLoader(),
-        cache,
-      );
+      linterRef.current = new Linter(config, {
+        documentSource: new FileSource(),
+        pluginLoader: new NodePluginLoader(),
+        cacheProvider: cache,
+      });
       await refreshIgnore();
       if (cache) {
         const keys = await cache.keys();

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -1,5 +1,7 @@
 import type { Config } from './linter.js';
-import type { DesignTokens } from './types.js';
+import type { PluginLoader } from './plugin-loader.js';
+import type { CacheProvider } from './cache-provider.js';
+import type { NormalizedTokens } from './token-utils.js';
 
 export interface LintDocument {
   id: string;
@@ -17,18 +19,12 @@ export interface DocumentSource {
 }
 
 export interface TokenProvider {
-  load(): Promise<DesignTokens>;
-}
-
-export interface SourceAdapter {
-  scan(
-    targets: string[],
-    config: Config,
-    additionalIgnorePaths?: string[],
-  ): Promise<LintDocument[]>;
+  load(): Promise<NormalizedTokens>;
 }
 
 export interface Environment {
-  source: SourceAdapter;
+  documentSource: DocumentSource;
+  pluginLoader?: PluginLoader;
+  cacheProvider?: CacheProvider;
   tokenProvider?: TokenProvider;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,7 +4,6 @@ export { Runner } from './runner.js';
 export type {
   Environment,
   TokenProvider,
-  SourceAdapter,
   DocumentSource,
   LintDocument,
 } from './environment.js';

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -1,4 +1,5 @@
 import type { DesignTokens, LintResult } from './types.js';
+import type { TokenProvider } from './environment.js';
 
 type TokenType = 'cssVar' | 'hexColor' | 'numeric' | 'string';
 
@@ -33,18 +34,28 @@ export class TokenTracker {
   private allTokenValues = new Set<string>();
   private usedTokenValues = new Set<string>();
   private unusedTokenRules: UnusedRuleConfig[] = [];
+  private provider?: TokenProvider;
+  private loaded = false;
 
-  constructor(tokens?: DesignTokens) {
-    this.allTokenValues = collectTokenValues(tokens);
+  constructor(provider?: TokenProvider) {
+    this.provider = provider;
   }
 
-  configure(
+  private async loadTokens(): Promise<void> {
+    if (this.loaded) return;
+    const tokens = (await this.provider?.load())?.merged;
+    this.allTokenValues = collectTokenValues(tokens);
+    this.loaded = true;
+  }
+
+  async configure(
     rules: {
       rule: { name: string };
       options?: unknown;
       severity: 'error' | 'warn';
     }[],
-  ): void {
+  ): Promise<void> {
+    await this.loadTokens();
     const unusedRules = rules.filter(isUnusedTokenRule);
     this.unusedTokenRules = unusedRules.map((u) => ({
       ruleId: u.rule.name,
@@ -57,7 +68,8 @@ export class TokenTracker {
     return this.unusedTokenRules.length > 0;
   }
 
-  trackUsage(text: string): void {
+  async trackUsage(text: string): Promise<void> {
+    await this.loadTokens();
     for (const token of this.allTokenValues) {
       if (this.usedTokenValues.has(token)) continue;
       const tokenType = getTokenType(token);

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -4,14 +4,21 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
 import { FileSource } from '../../src/node/file-source.ts';
+import type { Environment } from '../../src/core/environment.ts';
 
 void test('Linter integrates registry, parser and trackers', async () => {
+  const env: Environment = {
+    documentSource: new FileSource(),
+    tokenProvider: {
+      load: () => Promise.resolve({ themes: { default: {} }, merged: {} }),
+    },
+  };
   const linter = new Linter(
     {
       tokens: {},
       rules: { 'design-token/colors': 'error' },
     },
-    new FileSource(),
+    env,
   );
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
   const file = path.join(dir, 'file.css');

--- a/tests/core/runner.test.ts
+++ b/tests/core/runner.test.ts
@@ -40,7 +40,7 @@ void test('Runner handles non-positive concurrency values', async () => {
   await fs.writeFile(file, 'a{color:red}');
   const runner = new Runner({
     config: { concurrency: 0, tokens: {} },
-    tokenTracker: new TokenTracker({}),
+    tokenTracker: new TokenTracker(),
     lintDocument: (text, filePath) =>
       Promise.resolve({ filePath, messages: [] }),
   });
@@ -57,7 +57,7 @@ void test('Runner prunes cache and saves results', async () => {
   await cache.set('ghost.css', { mtime: 0, size: 0, result: {} });
   const runner = new Runner({
     config: { tokens: {} },
-    tokenTracker: new TokenTracker({}),
+    tokenTracker: new TokenTracker(),
     lintDocument: (text, filePath) =>
       Promise.resolve({ filePath, messages: [] }),
   });

--- a/tests/core/token-tracker.test.ts
+++ b/tests/core/token-tracker.test.ts
@@ -2,93 +2,101 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { TokenTracker } from '../../src/core/token-tracker.ts';
 import type { DesignTokens } from '../../src/core/types.ts';
+import type { TokenProvider } from '../../src/core/environment.ts';
 
-void test('TokenTracker reports unused tokens', () => {
+function makeProvider(tokens: DesignTokens): TokenProvider {
+  return {
+    load: () =>
+      Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+  };
+}
+
+void test('TokenTracker reports unused tokens', async () => {
   const tokens: DesignTokens = {
     colors: { red: 'var(--red)' },
     spacing: ['4px'],
   };
-  const tracker = new TokenTracker(tokens);
-  tracker.configure([
+  const tracker = new TokenTracker(makeProvider(tokens));
+  await tracker.configure([
     {
       rule: { name: 'design-system/no-unused-tokens' },
       options: {},
       severity: 'error',
     },
   ]);
-  tracker.trackUsage('const c = "var(--red)";');
+  await tracker.trackUsage('const c = "var(--red)";');
   const reports = tracker.generateReports('config');
   assert.equal(reports.length, 1);
   assert.equal(reports[0].messages[0].message.includes('4px'), true);
 });
 
-void test('cssVar classifier tracks custom property usage', () => {
+void test('cssVar classifier tracks custom property usage', async () => {
   const tokens: DesignTokens = {
     colors: { used: 'var(--used)', unused: 'var(--unused)' },
   };
-  const tracker = new TokenTracker(tokens);
-  tracker.configure([
+  const tracker = new TokenTracker(makeProvider(tokens));
+  await tracker.configure([
     {
       rule: { name: 'design-system/no-unused-tokens' },
       options: {},
       severity: 'error',
     },
   ]);
-  tracker.trackUsage('color: var(--used);');
+  await tracker.trackUsage('color: var(--used);');
   const reports = tracker.generateReports('config');
   assert.equal(reports.length, 1);
   assert.equal(reports[0].messages[0].message.includes('--unused'), true);
 });
 
-void test('hexColor classifier is case-insensitive', () => {
+void test('hexColor classifier is case-insensitive', async () => {
   const tokens: DesignTokens = {
     colors: { brand: '#ABCDEF', other: '#123456' },
   };
-  const tracker = new TokenTracker(tokens);
-  tracker.configure([
+  const tracker = new TokenTracker(makeProvider(tokens));
+  await tracker.configure([
     {
       rule: { name: 'design-system/no-unused-tokens' },
       options: {},
       severity: 'error',
     },
   ]);
-  tracker.trackUsage('color: #abcdef;');
+  await tracker.trackUsage('color: #abcdef;');
   const reports = tracker.generateReports('config');
   assert.equal(reports.length, 1);
   assert.equal(reports[0].messages[0].message.includes('#123456'), true);
 });
 
-void test('numeric classifier matches number tokens', () => {
+void test('numeric classifier matches number tokens', async () => {
   const tokens: DesignTokens = {
     spacing: ['4px', '8px'],
   };
-  const tracker = new TokenTracker(tokens);
-  tracker.configure([
+  const tracker = new TokenTracker(makeProvider(tokens));
+  await tracker.configure([
     {
       rule: { name: 'design-system/no-unused-tokens' },
       options: {},
       severity: 'error',
     },
   ]);
-  tracker.trackUsage('margin: 4px');
+  await tracker.trackUsage('margin: 4px');
   const reports = tracker.generateReports('config');
   assert.equal(reports.length, 1);
   assert.equal(reports[0].messages[0].message.includes('8px'), true);
 });
 
-void test('string classifier matches plain string tokens', () => {
+void test('string classifier matches plain string tokens', async () => {
   const tokens: DesignTokens = {
     colors: { used: 'red', unused: 'blue' },
   };
-  const tracker = new TokenTracker(tokens);
-  tracker.configure([
+  const tracker = new TokenTracker(makeProvider(tokens));
+  await tracker.configure([
     {
       rule: { name: 'design-system/no-unused-tokens' },
       options: {},
       severity: 'error',
     },
   ]);
-  tracker.trackUsage('color: red;');
+  await tracker.trackUsage('color: red;');
   const reports = tracker.generateReports('config');
   assert.equal(reports.length, 1);
   assert.equal(reports[0].messages[0].message.includes('blue'), true);

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
 import { FileSource } from '../../src/node/file-source.ts';
+import type { Environment } from '../../src/core/environment.ts';
 
 async function tempFile(content: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'tmp-'));
@@ -14,12 +15,19 @@ async function tempFile(content: string): Promise<string> {
 
 void test('design-system/no-unused-tokens reports unused tokens', async () => {
   const file = await tempFile('const color = "#000000";');
+  const tokens = { colors: { primary: '#000000', unused: '#123456' } };
+  const env: Environment = {
+    documentSource: new FileSource(),
+    tokenProvider: {
+      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+    },
+  };
   const linter = new Linter(
     {
-      tokens: { colors: { primary: '#000000', unused: '#123456' } },
+      tokens,
       rules: { 'design-system/no-unused-tokens': 'warn' },
     },
-    new FileSource(),
+    env,
   );
   const { results } = await linter.lintFiles([file]);
   const msg = results
@@ -32,12 +40,19 @@ void test('design-system/no-unused-tokens reports unused tokens', async () => {
 
 void test('design-system/no-unused-tokens passes when tokens used', async () => {
   const file = await tempFile('const color = "#000000";');
+  const tokens = { colors: { primary: '#000000' } };
+  const env: Environment = {
+    documentSource: new FileSource(),
+    tokenProvider: {
+      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+    },
+  };
   const linter = new Linter(
     {
-      tokens: { colors: { primary: '#000000' } },
+      tokens,
       rules: { 'design-system/no-unused-tokens': 'error' },
     },
-    new FileSource(),
+    env,
   );
   const { results } = await linter.lintFiles([file]);
   const has = results.some((r) =>
@@ -48,14 +63,21 @@ void test('design-system/no-unused-tokens passes when tokens used', async () => 
 
 void test('design-system/no-unused-tokens can ignore tokens', async () => {
   const file = await tempFile('const color = "#000000";');
+  const tokens = { colors: { primary: '#000000', unused: '#123456' } };
+  const env: Environment = {
+    documentSource: new FileSource(),
+    tokenProvider: {
+      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+    },
+  };
   const linter = new Linter(
     {
-      tokens: { colors: { primary: '#000000', unused: '#123456' } },
+      tokens,
       rules: {
         'design-system/no-unused-tokens': ['warn', { ignore: ['#123456'] }],
       },
     },
-    new FileSource(),
+    env,
   );
   const { results } = await linter.lintFiles([file]);
   const has = results.some((r) =>
@@ -66,12 +88,19 @@ void test('design-system/no-unused-tokens can ignore tokens', async () => {
 
 void test('design-system/no-unused-tokens matches hex case-insensitively', async () => {
   const file = await tempFile('const color = "#ABCDEF";');
+  const tokens = { colors: { primary: '#abcdef' } };
+  const env: Environment = {
+    documentSource: new FileSource(),
+    tokenProvider: {
+      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+    },
+  };
   const linter = new Linter(
     {
-      tokens: { colors: { primary: '#abcdef' } },
+      tokens,
       rules: { 'design-system/no-unused-tokens': 'warn' },
     },
-    new FileSource(),
+    env,
   );
   const { results } = await linter.lintFiles([file]);
   const has = results.some((r) =>


### PR DESCRIPTION
## Summary
- refactor Linter to consume a unified Environment object
- delegate token handling to TokenProvider and update TokenTracker
- adapt CLI and tests to new Environment-based API

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c02ed31eb483288799d21889a045ec