### PR TITLE
feat(core): replace lintFiles with lintTargets

### DIFF
--- a/.changeset/replace-lintfiles-with-linttargets.md
+++ b/.changeset/replace-lintfiles-with-linttargets.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+replace lintFiles with lintTargets

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ async function main() {
   const linter = new Linter(config, new FileSource());
 
   // 3. Lint files and optionally apply automatic fixes
-  const { results } = await linter.lintFiles(['src/**/*.{ts,tsx}'], true);
+  const { results } = await linter.lintTargets(['src/**/*.{ts,tsx}'], true);
 
   // 4. Format and display results
   const formatter = await getFormatter('stylish');
@@ -83,23 +83,14 @@ Lints files using built-in and plugin-provided rules.
   - `cacheProvider?: CacheProvider` – optional cache provider.
 - **Returns** `Linter` instance.
 
-#### `lintFiles(targets, fix?, additionalIgnorePaths?)`
+#### `lintTargets(targets, fix?, ignore?)`
 
 - **Parameters**
   - `targets: string[]` – file paths or glob patterns to lint.
   - `fix = false` – whether to apply automatic fixes.
-  - `additionalIgnorePaths: string[] = []` – extra ignore globs.
+  - `ignore?: string[]` – extra ignore file paths.
 - **Returns** `Promise<{ results: LintResult[]; ignoreFiles: string[]; warning?: string; }>`
 - **Throws** if reading or parsing files fails.
-
-#### `lintFile(path, fix?, ignorePaths?)`
-
-- **Parameters**
-  - `path: string` – path to a single file.
-  - `fix = false` – whether to apply automatic fixes.
-  - `ignorePaths: string[] = []` – extra ignore globs.
-- **Returns** `Promise<LintResult>`
-- **Throws** if the file cannot be processed.
 
 #### `getTokenCompletions()`
 

--- a/scripts/bench/fs.js
+++ b/scripts/bench/fs.js
@@ -2,14 +2,16 @@
 import { performance } from 'node:perf_hooks';
 import { Linter } from '../../dist/core/linter.js';
 import { loadConfig } from '../../dist/config/loader.js';
+import { createNodeEnvironment } from '../../dist/adapters/node/environment.js';
 
 const targets = process.argv.slice(2);
 
 (async () => {
   const config = await loadConfig(process.cwd());
-  const linter = new Linter(config);
+  const env = createNodeEnvironment(config);
+  const linter = new Linter(config, env);
   const start = performance.now();
-  await linter.lintFiles(targets.length ? targets : ['.']);
+  await linter.lintTargets(targets.length ? targets : ['.']);
   const end = performance.now();
   // eslint-disable-next-line no-console
   console.log(`Linted in ${(end - start).toFixed(2)}ms`);

--- a/src/adapters/node/file-source.ts
+++ b/src/adapters/node/file-source.ts
@@ -29,12 +29,23 @@ export class FileSource implements DocumentSource {
         absolute: true,
       })
     ).map(realpathIfExists);
+    const ignoreFiles = [
+      ...(
+        await globby(['**/.gitignore', '**/.designlintignore'], {
+          gitignore: false,
+          dot: true,
+          absolute: true,
+        })
+      ).map(realpathIfExists),
+      ...additionalIgnorePaths.map(realpathIfExists),
+    ];
+    const deduped = Array.from(new Set(ignoreFiles));
     const duration = performance.now() - start;
     if (process.env.DESIGNLINT_PROFILE) {
       console.log(
         `Scanned ${String(files.length)} files in ${duration.toFixed(2)}ms`,
       );
     }
-    return files.map(createFileDocument);
+    return { documents: files.map(createFileDocument), ignoreFiles: deduped };
   }
 }

