### PR TITLE
feat(core): add rule categories and message metadata

### DIFF
--- a/.changeset/add-rule-category-metadata.md
+++ b/.changeset/add-rule-category-metadata.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add rule categories and message metadata support

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -162,9 +162,13 @@ export class Linter {
     }
     const messages: LintMessage[] = [];
     const ruleDescriptions: Record<string, string> = {};
+    const ruleCategories: Record<string, string> = {};
     const disabledLines = getDisabledLines(text);
     const listeners = enabled.map(({ rule, options, severity }) => {
       ruleDescriptions[rule.name] = rule.meta.description;
+      if (rule.meta.category) {
+        ruleCategories[rule.name] = rule.meta.category;
+      }
       const themes =
         isRecord(options) && isStringArray(options.themes)
           ? options.themes
@@ -189,6 +193,7 @@ export class Linter {
       sourceId,
       messages: filtered,
       ruleDescriptions,
+      ruleCategories,
     };
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -51,12 +51,14 @@ export interface LintMessage {
   column: number;
   fix?: Fix;
   suggest?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface LintResult {
   sourceId: string;
   messages: LintMessage[];
   ruleDescriptions?: Record<string, string>;
+  ruleCategories?: Record<string, string>;
 }
 
 export interface RuleContext<TOptions = unknown> {
@@ -71,6 +73,7 @@ export interface RuleModule<TOptions = unknown> {
   name: string;
   meta: {
     description: string;
+    category?: string;
   };
   create(context: RuleContext<TOptions>): RuleListener;
 }

--- a/src/formatters/stylish.ts
+++ b/src/formatters/stylish.ts
@@ -30,8 +30,9 @@ export function stylish(results: LintResult[], useColor = true): string {
           : codes.yellow(sevText)
         : sevText;
       const suggestion = msg.suggest ? ` Did you mean \`${msg.suggest}\`?` : '';
+      const category = res.ruleCategories?.[msg.ruleId];
       lines.push(
-        `  ${String(msg.line)}:${String(msg.column)}  ${sev}  ${msg.message}${suggestion}  ${msg.ruleId}`,
+        `  ${String(msg.line)}:${String(msg.column)}  ${sev}  ${msg.message}${suggestion}  ${msg.ruleId}${category ? ` (${category})` : ''}`,
       );
     }
   }

--- a/src/rules/component-prefix.ts
+++ b/src/rules/component-prefix.ts
@@ -9,6 +9,7 @@ export const componentPrefixRule: RuleModule<ComponentPrefixOptions> = {
   name: 'design-system/component-prefix',
   meta: {
     description: 'enforce a prefix for design system components',
+    category: 'component',
   },
   create(context) {
     const prefix = context.options?.prefix ?? 'DS';

--- a/src/rules/component-usage.ts
+++ b/src/rules/component-usage.ts
@@ -10,6 +10,7 @@ export const componentUsageRule: RuleModule<ComponentUsageOptions> = {
   meta: {
     description:
       'disallow raw HTML elements when design system components exist',
+    category: 'component',
   },
   create(context) {
     const subs = context.options?.substitutions ?? {};

--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -4,7 +4,10 @@ import { isInNonStyleJsx } from '../utils/jsx.js';
 
 export const deprecationRule: RuleModule = {
   name: 'design-system/deprecation',
-  meta: { description: 'flag deprecated tokens or components' },
+  meta: {
+    description: 'flag deprecated tokens or components',
+    category: 'design-token',
+  },
   create(context) {
     const deprecations = context.tokens.deprecations;
     if (!deprecations || Object.keys(deprecations).length === 0) {

--- a/src/rules/icon-usage.ts
+++ b/src/rules/icon-usage.ts
@@ -11,6 +11,7 @@ export const iconUsageRule: RuleModule<IconUsageOptions> = {
   meta: {
     description:
       'disallow raw svg elements or non design system icon components',
+    category: 'component',
   },
   create(context) {
     const subs: Record<string, string> = {

--- a/src/rules/import-path.ts
+++ b/src/rules/import-path.ts
@@ -11,6 +11,7 @@ export const importPathRule: RuleModule<ImportPathOptions> = {
   meta: {
     description:
       'ensure design system components are imported from configured packages',
+    category: 'component',
   },
   create(context) {
     const opts: ImportPathOptions = context.options ?? {};

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -11,6 +11,7 @@ export const noInlineStylesRule: RuleModule<NoInlineStylesOptions> = {
   meta: {
     description:
       'disallow inline style or className attributes on design system components',
+    category: 'component',
   },
   create(context) {
     const ignoreClassName = context.options?.ignoreClassName ?? false;

--- a/src/rules/no-unused-tokens.ts
+++ b/src/rules/no-unused-tokens.ts
@@ -2,7 +2,10 @@ import type { RuleModule } from '../core/types.js';
 
 export const noUnusedTokensRule: RuleModule = {
   name: 'design-system/no-unused-tokens',
-  meta: { description: 'report unused design tokens' },
+  meta: {
+    description: 'report unused design tokens',
+    category: 'design-token',
+  },
   create() {
     return {};
   },

--- a/src/rules/token-animation.ts
+++ b/src/rules/token-animation.ts
@@ -8,7 +8,7 @@ import {
 
 export const animationRule: RuleModule = {
   name: 'design-token/animation',
-  meta: { description: 'enforce animation tokens' },
+  meta: { description: 'enforce animation tokens', category: 'design-token' },
   create(context) {
     const animationTokens = context.tokens.animations;
     if (

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -12,7 +12,7 @@ interface BlurRuleOptions {
 
 export const blurRule: RuleModule<BlurRuleOptions> = {
   name: 'design-token/blur',
-  meta: { description: 'enforce blur tokens' },
+  meta: { description: 'enforce blur tokens', category: 'design-token' },
   create(context) {
     const blurTokens = context.tokens.blurs;
     if (

--- a/src/rules/token-border-color.ts
+++ b/src/rules/token-border-color.ts
@@ -39,7 +39,10 @@ function detectFormat(value: string): ColorFormat | null {
 
 export const borderColorRule: RuleModule = {
   name: 'design-token/border-color',
-  meta: { description: 'enforce border-color tokens' },
+  meta: {
+    description: 'enforce border-color tokens',
+    category: 'design-token',
+  },
   create(context) {
     const borderColorTokens = context.tokens.borderColors;
     if (

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -14,7 +14,10 @@ interface BorderRadiusOptions {
 
 export const borderRadiusRule: RuleModule<BorderRadiusOptions> = {
   name: 'design-token/border-radius',
-  meta: { description: 'enforce border-radius tokens' },
+  meta: {
+    description: 'enforce border-radius tokens',
+    category: 'design-token',
+  },
   create(context) {
     const radiiTokens = context.tokens.borderRadius;
     if (

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -14,7 +14,10 @@ interface BorderWidthOptions {
 
 export const borderWidthRule: RuleModule<BorderWidthOptions> = {
   name: 'design-token/border-width',
-  meta: { description: 'enforce border-width tokens' },
+  meta: {
+    description: 'enforce border-width tokens',
+    category: 'design-token',
+  },
   create(context) {
     const widthTokens = context.tokens.borderWidths;
     if (

--- a/src/rules/token-box-shadow.ts
+++ b/src/rules/token-box-shadow.ts
@@ -8,7 +8,7 @@ import {
 
 export const boxShadowRule: RuleModule = {
   name: 'design-token/box-shadow',
-  meta: { description: 'enforce box-shadow tokens' },
+  meta: { description: 'enforce box-shadow tokens', category: 'design-token' },
   create(context) {
     const shadowTokens = context.tokens.shadows;
     if (

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -45,7 +45,7 @@ interface ColorRuleOptions {
 
 export const colorsRule: RuleModule<ColorRuleOptions> = {
   name: 'design-token/colors',
-  meta: { description: 'disallow raw colors' },
+  meta: { description: 'disallow raw colors', category: 'design-token' },
   create(context) {
     const colorTokens = context.tokens.colors;
     if (

--- a/src/rules/token-duration.ts
+++ b/src/rules/token-duration.ts
@@ -10,7 +10,7 @@ import { isStyleValue } from '../utils/style.js';
 
 export const durationRule: RuleModule = {
   name: 'design-token/duration',
-  meta: { description: 'enforce duration tokens' },
+  meta: { description: 'enforce duration tokens', category: 'design-token' },
   create(context) {
     const durationTokens = context.tokens.durations;
     if (

--- a/src/rules/token-font-family.ts
+++ b/src/rules/token-font-family.ts
@@ -7,7 +7,7 @@ import {
 
 export const fontFamilyRule: RuleModule = {
   name: 'design-token/font-family',
-  meta: { description: 'enforce font-family tokens' },
+  meta: { description: 'enforce font-family tokens', category: 'design-token' },
   create(context) {
     const fontFamilies = context.tokens.fonts;
     if (

--- a/src/rules/token-font-size.ts
+++ b/src/rules/token-font-size.ts
@@ -7,7 +7,7 @@ import {
 
 export const fontSizeRule: RuleModule = {
   name: 'design-token/font-size',
-  meta: { description: 'enforce font-size tokens' },
+  meta: { description: 'enforce font-size tokens', category: 'design-token' },
   create(context) {
     const fontSizes = context.tokens.fontSizes;
     if (

--- a/src/rules/token-font-weight.ts
+++ b/src/rules/token-font-weight.ts
@@ -9,7 +9,7 @@ import { isStyleValue } from '../utils/style.js';
 
 export const fontWeightRule: RuleModule = {
   name: 'design-token/font-weight',
-  meta: { description: 'enforce font-weight tokens' },
+  meta: { description: 'enforce font-weight tokens', category: 'design-token' },
   create(context) {
     const fontWeights = context.tokens.fontWeights;
     if (

--- a/src/rules/token-letter-spacing.ts
+++ b/src/rules/token-letter-spacing.ts
@@ -9,7 +9,10 @@ import { isStyleValue } from '../utils/style.js';
 
 export const letterSpacingRule: RuleModule = {
   name: 'design-token/letter-spacing',
-  meta: { description: 'enforce letter-spacing tokens' },
+  meta: {
+    description: 'enforce letter-spacing tokens',
+    category: 'design-token',
+  },
   create(context) {
     const letterSpacings = context.tokens.letterSpacings;
     if (

--- a/src/rules/token-line-height.ts
+++ b/src/rules/token-line-height.ts
@@ -9,7 +9,7 @@ import { isStyleValue } from '../utils/style.js';
 
 export const lineHeightRule: RuleModule = {
   name: 'design-token/line-height',
-  meta: { description: 'enforce line-height tokens' },
+  meta: { description: 'enforce line-height tokens', category: 'design-token' },
   create(context) {
     const lineHeights = context.tokens.lineHeights;
     if (

--- a/src/rules/token-opacity.ts
+++ b/src/rules/token-opacity.ts
@@ -10,7 +10,7 @@ import { isStyleValue } from '../utils/style.js';
 
 export const opacityRule: RuleModule = {
   name: 'design-token/opacity',
-  meta: { description: 'enforce opacity tokens' },
+  meta: { description: 'enforce opacity tokens', category: 'design-token' },
   create(context) {
     const opacityTokens = context.tokens.opacity;
     if (

--- a/src/rules/token-outline.ts
+++ b/src/rules/token-outline.ts
@@ -8,7 +8,7 @@ import {
 
 export const outlineRule: RuleModule = {
   name: 'design-token/outline',
-  meta: { description: 'enforce outline tokens' },
+  meta: { description: 'enforce outline tokens', category: 'design-token' },
   create(context) {
     const outlineTokens = context.tokens.outlines;
     if (

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -15,7 +15,7 @@ interface SpacingOptions {
 
 export const spacingRule: RuleModule<SpacingOptions> = {
   name: 'design-token/spacing',
-  meta: { description: 'enforce spacing scale' },
+  meta: { description: 'enforce spacing scale', category: 'design-token' },
   create(context) {
     const spacingTokens = context.tokens.spacing;
     if (

--- a/src/rules/token-z-index.ts
+++ b/src/rules/token-z-index.ts
@@ -9,7 +9,7 @@ import { isStyleValue } from '../utils/style.js';
 
 export const zIndexRule: RuleModule = {
   name: 'design-token/z-index',
-  meta: { description: 'enforce z-index tokens' },
+  meta: { description: 'enforce z-index tokens', category: 'design-token' },
   create(context) {
     const zTokens = context.tokens.zIndex;
     if (

--- a/src/rules/variant-prop.ts
+++ b/src/rules/variant-prop.ts
@@ -11,6 +11,7 @@ export const variantPropRule: RuleModule<VariantPropOptions> = {
   meta: {
     description:
       'ensure specified components use allowed values for their variant prop',
+    category: 'component',
   },
   create(context) {
     const { components = {}, prop: propName = 'variant' } =

--- a/tests/rules/metadata.test.ts
+++ b/tests/rules/metadata.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Linter } from '../../src/core/linter.ts';
+import { FileSource } from '../../src/adapters/node/file-source.ts';
+import type { PluginLoader } from '../../src/core/plugin-loader.ts';
+import type { PluginModule, RuleModule } from '../../src/core/types.ts';
+
+void test('metadata propagates through report', async () => {
+  class MockLoader implements PluginLoader {
+    load(
+      _p: string,
+      _c?: string,
+    ): Promise<{ path: string; plugin: PluginModule }> {
+      void _p;
+      void _c;
+      const rule: RuleModule = {
+        name: 'mock/rule',
+        meta: { description: 'mock rule', category: 'component' },
+        create(context) {
+          return {
+            onNode() {
+              context.report({
+                message: 'msg',
+                line: 1,
+                column: 1,
+                metadata: { foo: 'bar' },
+              });
+            },
+          };
+        },
+      };
+      return Promise.resolve({ path: 'mock', plugin: { rules: [rule] } });
+    }
+  }
+  const linter = new Linter(
+    { plugins: ['mock'], rules: { 'mock/rule': 'error' } },
+    { documentSource: new FileSource(), pluginLoader: new MockLoader() },
+  );
+  const res = await linter.lintText('const a = 1;', 'file.ts');
+  assert.equal(res.messages[0]?.metadata?.foo, 'bar');
+  assert.equal(res.ruleCategories?.['mock/rule'], 'component');
+});

--- a/tests/rules/token-colors.test.ts
+++ b/tests/rules/token-colors.test.ts
@@ -92,3 +92,18 @@ void test('design-token/colors reports template expression', async () => {
   );
   assert.equal(res.messages.length, 1);
 });
+
+void test('design-token/colors sets category', async () => {
+  const linter = new Linter(
+    {
+      tokens: { colors: { primary: '#ffffff' } },
+      rules: { 'design-token/colors': 'error' },
+    },
+    new FileSource(),
+  );
+  const res = await linter.lintText(
+    'const c = <div style={{ color: "hwb(0, 0%, 0%)" }} />;',
+    'file.tsx',
+  );
+  assert.equal(res.ruleCategories?.['design-token/colors'], 'design-token');
+});


### PR DESCRIPTION
## Summary
- add category field to rule metadata
- support optional metadata on lint messages
- update formatters and built-in rules to surface categories

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06564c94483288a023b3919d17f09