### PR TITLE
refactor(node): remove NodeEnvironment alias

### DIFF
--- a/.changeset/remove-nodeenvironment-alias.md
+++ b/.changeset/remove-nodeenvironment-alias.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': major
+---
+
+remove NodeEnvironment backward compatibility alias

--- a/src/adapters/node/environment.ts
+++ b/src/adapters/node/environment.ts
@@ -28,6 +28,3 @@ export function createNodeEnvironment(
     ),
   };
 }
-
-// Backward compatibility for previous name
-export const NodeEnvironment = createNodeEnvironment;

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -2,4 +2,4 @@ export { FileSource } from './file-source.js';
 export { createFileDocument } from './file-document.js';
 export { NodePluginLoader } from './plugin-loader.js';
 export { NodeCacheProvider } from './node-cache-provider.js';
-export { createNodeEnvironment, NodeEnvironment } from './environment.js';
+export { createNodeEnvironment } from './environment.js';

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -3,14 +3,14 @@ import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Linter } from '../../src/core/linter.ts';
-import { NodeEnvironment } from '../../src/adapters/node/environment.ts';
+import { createNodeEnvironment } from '../../src/adapters/node/environment.ts';
 
 void test('Linter integrates registry, parser and trackers', async () => {
   const config = {
     tokens: {},
     rules: { 'design-token/colors': 'error' },
   };
-  const env = NodeEnvironment(config);
+  const env = createNodeEnvironment(config);
   const linter = new Linter(config, env);
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
   const file = path.join(dir, 'file.css');

--- a/tests/core/profile.test.ts
+++ b/tests/core/profile.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../../src/adapters/node/utils/tmp.ts';
 import { Linter } from '../../src/core/linter.ts';
-import { NodeEnvironment } from '../../src/adapters/node/environment.ts';
+import { createNodeEnvironment } from '../../src/adapters/node/environment.ts';
 import type { Config } from '../../src/core/linter.ts';
 
 // Ensure FileSource.scan logs when profiling is enabled
@@ -16,7 +16,7 @@ void test('FileSource.scan logs when DESIGNLINT_PROFILE is set', async () => {
   const dir = makeTmpDir();
   fs.writeFileSync(path.join(dir, 'file.ts'), '');
   const config = { tokens: {}, rules: {} };
-  const env = NodeEnvironment(config);
+  const env = createNodeEnvironment(config);
   const linter = new Linter(config, env);
   const cwd = process.cwd();
   process.chdir(dir);
@@ -44,7 +44,7 @@ void test('FileSource.scan collects files from directory targets', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const env = NodeEnvironment(config);
+    const env = createNodeEnvironment(config);
     const docs = await env.documentSource.scan(['.'], config);
     const rels = docs.map((d) => path.relative(dir, d.id));
     assert.deepEqual(rels, ['a.ts']);


### PR DESCRIPTION
## Summary
- remove `NodeEnvironment` backward compatibility alias and comment
- adjust exports and tests to use `createNodeEnvironment`
- record breaking change in changeset

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c05d237dfc83288ac871b41f28d8d2