--- a/src/cli/execute.ts
+++ b/src/cli/execute.ts
@@ -36,7 +36,7 @@ export async function executeLint(
     results,
     ignoreFiles = [],
     warning,
-  } = await services.linterRef.current.lintFiles(
+  } = await services.linterRef.current.lintTargets(
     targets,
     opts.fix,
     services.ignorePath ? [services.ignorePath] : [],

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -15,7 +15,11 @@ export interface DocumentSource {
     targets: string[],
     config: Config,
     additionalIgnorePaths?: string[],
-  ): Promise<LintDocument[]>;
+  ): Promise<{
+    documents: LintDocument[];
+    ignoreFiles: string[];
+    warning?: string;
+  }>;
 }
 
 export interface TokenProvider {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -40,7 +40,7 @@ void test('CLI passes targets to environment factory', async () => {
       config: { tokens: {}, rules: {} },
       linterRef: {
         current: {
-          lintFiles: () => Promise.resolve({ results: [], ignoreFiles: [] }),
+          lintTargets: () => Promise.resolve({ results: [], ignoreFiles: [] }),
           getPluginPaths: () => Promise.resolve([]),
         } as unknown as Linter,
       },
@@ -1122,9 +1122,12 @@ void test('CLI cache updates after --fix run', async () => {
       return Promise.resolve();
     },
   };
-  const linter = new Linter(config, new FileSource(), undefined, cache);
-  const { results: res1 } = await linter.lintFiles([file], true);
-  const { results: res2 } = await linter.lintFiles([file], false);
+  const linter = new Linter(config, {
+    documentSource: new FileSource(),
+    cacheProvider: cache,
+  });
+  const { results: res1 } = await linter.lintTargets([file], true);
+  const { results: res2 } = await linter.lintTargets([file], false);
   assert.equal(res1[0].messages.length, 0);
   assert.strictEqual(res1[0], res2[0]);
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -210,7 +210,7 @@ void test("rule configured as 'off' is ignored", async () => {
     }),
   );
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const res = await linter.lintText('const c = "#fff";', 'file.ts');
   assert.equal(res.messages.length, 0);
 });
