### PR TITLE
feat: rename filePath to sourceId

### DIFF
--- a/.changeset/source-id-rename.md
+++ b/.changeset/source-id-rename.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": minor
+---
+
+rename filePath to sourceId in lint results and rule context

--- a/docs/api.md
+++ b/docs/api.md
@@ -137,7 +137,7 @@ Executes linting tasks with concurrency control.
   - `options` – object containing:
     - `config: Config`
     - `tokenTracker: TokenTracker`
-    - `lintText: (text: string, filePath: string, metadata?: Record<string, unknown>) => Promise<LintResult>`
+    - `lintText: (text: string, sourceId: string, metadata?: Record<string, unknown>) => Promise<LintResult>`
     - `source: DocumentSource`
 
 #### `run(documents, fix?, cache?)`

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -35,6 +35,7 @@ Use when you need machine-readable output for scripts or dashboards.
 ```json
 [
   {
+    "sourceId": "a.ts",
     "filePath": "a.ts",
     "messages": [
       {
@@ -93,7 +94,7 @@ my-formatter/
 
 ```js
 export default function (results) {
-  return results.map((r) => r.filePath).join('\n');
+  return results.map((r) => r.sourceId).join('\n');
 }
 ```
 
@@ -103,7 +104,7 @@ export default function (results) {
 import assert from 'node:assert/strict';
 import formatter from './formatter.js';
 
-const out = formatter([{ filePath: 'a.ts', messages: [] }]);
+const out = formatter([{ sourceId: 'a.ts', filePath: 'a.ts', messages: [] }]);
 assert.equal(out, 'a.ts');
 ```
 

--- a/src/adapters/node/file-document.ts
+++ b/src/adapters/node/file-document.ts
@@ -2,8 +2,8 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { LintDocument } from '../../core/environment.js';
 
