### PR TITLE
feat(node): add token provider

### DIFF
--- a/.changeset/add-node-token-provider.md
+++ b/.changeset/add-node-token-provider.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+add node token provider and update environment

--- a/src/adapters/node/environment.ts
+++ b/src/adapters/node/environment.ts
@@ -3,7 +3,7 @@ import type { Config } from '../../core/linter.js';
 import { FileSource } from './file-source.js';
 import { NodePluginLoader } from './plugin-loader.js';
 import { NodeCacheProvider } from './node-cache-provider.js';
-import { ConfigTokenProvider } from '../../config/config-token-provider.js';
+import { NodeTokenProvider } from './token-provider.js';
 
 export interface NodeEnvironmentOptions {
   cacheLocation?: string;
@@ -20,6 +20,9 @@ export function NodeEnvironment(
     cacheProvider: cacheLocation
       ? new NodeCacheProvider(cacheLocation)
       : undefined,
-    tokenProvider: new ConfigTokenProvider(config),
+    tokenProvider: new NodeTokenProvider(
+      config.tokens,
+      config.wrapTokensWithVar,
+    ),
   };
 }

--- a/src/adapters/node/token-provider.ts
+++ b/src/adapters/node/token-provider.ts
@@ -1,0 +1,33 @@
+import type { TokenProvider } from '../../core/environment.js';
+import type { DesignTokens } from '../../core/types.js';
+import {
+  normalizeTokens,
+  type NormalizedTokens,
+} from '../../core/token-utils.js';
+
+export class NodeTokenProvider implements TokenProvider {
+  private tokens?: DesignTokens | Record<string, DesignTokens>;
+  private wrapVar: boolean;
+  private normalized?: NormalizedTokens;
+
+  constructor(
+    tokens?: DesignTokens | Record<string, DesignTokens>,
+    wrapTokensWithVar = false,
+  ) {
+    this.tokens = tokens;
+    this.wrapVar = wrapTokensWithVar;
+  }
+
+  load(): Promise<NormalizedTokens> {
+    this.normalized ??= normalizeTokens(this.tokens, this.wrapVar);
+    return Promise.resolve(this.normalized);
+  }
+
+  getTokens(): NormalizedTokens | undefined {
+    return this.normalized;
+  }
+
+  subscribe(): () => void {
+    return () => undefined;
+  }
+}

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -3,23 +3,15 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
-import { FileSource } from '../../src/adapters/node/file-source.ts';
-import type { Environment } from '../../src/core/environment.ts';
+import { NodeEnvironment } from '../../src/adapters/node/environment.ts';
 
 void test('Linter integrates registry, parser and trackers', async () => {
-  const env: Environment = {
-    documentSource: new FileSource(),
-    tokenProvider: {
-      load: () => Promise.resolve({ themes: { default: {} }, merged: {} }),
-    },
+  const config = {
+    tokens: {},
+    rules: { 'design-token/colors': 'error' },
   };
-  const linter = new Linter(
-    {
-      tokens: {},
-      rules: { 'design-token/colors': 'error' },
-    },
-    env,
-  );
+  const env = NodeEnvironment(config);
+  const linter = new Linter(config, env);
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
   const file = path.join(dir, 'file.css');
   await fs.writeFile(file, 'a{color:#fff;}');


### PR DESCRIPTION
## Summary
- add NodeTokenProvider to normalize tokens and expose getTokens/subscribe
- switch NodeEnvironment to NodeTokenProvider
- rely on NodeEnvironment for tokens in linter tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c0362975bc8328a853cc1541a3db8f