@@ -223,7 +223,7 @@ void test('throws on unknown rule name', async () => {
     JSON.stringify({ rules: { 'unknown/rule': 'error' } }),
   );
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   await assert.rejects(
     () => linter.lintText('const x = 1;', 'file.ts'),
     /Unknown rule\(s\): unknown\/rule/,

--- a/tests/core/glob-ignore.test.ts
+++ b/tests/core/glob-ignore.test.ts
@@ -17,8 +17,8 @@ void test('FileSource.scan applies nested ignore files for glob targets', async 
   process.chdir(dir);
   try {
     const config: Config = { tokens: {}, rules: {} };
-    const docs = await new FileSource().scan(['**/*.ts'], config);
-    const rels = docs.map((d) => path.relative(dir, d.id)).sort();
+    const { documents } = await new FileSource().scan(['**/*.ts'], config);
+    const rels = documents.map((d) => path.relative(dir, d.id)).sort();
     assert.deepEqual(rels, ['src/keep.ts']);
   } finally {
     process.chdir(cwd);

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -15,6 +15,7 @@ void test('Linter integrates registry, parser and trackers', async () => {
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
   const file = path.join(dir, 'file.css');
   await fs.writeFile(file, 'a{color:#fff;}');
-  const res = await linter.lintFile(file);
+  const { results } = await linter.lintTargets([file]);
+  const res = results[0];
   assert.equal(res.messages.length, 1);
 });

--- a/tests/core/profile.test.ts
+++ b/tests/core/profile.test.ts
@@ -28,7 +28,7 @@ void test('FileSource.scan logs when DESIGNLINT_PROFILE is set', async () => {
   };
   try {
     // Include a missing file to hit the catch branch
-    await linter.lintFiles(['file.ts', 'missing.ts']);
+    await linter.lintTargets(['file.ts', 'missing.ts']);
   } finally {
     console.log = origLog;
     delete process.env.DESIGNLINT_PROFILE;
@@ -45,8 +45,8 @@ void test('FileSource.scan collects files from directory targets', async () => {
   process.chdir(dir);
   try {
     const env = createNodeEnvironment(config);
-    const docs = await env.documentSource.scan(['.'], config);
-    const rels = docs.map((d) => path.relative(dir, d.id));
+    const { documents } = await env.documentSource.scan(['.'], config);
+    const rels = documents.map((d) => path.relative(dir, d.id));
     assert.deepEqual(rels, ['a.ts']);
   } finally {
     process.chdir(cwd);

--- a/tests/glob.test.ts
+++ b/tests/glob.test.ts
@@ -6,7 +6,7 @@ import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
-void test('lintFiles expands glob patterns with globby', async () => {
+void test('lintTargets expands glob patterns with globby', async () => {
   const dir = makeTmpDir();
   fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'src', 'a.module.css'), '');
@@ -15,7 +15,7 @@ void test('lintFiles expands glob patterns with globby', async () => {
   process.chdir(dir);
   try {
     const linter = new Linter({ tokens: {}, rules: {} }, new FileSource());
-    const { results, warning } = await linter.lintFiles([
+    const { results, warning } = await linter.lintTargets([
       '**/*.module.{css,scss}',
     ]);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -6,7 +6,7 @@ import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
-void test('lintFiles ignores common directories by default', async () => {
+void test('lintTargets ignores common directories by default', async () => {
   const dir = makeTmpDir();
   fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'src', 'file.ts'), 'const a = "old";');
@@ -28,7 +28,7 @@ void test('lintFiles ignores common directories by default', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId));
     assert.deepEqual(files, ['src/file.ts']);
   } finally {
@@ -36,7 +36,7 @@ void test('lintFiles ignores common directories by default', async () => {
   }
 });
 
-void test('lintFiles respects .gitignore via globby', async () => {
+void test('lintTargets respects .gitignore via globby', async () => {
   const dir = makeTmpDir();
   fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'src', 'keep.ts'), 'const a = "old";');
@@ -53,7 +53,7 @@ void test('lintFiles respects .gitignore via globby', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
@@ -82,7 +82,7 @@ void test('.designlintignore can unignore paths', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['node_modules/pkg/index.ts', 'src/file.ts']);
   } finally {
@@ -107,7 +107,7 @@ void test('.designlintignore overrides .gitignore', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['src/file.ts']);
   } finally {
@@ -135,7 +135,7 @@ void test('.designlintignore supports negative patterns', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['src/file.ts']);
   } finally {
@@ -160,7 +160,7 @@ void test('.designlintignore supports Windows paths', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
@@ -185,7 +185,7 @@ void test('config ignoreFiles are respected', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
@@ -211,7 +211,7 @@ void test('additional ignore file is respected', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.'], false, [extra]);
+    const { results } = await linter.lintTargets(['.'], false, [extra]);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['src/keep.ts']);
   } finally {
@@ -219,7 +219,7 @@ void test('additional ignore file is respected', async () => {
   }
 });
 
-void test('lintFiles respects nested .gitignore', async () => {
+void test('lintTargets respects nested .gitignore', async () => {
   const dir = makeTmpDir();
   fs.mkdirSync(path.join(dir, 'nested'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'nested', 'keep.ts'), 'const a = "old";');
@@ -236,7 +236,7 @@ void test('lintFiles respects nested .gitignore', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['nested/keep.ts']);
   } finally {
@@ -262,7 +262,7 @@ void test('nested .designlintignore overrides parent patterns', async () => {
       },
       new FileSource(),
     );
-    const { results } = await linter.lintFiles(['.']);
+    const { results } = await linter.lintTargets(['.']);
     const files = results.map((r) => path.relative(dir, r.sourceId)).sort();
     assert.deepEqual(files, ['src/keep.ts', 'src/skip.ts']);
   } finally {

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -28,7 +28,8 @@ void test('inline directives disable linting', async () => {
     },
     new FileSource(),
   );
-  const res = await linter.lintFile(file);
+  const { results } = await linter.lintTargets([file]);
+  const res = results[0];
   const lines = res.messages.map((m) => m.line).sort();
   assert.deepEqual(lines, [1, 9]);
 });
@@ -47,7 +48,8 @@ void test('strings resembling directives do not disable next line', async () => 
     },
     new FileSource(),
   );
-  const res = await linter.lintFile(file);
+  const { results } = await linter.lintTargets([file]);
+  const res = results[0];
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].line, 2);
 });

--- a/tests/lint-file.test.ts
+++ b/tests/lint-file.test.ts
@@ -9,19 +9,20 @@ import { loadConfig } from '../src/config/loader.ts';
 
 const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');
 
-void test('lintDocument matches lintFile wrapper', async () => {
+void test('lintDocument matches lintTargets result', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const doc = createFileDocument(file);
   const res1 = await linter.lintDocument(doc);
-  const res2 = await linter.lintFile(file);
+  const { results } = await linter.lintTargets([file]);
+  const [res2] = results;
   assert.deepEqual(res1, res2);
 });
 
 void test('lintDocument reports unreadable file', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const doc = createFileDocument(file);
   const original = fs.readFile;
@@ -47,9 +48,9 @@ void test('lintDocument reports unreadable file', async () => {
   }
 });
 
-void test('lintFiles reports unreadable file', async () => {
+void test('lintTargets reports unreadable file', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const original = fs.readFile;
   const stub = mock.method(
@@ -64,7 +65,7 @@ void test('lintFiles reports unreadable file', async () => {
     },
   );
   try {
-    const { results } = await linter.lintFiles([file]);
+    const { results } = await linter.lintTargets([file]);
     const res = results[0];
     assert.equal(res.messages.length, 1);
     const msg = res.messages[0];

--- a/tests/patterns.test.ts
+++ b/tests/patterns.test.ts
@@ -6,7 +6,7 @@ import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
 import { Linter } from '../src/core/linter.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
-void test('lintFiles uses patterns option to include custom extensions', async () => {
+void test('lintTargets uses patterns option to include custom extensions', async () => {
   const tmp = makeTmpDir();
   const file = path.join(tmp, 'bad.foo');
   fs.writeFileSync(file, "const color = '#ffffff';");
@@ -15,13 +15,13 @@ void test('lintFiles uses patterns option to include custom extensions', async (
     rules: { 'design-token/colors': 'error' },
   };
   const defaultLinter = new Linter(baseConfig, new FileSource());
-  const { results: defaultResults } = await defaultLinter.lintFiles([tmp]);
+  const { results: defaultResults } = await defaultLinter.lintTargets([tmp]);
   assert.equal(defaultResults.length, 0);
   const customLinter = new Linter(
     { ...baseConfig, patterns: ['**/*.foo'] },
     new FileSource(),
   );
-  const { results: customResults } = await customLinter.lintFiles([tmp]);
+  const { results: customResults } = await customLinter.lintTargets([tmp]);
   assert.equal(customResults.length, 1);
   assert.equal(customResults[0].sourceId, file);
 });

--- a/tests/performance.test.ts
+++ b/tests/performance.test.ts
@@ -10,8 +10,8 @@ import { FileSource } from '../src/adapters/node/file-source.ts';
 void test('lints large projects without crashing', async () => {
   const dir = path.join(__dirname, 'fixtures', 'large-project');
   const config = await loadConfig(dir);
-  const linter = new Linter(config, new FileSource());
-  const { results } = await linter.lintFiles([dir]);
+  const linter = new Linter(config, { documentSource: new FileSource() });
+  const { results } = await linter.lintTargets([dir]);
   assert.equal(results.length, 200);
 });
 
@@ -26,8 +26,8 @@ void test('lints very large projects without EMFILE', async () => {
     );
   }
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, new FileSource());
-  const { results } = await linter.lintFiles([tmp]);
+  const linter = new Linter(config, { documentSource: new FileSource() });
+  const { results } = await linter.lintTargets([tmp]);
   assert.equal(results.length, count);
   fs.rmSync(tmp, { recursive: true, force: true });
 });
@@ -75,8 +75,8 @@ void test('respects configured concurrency limit', async () => {
   fsp.stat = trackedStat;
 
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, new FileSource());
-  const { results } = await linter.lintFiles([tmp]);
+  const linter = new Linter(config, { documentSource: new FileSource() });
+  const { results } = await linter.lintTargets([tmp]);
   assert.equal(results.length, count);
   assert.ok(max <= 2);
   fsp.readFile = origRead;

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -15,8 +15,10 @@ void test('external plugin rules execute', async () => {
       plugins: [pluginPath],
       rules: { 'plugin/test': 'error' },
     },
-    new FileSource(),
-    new NodePluginLoader(),
+    {
+      documentSource: new FileSource(),
+      pluginLoader: new NodePluginLoader(),
+    },
   );
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
@@ -26,7 +28,10 @@ void test('external plugin rules execute', async () => {
 void test('plugins resolve relative to config file', async () => {
   const dir = path.join(__dirname, 'fixtures', 'plugin-relative');
   const config = await loadConfig(dir);
-  const linter = new Linter(config, new FileSource(), new NodePluginLoader());
+  const linter = new Linter(config, {
+    documentSource: new FileSource(),
+    pluginLoader: new NodePluginLoader(),
+  });
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].ruleId, 'plugin/test');
@@ -39,8 +44,10 @@ void test('loads ESM plugin modules', async () => {
       plugins: [pluginPath],
       rules: { 'plugin/esm': 'error' },
     },
-    new FileSource(),
-    new NodePluginLoader(),
+    {
+      documentSource: new FileSource(),
+      pluginLoader: new NodePluginLoader(),
+    },
   );
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);
@@ -51,8 +58,10 @@ void test('throws for invalid plugin modules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-plugin.ts');
   const linter = new Linter(
     { plugins: [pluginPath] },
-    new FileSource(),
-    new NodePluginLoader(),
+    {
+      documentSource: new FileSource(),
+      pluginLoader: new NodePluginLoader(),
+    },
   );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
@@ -64,8 +73,10 @@ void test('throws for invalid plugin rules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-rule-plugin.ts');
   const linter = new Linter(
     { plugins: [pluginPath] },
-    new FileSource(),
-    new NodePluginLoader(),
+    {
+      documentSource: new FileSource(),
+      pluginLoader: new NodePluginLoader(),
+    },
   );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
@@ -77,8 +88,10 @@ void test('throws when plugin module missing', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'missing-plugin.js');
   const linter = new Linter(
     { plugins: [pluginPath] },
-    new FileSource(),
-    new NodePluginLoader(),
+    {
+      documentSource: new FileSource(),
+      pluginLoader: new NodePluginLoader(),
+    },
   );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
@@ -104,8 +117,10 @@ void test('throws when two plugins define the same rule name', async () => {
   const pluginB = path.join(__dirname, 'fixtures', 'duplicate-rule-plugin.ts');
   const linter = new Linter(
     { plugins: [pluginA, pluginB] },
-    new FileSource(),
-    new NodePluginLoader(),
+    {
+      documentSource: new FileSource(),
+      pluginLoader: new NodePluginLoader(),
+    },
   );
   await assert.rejects(
     () => linter.lintText('const a = 1;', 'file.ts'),
@@ -122,8 +137,10 @@ void test('getPluginPaths returns resolved plugin paths', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin.ts');
   const linter = new Linter(
     { plugins: [pluginPath] },
-    new FileSource(),
-    new NodePluginLoader(),
+    {
+      documentSource: new FileSource(),
+      pluginLoader: new NodePluginLoader(),
+    },
   );
   await linter.lintText('const a = 1;', 'file.ts');
   const paths = await linter.getPluginPaths();
@@ -148,8 +165,7 @@ void test('supports custom plugin loaders', async () => {
   }
   const linter = new Linter(
     { plugins: ['mock'], rules: { 'mock/rule': 'error' } },
-    new FileSource(),
-    new MockLoader(),
+    { documentSource: new FileSource(), pluginLoader: new MockLoader() },
   );
   const res = await linter.lintText('const a = 1;', 'file.ts');
   assert.equal(res.messages.length, 1);

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -30,7 +30,7 @@ void test('design-system/no-unused-tokens reports unused tokens', async () => {
     },
     env,
   );
-  const { results } = await linter.lintFiles([file]);
+  const { results } = await linter.lintTargets([file]);
   const msg = results
     .flatMap((r) => r.messages)
     .find((m) => m.ruleId === 'design-system/no-unused-tokens');
@@ -56,7 +56,7 @@ void test('design-system/no-unused-tokens passes when tokens used', async () => 
     },
     env,
   );
-  const { results } = await linter.lintFiles([file]);
+  const { results } = await linter.lintTargets([file]);
   const has = results.some((r) =>
     r.messages.some((m) => m.ruleId === 'design-system/no-unused-tokens'),
   );
@@ -82,7 +82,7 @@ void test('design-system/no-unused-tokens can ignore tokens', async () => {
     },
     env,
   );
-  const { results } = await linter.lintFiles([file]);
+  const { results } = await linter.lintTargets([file]);
   const has = results.some((r) =>
     r.messages.some((m) => m.ruleId === 'design-system/no-unused-tokens'),
   );
@@ -106,7 +106,7 @@ void test('design-system/no-unused-tokens matches hex case-insensitively', async
     },
     env,
   );
-  const { results } = await linter.lintFiles([file]);
+  const { results } = await linter.lintTargets([file]);
   const has = results.some((r) =>
     r.messages.some((m) => m.ruleId === 'design-system/no-unused-tokens'),
   );

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -28,14 +28,14 @@ function assertIds(messages: { ruleId: string }[]) {
 }
 
 void test('reports raw tokens in .scss files', async () => {
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(cssSample, 'file.scss');
   assert.equal(res.messages.length, 3);
   assertIds(res.messages);
 });
 
 void test('reports raw tokens in Vue <style lang="scss">', async () => {
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(
     `<template><div/></template><style lang="scss">${cssSample}</style>`,
     'Comp.vue',
@@ -45,7 +45,7 @@ void test('reports raw tokens in Vue <style lang="scss">', async () => {
 });
 
 void test('reports raw tokens in Svelte <style lang="scss">', async () => {
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(
     `<div></div><style lang="scss">${cssSample}</style>`,
     'Comp.svelte',
@@ -55,7 +55,7 @@ void test('reports raw tokens in Svelte <style lang="scss">', async () => {
 });
 
 void test('reports raw tokens in string style attributes', async () => {
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(
     `const C = () => <div style="color: #fff; margin: 5px; opacity: 0.5"></div>;`,
     'file.tsx',

--- a/tests/svelte-style-bindings.test.ts
+++ b/tests/svelte-style-bindings.test.ts
@@ -9,8 +9,12 @@ const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');
 
 async function lint(file: string) {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, new FileSource());
-  return linter.lintFile(path.join(fixtureDir, 'src', file), false);
+  const linter = new Linter(config, { documentSource: new FileSource() });
+  const { results } = await linter.lintTargets(
+    [path.join(fixtureDir, 'src', file)],
+    false,
+  );
+  return results[0];
 }
 
 void test('style bindings report spacing and color violations', async () => {

--- a/tests/tagged-template.test.ts
+++ b/tests/tagged-template.test.ts
@@ -9,11 +9,11 @@ const fixtureDir = path.join(__dirname, 'fixtures', 'tagged-template');
 
 void test('reports CSS in tagged template literals', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'styled.ts');
   const {
     results: [res],
-  } = await linter.lintFiles([file]);
+  } = await linter.lintTargets([file]);
   const colorMessages = res.messages.filter(
     (m) => m.ruleId === 'design-token/colors',
   );

--- a/tests/vue-style-bindings.test.ts
+++ b/tests/vue-style-bindings.test.ts
@@ -9,10 +9,10 @@ const fixtureDir = path.join(__dirname, 'fixtures', 'vue');
 
 async function lint(file: string) {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, new FileSource());
+  const linter = new Linter(config, { documentSource: new FileSource() });
   const {
     results: [res],
-  } = await linter.lintFiles([path.join(fixtureDir, 'src', file)]);
+  } = await linter.lintTargets([path.join(fixtureDir, 'src', file)]);
   return res;
 }
 


### PR DESCRIPTION
## Summary
- replace `lintFile`/`lintFiles` with new `lintTargets` API
- expand document scanning to report ignore files
- update CLI, docs, and tests for new entrypoint

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c061e6be6083289766c19c8361dd1a