-export function createFileDocument(filePath: string): LintDocument {
-  const absPath = path.resolve(filePath);
+export function createFileDocument(sourceId: string): LintDocument {
+  const absPath = path.resolve(sourceId);
   const ext = path.extname(absPath).slice(1).toLowerCase();
   const typeMap: Record<string, string> = {
     ts: 'ts',

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -212,8 +212,8 @@ export async function startWatch(ctx: WatchOptions) {
     }
   };
 
-  const handle = async (filePath: string) => {
-    const resolved = realpathIfExists(path.resolve(filePath));
+  const handle = async (sourceId: string) => {
+    const resolved = realpathIfExists(path.resolve(sourceId));
     if (outputPath && resolved === outputPath) return;
     if (reportPath && resolved === reportPath) return;
     if (
@@ -229,8 +229,8 @@ export async function startWatch(ctx: WatchOptions) {
     }
   };
 
-  const handleUnlink = async (filePath: string) => {
-    const resolved = realpathIfExists(path.resolve(filePath));
+  const handleUnlink = async (sourceId: string) => {
+    const resolved = realpathIfExists(path.resolve(sourceId));
     await cache?.remove(resolved);
     if (outputPath && resolved === outputPath) return;
     if (reportPath && resolved === reportPath) return;

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -14,7 +14,7 @@ export class CacheManager {
     doc: LintDocument,
     lintFn: (
       text: string,
-      filePath: string,
+      sourceId: string,
       docType: string,
       metadata?: Record<string, unknown>,
     ) => Promise<LintResult>,
@@ -56,6 +56,7 @@ export class CacheManager {
       await this.cache?.remove(doc.id);
       const message = e instanceof Error ? e.message : 'Failed to read file';
       const result: LintResult = {
+        sourceId: doc.id,
         filePath: doc.id,
         messages: [
           {

--- a/src/core/parser-registry.ts
+++ b/src/core/parser-registry.ts
@@ -6,7 +6,7 @@ import { lintCSS } from './parsers/css-parser.js';
 
 export type ParserStrategy = (
   text: string,
-  filePath: string,
+  sourceId: string,
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ) => Promise<void> | void;

--- a/src/core/parsers/css-parser.ts
+++ b/src/core/parsers/css-parser.ts
@@ -45,11 +45,11 @@ export function parseCSS(
 
 export function lintCSS(
   text: string,
-  filePath: string,
+  sourceId: string,
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ): void {
-  const lower = filePath.toLowerCase();
+  const lower = sourceId.toLowerCase();
   let lang: string | undefined;
   if (lower.endsWith('.scss') || lower.endsWith('.sass')) lang = 'scss';
   else if (lower.endsWith('.less')) lang = 'less';

--- a/src/core/parsers/svelte-parser.ts
+++ b/src/core/parsers/svelte-parser.ts
@@ -5,7 +5,7 @@ import type { parse as svelteParse } from 'svelte/compiler';
 
 export async function lintSvelte(
   text: string,
-  filePath: string,
+  sourceId: string,
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ): Promise<void> {
@@ -108,7 +108,7 @@ export async function lintSvelte(
   for (const scriptContent of scriptBlocks) {
     const combined = `${scriptContent}\nfunction __render(){ return (${templateTsx}); }`;
     const source = ts.createSourceFile(
-      filePath,
+      sourceId,
       combined,
       ts.ScriptTarget.Latest,
       true,

--- a/src/core/parsers/ts-parser.ts
+++ b/src/core/parsers/ts-parser.ts
@@ -4,12 +4,12 @@ import type { RuleModule, LintMessage } from '../types.js';
 
 export function lintTS(
   text: string,
-  filePath: string,
+  sourceId: string,
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ): void {
   const source = ts.createSourceFile(
-    filePath,
+    sourceId,
     text,
     ts.ScriptTarget.Latest,
     true,

--- a/src/core/parsers/vue-parser.ts
+++ b/src/core/parsers/vue-parser.ts
@@ -4,12 +4,12 @@ import type { RuleModule, LintMessage } from '../types.js';
 
 export async function lintVue(
   text: string,
-  filePath: string,
+  sourceId: string,
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ): Promise<void> {
   const { parse } = await import('@vue/compiler-sfc');
-  const { descriptor } = parse(text, { filename: filePath });
+  const { descriptor } = parse(text, { filename: sourceId });
   const template = descriptor.template?.content ?? '';
   const templateTsx = template
     .replace(/class=/g, 'className=')
@@ -25,7 +25,7 @@ export async function lintVue(
   for (const scriptContent of scriptBlocks) {
     const combined = `${scriptContent}\nfunction __render(){ return (${templateTsx}); }`;
     const source = ts.createSourceFile(
-      filePath,
+      sourceId,
       combined,
       ts.ScriptTarget.Latest,
       true,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -12,7 +12,7 @@ export interface RunnerOptions {
   tokenTracker: TokenTracker;
   lintDocument: (
     text: string,
-    filePath: string,
+    sourceId: string,
     docType: string,
     metadata?: Record<string, unknown>,
   ) => Promise<LintResult>;
@@ -23,7 +23,7 @@ export class Runner {
   private tokenTracker: TokenTracker;
   private lintDocumentFn: (
     text: string,
-    filePath: string,
+    sourceId: string,
     docType: string,
     metadata?: Record<string, unknown>,
   ) => Promise<LintResult>;

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -87,6 +87,7 @@ export class TokenTracker {
       );
       if (unused.length) {
         results.push({
+          sourceId: configPath,
           filePath: configPath,
           messages: unused.map((t) => ({
             ruleId,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -54,7 +54,9 @@ export interface LintMessage {
 }
 
 export interface LintResult {
-  filePath: string;
+  sourceId: string;
+  /** @deprecated use sourceId instead */
+  filePath?: string;
   messages: LintMessage[];
   ruleDescriptions?: Record<string, string>;
 }
@@ -64,7 +66,9 @@ export interface RuleContext<TOptions = unknown> {
   tokens: DesignTokens;
   options?: TOptions;
   metadata?: Record<string, unknown>;
-  filePath: string;
+  sourceId: string;
+  /** @deprecated use sourceId instead */
+  filePath?: string;
 }
 
 export interface RuleModule<TOptions = unknown> {

--- a/src/formatters/sarif.ts
+++ b/src/formatters/sarif.ts
@@ -70,7 +70,8 @@ export function sarifFormatter(
         locations: [
           {
             physicalLocation: {
-              artifactLocation: { uri: res.filePath },
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-deprecated
+              artifactLocation: { uri: res.sourceId ?? res.filePath },
               region: { startLine: msg.line, startColumn: msg.column },
             },
           },

--- a/src/formatters/stylish.ts
+++ b/src/formatters/stylish.ts
@@ -13,7 +13,8 @@ export function stylish(results: LintResult[], useColor = true): string {
   let errorCount = 0;
   let warnCount = 0;
   for (const res of results) {
-    const filePath = relFromCwd(res.filePath);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-deprecated
+    const filePath = relFromCwd(res.sourceId ?? res.filePath ?? '');
     if (res.messages.length === 0) {
       const ok = useColor ? codes.green('[OK]') : '[OK]';
       lines.push(`${ok} ${filePath}`);

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -11,7 +11,11 @@ void test('NodeCacheProvider loads and saves entries via flat-cache', async () =
   const file = path.join(dir, 'cache.json');
 
   let cache = new NodeCacheProvider(file);
-  const result: LintResult = { filePath: 'foo', messages: [] };
+  const result: LintResult = {
+    sourceId: 'foo',
+    filePath: 'foo',
+    messages: [],
+  };
   const entry = { mtime: 1, result };
   await cache.set('foo', entry);
   await cache.save();

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -147,10 +147,15 @@ void test('CLI expands glob patterns with braces', () => {
   assert.equal(res.status, 0);
   const out = JSON.parse(res.stdout) as unknown;
   const files = Array.isArray(out)
-    ? (out as { filePath: string }[])
-        .map((r) => path.relative(dir, r.filePath))
+    ? (out as { sourceId: string; filePath?: string }[])
+        .map((r) => path.relative(dir, r.sourceId))
         .sort()
     : [];
+  if (Array.isArray(out)) {
+    for (const r of out as { sourceId: string; filePath?: string }[]) {
+      assert.equal(r.filePath, r.sourceId);
+    }
+  }
   assert.deepEqual(files, ['src/a.module.css', 'src/b.module.scss']);
 });
 
@@ -707,13 +712,17 @@ void test('CLI ignores common directories by default', () => {
     { encoding: 'utf8', cwd: parent },
   );
   interface Result {
-    filePath: string;
+    sourceId: string;
+    filePath?: string;
   }
   const parsed = JSON.parse(res.stdout) as unknown;
   assert(Array.isArray(parsed));
   const files = (parsed as Result[])
-    .map((r) => path.relative(dir, r.filePath))
+    .map((r) => path.relative(dir, r.sourceId))
     .sort();
+  for (const r of parsed as Result[]) {
+    assert.equal(r.filePath, r.sourceId);
+  }
   assert.deepEqual(files, ['src/file.ts']);
 });
 
@@ -758,13 +767,17 @@ void test('.designlintignore can unignore paths via CLI', () => {
     },
   );
   interface Result {
-    filePath: string;
+    sourceId: string;
+    filePath?: string;
   }
   const parsed = JSON.parse(res.stdout) as unknown;
   assert(Array.isArray(parsed));
   const files = (parsed as Result[])
-    .map((r) => path.relative(dir, r.filePath))
+    .map((r) => path.relative(dir, r.sourceId))
     .sort();
+  for (const r of parsed as Result[]) {
+    assert.equal(r.filePath, r.sourceId);
+  }
   assert.deepEqual(files, ['node_modules/pkg/index.ts', 'src/file.ts']);
 });
 
@@ -802,13 +815,17 @@ void test('CLI skips directories listed in .designlintignore', () => {
     { encoding: 'utf8', cwd: dir },
   );
   interface Result {
-    filePath: string;
+    sourceId: string;
+    filePath?: string;
   }
   const parsed = JSON.parse(res.stdout) as unknown;
   assert(Array.isArray(parsed));
   const files = (parsed as Result[])
-    .map((r) => path.relative(dir, r.filePath))
+    .map((r) => path.relative(dir, r.sourceId))
     .sort();
+  for (const r of parsed as Result[]) {
+    assert.equal(r.filePath, r.sourceId);
+  }
   assert.deepEqual(files, ['src/file.ts']);
 });
 
@@ -844,13 +861,17 @@ void test('CLI --ignore-path excludes files', () => {
   );
   assert.notEqual(res.status, 0);
   interface Result {
-    filePath: string;
+    sourceId: string;
+    filePath?: string;
   }
   const parsed = JSON.parse(res.stdout) as unknown;
   assert(Array.isArray(parsed));
   const files = (parsed as Result[])
-    .map((r) => path.relative(dir, r.filePath))
+    .map((r) => path.relative(dir, r.sourceId))
     .sort();
+  for (const r of parsed as Result[]) {
+    assert.equal(r.filePath, r.sourceId);
+  }
   assert.deepEqual(files, ['src/keep.ts']);
 });
 
@@ -967,10 +988,12 @@ void test('CLI --report outputs JSON log', () => {
   assert.ok(fs.existsSync(report));
   const parsed: unknown = JSON.parse(readWhenReady(report));
   const log = parsed as {
-    filePath: string;
+    sourceId: string;
+    filePath?: string;
     messages: { ruleId: string }[];
   }[];
-  assert.equal(path.relative(dir, log[0]?.filePath), 'file.ts');
+  assert.equal(path.relative(dir, log[0]?.sourceId), 'file.ts');
+  assert.equal(log[0]?.filePath, log[0]?.sourceId);
   assert.equal(log[0]?.messages[0]?.ruleId, 'design-system/deprecation');
 });
 

--- a/tests/core/cache-manager.test.ts
+++ b/tests/core/cache-manager.test.ts
@@ -11,10 +11,11 @@ void test('CacheManager applies fixes when enabled', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cm-'));
   const file = path.join(dir, 'a.txt');
   await fs.writeFile(file, 'bad');
-  const lintFn = (text: string, filePath: string): Promise<LintResult> => {
+  const lintFn = (text: string, sourceId: string): Promise<LintResult> => {
     if (text === 'bad') {
       return Promise.resolve({
-        filePath,
+        sourceId,
+        filePath: sourceId,
         messages: [
           {
             ruleId: 'test',
@@ -27,7 +28,7 @@ void test('CacheManager applies fixes when enabled', async () => {
         ],
       });
     }
-    return Promise.resolve({ filePath, messages: [] });
+    return Promise.resolve({ sourceId, filePath: sourceId, messages: [] });
   };
   const manager = new CacheManager(undefined, true);
   const doc = createFileDocument(file);

--- a/tests/core/parser-registry.test.ts
+++ b/tests/core/parser-registry.test.ts
@@ -46,6 +46,7 @@ for (const c of cases) {
     assert.ok(parser, 'parser exists');
     const messages: LintMessage[] = [];
     const ctx: RuleContext = {
+      sourceId: c.filePath,
       filePath: c.filePath,
       tokens: {},
       options: undefined,

--- a/tests/core/runner.test.ts
+++ b/tests/core/runner.test.ts
@@ -41,10 +41,12 @@ void test('Runner handles non-positive concurrency values', async () => {
   const runner = new Runner({
     config: { concurrency: 0, tokens: {} },
     tokenTracker: new TokenTracker(),
-    lintDocument: (text, filePath) =>
-      Promise.resolve({ filePath, messages: [] }),
+    lintDocument: (text, sourceId) =>
+      Promise.resolve({ sourceId, filePath: sourceId, messages: [] }),
   });
   const res = await runner.run([createFileDocument(file)]);
+  assert.equal(res.results[0]?.sourceId, file);
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   assert.equal(res.results[0]?.filePath, file);
   await fs.rm(dir, { recursive: true, force: true });
 });
@@ -58,8 +60,8 @@ void test('Runner prunes cache and saves results', async () => {
   const runner = new Runner({
     config: { tokens: {} },
     tokenTracker: new TokenTracker(),
-    lintDocument: (text, filePath) =>
-      Promise.resolve({ filePath, messages: [] }),
+    lintDocument: (text, sourceId) =>
+      Promise.resolve({ sourceId, filePath: sourceId, messages: [] }),
   });
   await runner.run([createFileDocument(file)], false, cache, 'cache');
   assert.deepEqual(await cache.keys(), [file]);

--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -73,7 +73,8 @@ for (const { name, files } of fixtures) {
     );
     assert.notEqual(result.status, 0);
     interface Result {
-      filePath: string;
+      sourceId: string;
+      filePath?: string;
       messages: { ruleId: string }[];
     }
     const parsed = JSON.parse(result.stdout) as unknown;
@@ -81,10 +82,13 @@ for (const { name, files } of fixtures) {
     const results = parsed as Result[];
     const byFile = Object.fromEntries(
       results.map((r) => [
-        path.relative(fixture, r.filePath),
+        path.relative(fixture, r.sourceId),
         new Set(r.messages.map((m) => m.ruleId)),
       ]),
     );
+    for (const r of results) {
+      assert.equal(r.filePath, r.sourceId);
+    }
     assert.deepEqual(Object.keys(byFile).sort(), files.sort());
     const ruleSet = new Set(
       results.flatMap((r) => r.messages.map((m) => m.ruleId)),

--- a/tests/formatters/formatters.test.ts
+++ b/tests/formatters/formatters.test.ts
@@ -20,6 +20,7 @@ interface SarifLog {
 void test('stylish formatter outputs text', () => {
   const results: LintResult[] = [
     {
+      sourceId: 'file.ts',
       filePath: 'file.ts',
       messages: [
         {
@@ -39,6 +40,7 @@ void test('stylish formatter outputs text', () => {
 void test('stylish formatter outputs suggestions', () => {
   const results: LintResult[] = [
     {
+      sourceId: 'file.ts',
       filePath: 'file.ts',
       messages: [
         {
@@ -58,8 +60,8 @@ void test('stylish formatter outputs suggestions', () => {
 
 void test('stylish formatter outputs OK for files without messages', () => {
   const results: LintResult[] = [
-    { filePath: 'a.ts', messages: [] },
-    { filePath: 'b.ts', messages: [] },
+    { sourceId: 'a.ts', filePath: 'a.ts', messages: [] },
+    { sourceId: 'b.ts', filePath: 'b.ts', messages: [] },
   ];
   const out = stylish(results, false);
   assert.equal(out, '[OK] a.ts\n[OK] b.ts');
@@ -67,7 +69,9 @@ void test('stylish formatter outputs OK for files without messages', () => {
 
 void test('stylish formatter outputs relative paths', () => {
   const abs = join(process.cwd(), 'c.ts');
-  const results: LintResult[] = [{ filePath: abs, messages: [] }];
+  const results: LintResult[] = [
+    { sourceId: abs, filePath: abs, messages: [] },
+  ];
   const out = stylish(results, false);
   assert.equal(out, '[OK] c.ts');
 });
@@ -75,6 +79,7 @@ void test('stylish formatter outputs relative paths', () => {
 void test('stylish formatter does not insert blank line before summary', () => {
   const results: LintResult[] = [
     {
+      sourceId: 'a.ts',
       filePath: 'a.ts',
       messages: [
         {
@@ -97,6 +102,7 @@ void test('stylish formatter does not insert blank line before summary', () => {
 void test('json formatter outputs json', () => {
   const results: LintResult[] = [
     {
+      sourceId: 'file.ts',
       filePath: 'file.ts',
       messages: [
         {
@@ -110,13 +116,15 @@ void test('json formatter outputs json', () => {
     },
   ];
   const out = jsonFormatter(results);
-  const parsed = JSON.parse(out) as { filePath: string }[];
+  const parsed = JSON.parse(out) as { sourceId: string; filePath?: string }[];
+  assert.equal(parsed[0]?.sourceId, 'file.ts');
   assert.equal(parsed[0]?.filePath, 'file.ts');
 });
 
 void test('sarif formatter outputs rules and links results', () => {
   const results: LintResult[] = [
     {
+      sourceId: 'file.ts',
       filePath: 'file.ts',
       messages: [
         {
@@ -153,6 +161,7 @@ void test('sarif formatter outputs rules and links results', () => {
 void test('sarif formatter updates rule descriptions from later results', () => {
   const results: LintResult[] = [
     {
+      sourceId: 'a.ts',
       filePath: 'a.ts',
       messages: [
         {
@@ -165,6 +174,7 @@ void test('sarif formatter updates rule descriptions from later results', () => 
       ],
     },
     {
+      sourceId: 'b.ts',
       filePath: 'b.ts',
       messages: [
         {
@@ -199,7 +209,7 @@ void test('getFormatter resolves formatter relative to cwd', async () => {
   process.chdir(fixtureDir);
   try {
     const formatter = await getFormatter('./custom-formatter.ts');
-    const out = formatter([{ filePath: 'a', messages: [] }]);
+    const out = formatter([{ sourceId: 'a', filePath: 'a', messages: [] }]);
     assert.equal(out, 'custom:1');
   } finally {
     process.chdir(prev);

--- a/tests/glob.test.ts
+++ b/tests/glob.test.ts
@@ -18,7 +18,11 @@ void test('lintFiles expands glob patterns with globby', async () => {
     const { results, warning } = await linter.lintFiles([
       '**/*.module.{css,scss}',
     ]);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    for (const r of results) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      assert.equal(r.filePath, r.sourceId);
+    }
     assert.deepEqual(files, ['src/a.module.css', 'src/b.module.scss']);
     assert.equal(warning, undefined);
   } finally {

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -29,7 +29,9 @@ void test('lintFiles ignores common directories by default', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath));
+    const files = results.map((r) => path.relative(dir, r.sourceId));
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/file.ts']);
   } finally {
     process.chdir(cwd);
@@ -54,7 +56,9 @@ void test('lintFiles respects .gitignore via globby', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
     process.chdir(cwd);
@@ -83,7 +87,9 @@ void test('.designlintignore can unignore paths', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['node_modules/pkg/index.ts', 'src/file.ts']);
   } finally {
     process.chdir(cwd);
@@ -108,7 +114,9 @@ void test('.designlintignore overrides .gitignore', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/file.ts']);
   } finally {
     process.chdir(cwd);
@@ -136,7 +144,9 @@ void test('.designlintignore supports negative patterns', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/file.ts']);
   } finally {
     process.chdir(cwd);
@@ -161,7 +171,9 @@ void test('.designlintignore supports Windows paths', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
     process.chdir(cwd);
@@ -186,7 +198,9 @@ void test('config ignoreFiles are respected', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
     process.chdir(cwd);
@@ -212,7 +226,9 @@ void test('additional ignore file is respected', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.'], false, [extra]);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
     process.chdir(cwd);
@@ -237,7 +253,9 @@ void test('lintFiles respects nested .gitignore', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['nested/keep.ts']);
   } finally {
     process.chdir(cwd);
@@ -263,7 +281,9 @@ void test('nested .designlintignore overrides parent patterns', async () => {
       new FileSource(),
     );
     const { results } = await linter.lintFiles(['.']);
-    const files = results.map((r) => path.relative(dir, r.filePath)).sort();
+    const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    for (const r of results) assert.equal(r.filePath, r.sourceId);
     assert.deepEqual(files, ['src/keep.ts', 'src/skip.ts']);
   } finally {
     process.chdir(cwd);

--- a/tests/nested-config.test.ts
+++ b/tests/nested-config.test.ts
@@ -23,13 +23,17 @@ void test('CLI loads nearest config in nested project', () => {
   );
   assert.notEqual(res.status, 0);
   interface Result {
-    filePath: string;
+    sourceId: string;
+    filePath?: string;
     messages: { ruleId: string }[];
   }
   const parsed = JSON.parse(res.stdout) as unknown;
   assert(Array.isArray(parsed));
   const results = parsed as Result[];
-  const files = results.map((r) => path.relative(appDir, r.filePath)).sort();
+  const files = results.map((r) => path.relative(appDir, r.sourceId)).sort();
+  for (const r of results) {
+    assert.equal(r.filePath, r.sourceId);
+  }
   assert.deepEqual(files, ['src/App.module.css', 'src/App.tsx']);
   for (const r of results) {
     for (const m of r.messages) {

--- a/tests/patterns.test.ts
+++ b/tests/patterns.test.ts
@@ -23,5 +23,7 @@ void test('lintFiles uses patterns option to include custom extensions', async (
   );
   const { results: customResults } = await customLinter.lintFiles([tmp]);
   assert.equal(customResults.length, 1);
+  assert.equal(customResults[0].sourceId, file);
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   assert.equal(customResults[0].filePath, file);
 });


### PR DESCRIPTION
## Summary
- rename `filePath` to `sourceId` with deprecated alias for lint results and rule context
- update linter, parsers, adapters, formatters, and docs to use `sourceId`
- adjust tests and fixtures to cover backward compatibility

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05c22c3bc83289fa84d353de8eb45