### PR TITLE
refactor: add NodeEnvironment and reorganize node adapters

### DIFF
--- a/.changeset/node-environment-refactor.md
+++ b/.changeset/node-environment-refactor.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor node adapters into adapters/node and add NodeEnvironment factory

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ Starting with document discovery, a `DocumentSource` enumerates raw content from
 
 ### DocumentSource
 
-Provides documents from an environment and defines how they are refreshed. The Node adapter [`FileSource`](https://github.com/bylapidist/design-lint/blob/main/src/node/file-source.ts) reads from the filesystem. Future integrations could stream documents from IDEs, design tools or remote APIs.
+Provides documents from an environment and defines how they are refreshed. The Node adapter [`FileSource`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/file-source.ts) reads from the filesystem. Future integrations could stream documents from IDEs, design tools or remote APIs.
 
 ### Parser adapters
 
@@ -26,11 +26,11 @@ Streams lint results through built-in or custom formatters. See [`src/formatters
 
 ### PluginLoader
 
-Resolves and loads configuration packages, rules and formatters. The Node adapter [`PluginLoader`](https://github.com/bylapidist/design-lint/blob/main/src/node/plugin-loader.ts) uses Node's module resolution, with room for runtimes like Deno or Bun.
+Resolves and loads configuration packages, rules and formatters. The Node adapter [`PluginLoader`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/plugin-loader.ts) uses Node's module resolution, with room for runtimes like Deno or Bun.
 
 ### CacheProvider
 
-Stores metadata and parsed documents across runs. The Node implementation [`NodeCacheProvider`](https://github.com/bylapidist/design-lint/blob/main/src/node/node-cache-provider.ts) caches to disk; alternative providers could target cloud storage or in-memory caches.
+Stores metadata and parsed documents across runs. The Node implementation [`NodeCacheProvider`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/node-cache-provider.ts) caches to disk; alternative providers could target cloud storage or in-memory caches.
 
 ## Performance considerations
 

--- a/src/adapters/node/environment.ts
+++ b/src/adapters/node/environment.ts
@@ -1,0 +1,25 @@
+import type { Environment } from '../../core/environment.js';
+import type { Config } from '../../core/linter.js';
+import { FileSource } from './file-source.js';
+import { NodePluginLoader } from './plugin-loader.js';
+import { NodeCacheProvider } from './node-cache-provider.js';
+import { ConfigTokenProvider } from '../../config/config-token-provider.js';
+
+export interface NodeEnvironmentOptions {
+  cacheLocation?: string;
+}
+
+export function NodeEnvironment(
+  config: Config,
+  options: NodeEnvironmentOptions = {},
+): Environment {
+  const { cacheLocation } = options;
+  return {
+    documentSource: new FileSource(),
+    pluginLoader: new NodePluginLoader(),
+    cacheProvider: cacheLocation
+      ? new NodeCacheProvider(cacheLocation)
+      : undefined,
+    tokenProvider: new ConfigTokenProvider(config),
+  };
+}

--- a/src/adapters/node/file-document.ts
+++ b/src/adapters/node/file-document.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import type { LintDocument } from '../core/environment.js';
+import type { LintDocument } from '../../core/environment.js';
 
 export function createFileDocument(filePath: string): LintDocument {
   const absPath = path.resolve(filePath);

--- a/src/adapters/node/file-source.ts
+++ b/src/adapters/node/file-source.ts
@@ -1,9 +1,9 @@
 import { globby } from 'globby';
 import { performance } from 'node:perf_hooks';
-import { realpathIfExists } from '../utils/paths.js';
-import { getIgnorePatterns } from '../core/ignore.js';
-import type { Config } from '../core/linter.js';
-import type { DocumentSource } from '../core/environment.js';
+import { realpathIfExists } from '../../utils/paths.js';
+import { getIgnorePatterns } from '../../core/ignore.js';
+import type { Config } from '../../core/linter.js';
+import type { DocumentSource } from '../../core/environment.js';
 import { createFileDocument } from './file-document.js';
 
 const defaultPatterns = [

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -2,3 +2,4 @@ export { FileSource } from './file-source.js';
 export { createFileDocument } from './file-document.js';
 export { NodePluginLoader } from './plugin-loader.js';
 export { NodeCacheProvider } from './node-cache-provider.js';
+export { NodeEnvironment } from './environment.js';

--- a/src/adapters/node/node-cache-provider.ts
+++ b/src/adapters/node/node-cache-provider.ts
@@ -1,6 +1,6 @@
 import flatCache, { type FlatCache } from 'flat-cache';
 import path from 'path';
-import type { CacheProvider, CacheEntry } from '../core/cache-provider.js';
+import type { CacheProvider, CacheEntry } from '../../core/cache-provider.js';
 
 export class NodeCacheProvider implements CacheProvider {
   private cache: FlatCache;

--- a/src/adapters/node/plugin-loader.ts
+++ b/src/adapters/node/plugin-loader.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
 import { pathToFileURL } from 'url';
-import { realpathIfExists, relFromCwd } from '../utils/paths.js';
-import type { PluginModule } from '../core/types.js';
-import type { PluginLoader, LoadedPlugin } from '../core/plugin-loader.js';
-import { createEngineError } from '../core/plugin-manager.js';
+import { realpathIfExists, relFromCwd } from '../../utils/paths.js';
+import type { PluginModule } from '../../core/types.js';
+import type { PluginLoader, LoadedPlugin } from '../../core/plugin-loader.js';
+import { createEngineError } from '../../core/plugin-manager.js';
 
 export class NodePluginLoader implements PluginLoader {
   async load(p: string, configPath?: string): Promise<LoadedPlugin> {

--- a/src/config/config-token-provider.ts
+++ b/src/config/config-token-provider.ts
@@ -1,0 +1,17 @@
+import type { Config } from '../core/linter.js';
+import type { TokenProvider } from '../core/environment.js';
+import { normalizeTokens } from '../core/token-utils.js';
+
+export class ConfigTokenProvider implements TokenProvider {
+  private config: Config;
+
+  constructor(config: Config) {
+    this.config = config;
+  }
+
+  load() {
+    return Promise.resolve(
+      normalizeTokens(this.config.tokens, this.config.wrapTokensWithVar),
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './core/index.js';
-export * from './node/index.js';
+export * from './adapters/node/index.js';
 export { loadConfig } from './config/loader.js';
 export { defineConfig } from './config/define-config.js';
 export { getFormatter } from './formatters/index.js';

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { NodeCacheProvider } from '../src/node/node-cache-provider.ts';
+import { NodeCacheProvider } from '../src/adapters/node/node-cache-provider.ts';
 import type { LintResult } from '../src/core/types.ts';
 
 void test('NodeCacheProvider loads and saves entries via flat-cache', async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -5,7 +5,7 @@ import { makeTmpDir } from '../src/utils/tmp.ts';
 import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('returns default config when none found', async () => {
   const tmp = makeTmpDir();

--- a/tests/core/cache-manager.test.ts
+++ b/tests/core/cache-manager.test.ts
@@ -5,7 +5,7 @@ import { promises as fs } from 'fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { LintResult } from '../../src/core/types.ts';
-import { createFileDocument } from '../../src/node/file-document.ts';
+import { createFileDocument } from '../../src/adapters/node/file-document.ts';
 
 void test('CacheManager applies fixes when enabled', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cm-'));

--- a/tests/core/glob-ignore.test.ts
+++ b/tests/core/glob-ignore.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { makeTmpDir } from '../../src/utils/tmp.ts';
 import type { Config } from '../../src/core/linter.ts';
 

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 import type { Environment } from '../../src/core/environment.ts';
 
 void test('Linter integrates registry, parser and trackers', async () => {

--- a/tests/core/parser-registry.test.ts
+++ b/tests/core/parser-registry.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { parserRegistry } from '../../src/core/parser-registry.ts';
-import { createFileDocument } from '../../src/node/file-document.ts';
+import { createFileDocument } from '../../src/adapters/node/file-document.ts';
 import type {
   RuleModule,
   RuleContext,

--- a/tests/core/profile.test.ts
+++ b/tests/core/profile.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../../src/utils/tmp.ts';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 import type { Config } from '../../src/core/linter.ts';
 import type { Environment } from '../../src/core/environment.ts';
 

--- a/tests/core/runner.test.ts
+++ b/tests/core/runner.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Runner } from '../../src/index.ts';
 import { TokenTracker } from '../../src/core/token-tracker.ts';
-import { createFileDocument } from '../../src/node/file-document.ts';
+import { createFileDocument } from '../../src/adapters/node/file-document.ts';
 
 interface CacheEntry {
   mtime: number;

--- a/tests/glob.test.ts
+++ b/tests/glob.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('lintFiles expands glob patterns with globby', async () => {
   const dir = makeTmpDir();

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('lintFiles ignores common directories by default', async () => {
   const dir = makeTmpDir();

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('inline directives disable linting', async () => {
   const dir = makeTmpDir();

--- a/tests/lint-file.test.ts
+++ b/tests/lint-file.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
-import { createFileDocument } from '../src/node/file-document.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
+import { createFileDocument } from '../src/adapters/node/file-document.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');

--- a/tests/patterns.test.ts
+++ b/tests/patterns.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('lintFiles uses patterns option to include custom extensions', async () => {
   const tmp = makeTmpDir();

--- a/tests/performance.test.ts
+++ b/tests/performance.test.ts
@@ -5,7 +5,7 @@ import { makeTmpDir } from '../src/utils/tmp.ts';
 import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('lints large projects without crashing', async () => {
   const dir = path.join(__dirname, 'fixtures', 'large-project');

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -2,9 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
-import { NodePluginLoader } from '../src/node/plugin-loader.ts';
+import { NodePluginLoader } from '../src/adapters/node/plugin-loader.ts';
 import type { PluginLoader } from '../src/core/plugin-loader.ts';
 import type { PluginModule, RuleModule } from '../src/core/types.ts';
 

--- a/tests/rules/animation.test.ts
+++ b/tests/rules/animation.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/animation reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/blur.test.ts
+++ b/tests/rules/blur.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/blur reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/border-color.test.ts
+++ b/tests/rules/border-color.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/border-color reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/border-radius.test.ts
+++ b/tests/rules/border-radius.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/border-radius reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/border-width.test.ts
+++ b/tests/rules/border-width.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/border-width reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/box-shadow.test.ts
+++ b/tests/rules/box-shadow.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/box-shadow reports disallowed value', async () => {
   const linter = new Linter(

--- a/tests/rules/colors.test.ts
+++ b/tests/rules/colors.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/colors reports disallowed hex', async () => {
   const linter = new Linter(

--- a/tests/rules/component-prefix.test.ts
+++ b/tests/rules/component-prefix.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-prefix enforces prefix on components', async () => {

--- a/tests/rules/component-usage.test.ts
+++ b/tests/rules/component-usage.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-usage suggests substitutions', async () => {

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/deprecation flags deprecated token', async () => {
   const linter = new Linter(

--- a/tests/rules/duration.test.ts
+++ b/tests/rules/duration.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/duration reports invalid transition duration', async () => {
   const linter = new Linter(

--- a/tests/rules/font-family.test.ts
+++ b/tests/rules/font-family.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/font-family reports invalid font-family', async () => {
   const linter = new Linter(

--- a/tests/rules/font-size.test.ts
+++ b/tests/rules/font-size.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/font-size reports invalid font-size', async () => {
   const linter = new Linter(

--- a/tests/rules/font-weight.test.ts
+++ b/tests/rules/font-weight.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/font-weight reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/icon-usage.test.ts
+++ b/tests/rules/icon-usage.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/icon-usage reports raw svg', async () => {

--- a/tests/rules/import-path.test.ts
+++ b/tests/rules/import-path.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/import-path flags components from wrong package', async () => {
   const linter = new Linter(

--- a/tests/rules/letter-spacing.test.ts
+++ b/tests/rules/letter-spacing.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/letter-spacing reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/line-height.test.ts
+++ b/tests/rules/line-height.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/line-height reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/no-inline-styles.test.ts
+++ b/tests/rules/no-inline-styles.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/no-inline-styles flags style attribute on components', async () => {
   const linter = new Linter(

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 import type { Environment } from '../../src/core/environment.ts';
 
 async function tempFile(content: string): Promise<string> {
@@ -19,7 +19,8 @@ void test('design-system/no-unused-tokens reports unused tokens', async () => {
   const env: Environment = {
     documentSource: new FileSource(),
     tokenProvider: {
-      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+      load: () =>
+        Promise.resolve({ themes: { default: tokens }, merged: tokens }),
     },
   };
   const linter = new Linter(
@@ -44,7 +45,8 @@ void test('design-system/no-unused-tokens passes when tokens used', async () => 
   const env: Environment = {
     documentSource: new FileSource(),
     tokenProvider: {
-      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+      load: () =>
+        Promise.resolve({ themes: { default: tokens }, merged: tokens }),
     },
   };
   const linter = new Linter(
@@ -67,7 +69,8 @@ void test('design-system/no-unused-tokens can ignore tokens', async () => {
   const env: Environment = {
     documentSource: new FileSource(),
     tokenProvider: {
-      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+      load: () =>
+        Promise.resolve({ themes: { default: tokens }, merged: tokens }),
     },
   };
   const linter = new Linter(
@@ -92,7 +95,8 @@ void test('design-system/no-unused-tokens matches hex case-insensitively', async
   const env: Environment = {
     documentSource: new FileSource(),
     tokenProvider: {
-      load: () => Promise.resolve({ themes: { default: tokens }, merged: tokens }),
+      load: () =>
+        Promise.resolve({ themes: { default: tokens }, merged: tokens }),
     },
   };
   const linter = new Linter(

--- a/tests/rules/opacity.test.ts
+++ b/tests/rules/opacity.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/opacity reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/outline.test.ts
+++ b/tests/rules/outline.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/outline reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/rules/parse-error.test.ts
+++ b/tests/rules/parse-error.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('reports CSS parse errors', async () => {
   const linter = new Linter({}, new FileSource());

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/spacing enforces multiples', async () => {
   const linter = new Linter(

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 const config = {
   tokens: {

--- a/tests/rules/token-colors.test.ts
+++ b/tests/rules/token-colors.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/colors reports disallowed hwb', async () => {
   const linter = new Linter(

--- a/tests/rules/token-suggestion.test.ts
+++ b/tests/rules/token-suggestion.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('suggests closest token name', async () => {
   const linter = new Linter(

--- a/tests/rules/variant-prop.test.ts
+++ b/tests/rules/variant-prop.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/variant-prop flags invalid variant', async () => {
   const linter = new Linter(

--- a/tests/rules/z-index.test.ts
+++ b/tests/rules/z-index.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/node/file-source.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-token/z-index reports invalid value', async () => {
   const linter = new Linter(

--- a/tests/svelte-style-bindings.test.ts
+++ b/tests/svelte-style-bindings.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');

--- a/tests/tagged-template.test.ts
+++ b/tests/tagged-template.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'tagged-template');

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('getTokenCompletions returns token names', () => {
   const linter = new Linter(

--- a/tests/token-patterns.test.ts
+++ b/tests/token-patterns.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 const rule = { 'design-token/colors': 'error' };
 

--- a/tests/token-utils.test.ts
+++ b/tests/token-utils.test.ts
@@ -7,7 +7,7 @@ import {
   extractVarName,
 } from '../src/core/token-utils.ts';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('normalizeTokens wraps values with var when enabled', () => {
   const tokens = { colors: { primary: '--color-primary' } };

--- a/tests/vue-style-bindings.test.ts
+++ b/tests/vue-style-bindings.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Linter } from '../src/core/linter.ts';
-import { FileSource } from '../src/node/file-source.ts';
+import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'vue');


### PR DESCRIPTION
## Summary
- move node-specific sources into `src/adapters/node`
- introduce `ConfigTokenProvider` and `NodeEnvironment` factory
- update imports, docs and CLI to use new adapter path

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c031c48b4083288dcd21d92afe4a03