### PR TITLE
feat: expose createLinter and refine CLI environment

### DIFF
--- a/.changeset/create-linter-programmatic.md
+++ b/.changeset/create-linter-programmatic.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+expose `createLinter` for programmatic use and rename CLI environment targets to patterns

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,18 +12,19 @@ A typical control flow when using the library directly:
 ```ts
 import {
   loadConfig,
-  Linter,
-  FileSource,
+  createLinter,
   getFormatter,
   applyFixes,
+  createNodeEnvironment,
 } from '@lapidist/design-lint';
 
 async function main() {
   // 1. Load configuration from the current working directory
   const config = await loadConfig(process.cwd());
 
-  // 2. Create a linter instance
-  const linter = new Linter(config, new FileSource());
+  // 2. Create an environment and linter instance
+  const env = createNodeEnvironment(config);
+  const linter = createLinter(config, env);
 
   // 3. Lint files and optionally apply automatic fixes
   const { results } = await linter.lintTargets(['src/**/*.{ts,tsx}'], true);

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -2,11 +2,20 @@ import fs from 'fs';
 import path from 'path';
 import ignore, { type Ignore } from 'ignore';
 import { getFormatter } from '../formatters/index.js';
-import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths.js';
 import type { CacheProvider } from '../core/cache-provider.js';
 import type { Config, Linter } from '../core/linter.js';
 import type { LintResult } from '../core/types.js';
 import { createNodeEnvironment } from '../adapters/node/environment.js';
+
+const relFromCwd = (p: string) =>
+  path.relative(process.cwd(), p).split(path.sep).join('/');
+const realpathIfExists = (p: string) => {
+  try {
+    return fs.realpathSync.native(p);
+  } catch {
+    return p;
+  }
+};
 
 export interface Environment {
   formatter: (results: LintResult[], useColor?: boolean) => string;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -94,13 +94,13 @@ export async function run(argv = process.argv.slice(2)) {
 
   program.action(async (files: string[], options: CliOptions) => {
     if (options.color === false) useColor = false;
-    const targets = files.length ? files : ['.'];
+    const patterns = files.length ? files : ['.'];
     try {
-      const env = await prepareEnvironment({ ...options, patterns: targets });
+      const env = await prepareEnvironment({ ...options, patterns });
       const services = { ...env, useColor };
-      const { exitCode } = await executeLint(targets, options, services);
+      const { exitCode } = await executeLint(patterns, options, services);
       process.exitCode = exitCode;
-      if (options.watch) await watchMode(targets, options, services);
+      if (options.watch) await watchMode(patterns, options, services);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(useColor ? chalk.red(message) : message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
+import { Linter, type Config } from './core/linter.js';
+import type { Environment } from './core/environment.js';
+
 export * from './core/index.js';
 export * from './adapters/node/index.js';
 export { loadConfig } from './config/loader.js';
 export { defineConfig } from './config/define-config.js';
 export { getFormatter } from './formatters/index.js';
 export { builtInRules } from './rules/index.js';
+
+export function createLinter(config: Config, env: Environment): Linter {
+  return new Linter(config, env);
+}


### PR DESCRIPTION
## Summary
- export `createLinter` for programmatic usage
- use `patterns` terminology and self-contained path utils in CLI environment
- document programmatic usage with `createLinter` and custom environment

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c06b4bc9688328996ce60b6ee6d70e