### PR TITLE
docs: fix dead links in documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,31 +30,31 @@ The `Environment` abstraction hides platform concerns. The default Node environm
 
 ## Core modules
 ### DocumentSource
-Supplies raw text to the linter. The Node adapter [`FileSource`](../src/adapters/node/file-source.ts) reads from disk.
+Supplies raw text to the linter. The Node adapter [`FileSource`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/file-source.ts) reads from disk.
 
 ### Parser adapters
-Convert documents into ASTs. CSS uses PostCSS, JavaScript and TypeScript rely on the TypeScript compiler, and Vue/Svelte files compile before analysis. See [`src/core/parsers`](../src/core/parsers).
+Convert documents into ASTs. CSS uses PostCSS, JavaScript and TypeScript rely on the TypeScript compiler, and Vue/Svelte files compile before analysis. See [`src/core/parsers`](https://github.com/bylapidist/design-lint/tree/main/src/core/parsers).
 
 ### Rule engine
-Registers rules and coordinates execution. See [`src/core/linter.ts`](../src/core/linter.ts) and [`src/core/rule-registry.ts`](../src/core/rule-registry.ts).
+Registers rules and coordinates execution. See [`src/core/linter.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/linter.ts) and [`src/core/rule-registry.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/rule-registry.ts).
 
 ### Formatter pipeline
-Transforms collected results into human- or machine-readable output. Implementations live under [`src/formatters`](../src/formatters).
+Transforms collected results into human- or machine-readable output. Implementations live under [`src/formatters`](https://github.com/bylapidist/design-lint/tree/main/src/formatters).
 
 ### Plugin loader
-Resolves configuration packages, rules, and formatters. The Node implementation is [`src/adapters/node/plugin-loader.ts`](../src/adapters/node/plugin-loader.ts).
+Resolves configuration packages, rules, and formatters. The Node implementation is [`src/adapters/node/plugin-loader.ts`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/plugin-loader.ts).
 
 ### Cache provider
-Stores metadata and parsed documents across runs. [`src/adapters/node/node-cache-provider.ts`](../src/adapters/node/node-cache-provider.ts) caches to disk.
+Stores metadata and parsed documents across runs. [`src/adapters/node/node-cache-provider.ts`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/node-cache-provider.ts) caches to disk.
 
 ### Token provider
-Supplies design tokens to rules. [`src/adapters/node/token-provider.ts`](../src/adapters/node/token-provider.ts) normalises tokens from configuration.
+Supplies design tokens to rules. [`src/adapters/node/token-provider.ts`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/token-provider.ts) normalises tokens from configuration.
 
 ## Performance and caching
 design-lint processes files concurrently across CPU cores. Parsed documents and rule results are cached between runs in `.designlintcache` to reduce work.
 
 ## Contributing to core
-To work on design-lint itself, read [CONTRIBUTING.md](../CONTRIBUTING.md). It covers the testing and build process, commit guidelines, and release workflow.
+To work on design-lint itself, read [CONTRIBUTING.md](https://github.com/bylapidist/design-lint/blob/main/CONTRIBUTING.md). It covers the testing and build process, commit guidelines, and release workflow.
 
 ## See also
 - [API reference](./api.md)

--- a/docs/changelog-guide.md
+++ b/docs/changelog-guide.md
@@ -24,8 +24,8 @@ This guide explains how to read the project changelog and version numbers. It ta
 Commit messages use the [Conventional Commits](https://www.conventionalcommits.org/) format to generate changelog entries automatically. Example: `feat(rules): add opacity rule`.
 
 ## Changesets
-Changesets describe pending releases. Each changeset file indicates the semver bump and a summary of the change. During release, the changelog is updated based on these files. See [AGENTS.md](../AGENTS.md) for the expected format.
+Changesets describe pending releases. Each changeset file indicates the semver bump and a summary of the change. During release, the changelog is updated based on these files. See [AGENTS.md](https://github.com/bylapidist/design-lint/blob/main/AGENTS.md) for the expected format.
 
 ## See also
-- [CHANGELOG](../CHANGELOG.md)
-- [Contributing](../CONTRIBUTING.md)
+- [CHANGELOG](https://github.com/bylapidist/design-lint/blob/main/CHANGELOG.md)
+- [Contributing](https://github.com/bylapidist/design-lint/blob/main/CONTRIBUTING.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ Design decisions often live outside your source tree. design-lint brings those d
 - [Examples](./examples/index.md)
 
 ## What's new
-See the [CHANGELOG](../CHANGELOG.md) for the latest features and fixes. For guidance on interpreting entries, read the [changelog guide](./changelog-guide.md).
+See the [CHANGELOG](https://github.com/bylapidist/design-lint/blob/main/CHANGELOG.md) for the latest features and fixes. For guidance on interpreting entries, read the [changelog guide](./changelog-guide.md).
 
 ## See also
 - [Glossary](./glossary.md)
 - [Troubleshooting](./troubleshooting.md)
-- [Contributing](../CONTRIBUTING.md)
+- [Contributing](https://github.com/bylapidist/design-lint/blob/main/CONTRIBUTING.md)

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -58,7 +58,7 @@ Additional checks for maintainability.
 - [design-system/no-unused-tokens](./design-system/no-unused-tokens.md)
 
 ## Adding or deprecating rules
-To propose a new rule or retire an existing one, open an issue or pull request following the guidelines in [CONTRIBUTING.md](../../CONTRIBUTING.md). Include rationale, examples, and implementation notes. Deprecated rules should remain in the documentation until removed in a major release.
+To propose a new rule or retire an existing one, open an issue or pull request following the guidelines in [CONTRIBUTING.md](https://github.com/bylapidist/design-lint/blob/main/CONTRIBUTING.md). Include rationale, examples, and implementation notes. Deprecated rules should remain in the documentation until removed in a major release.
 
 ## See also
 - [Configuration](../configuration.md)


### PR DESCRIPTION
## Summary
- replace references to repository files with GitHub links to avoid dead links during VitePress build
- update architecture and contributing references for accurate navigation

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68c07467c29883289ffaee34d313412a