### PR TITLE
docs: remove debug flag references

### DIFF
--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -36,7 +36,7 @@ npx design-lint src --format json
 }
 ```
 
-> **Tip:** Combine the `json` formatter with `--output-file` to generate artifacts in CI.
+> **Tip:** Combine the `json` formatter with `--output` to generate artifacts in CI.
 
 ## Writing a custom formatter
 A formatter exports a default function receiving lint results and returning a string.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,7 +24,7 @@ This guide helps you resolve common issues when running design-lint.
 
 **Cause:** Token file path is wrong or the file contains invalid JSON.
 
-**Resolution:** Verify token paths and run with `--debug` to inspect loaded tokens. See [configuration](./configuration.md#tokens).
+**Resolution:** Verify token paths and inspect loaded tokens. See [configuration](./configuration.md#tokens).
 
 ## Config file not found
 **Symptom:** `Error: Config file not found`.
@@ -59,7 +59,7 @@ This guide helps you resolve common issues when running design-lint.
 
 **Cause:** Unhandled exception in a rule or formatter.
 
-**Resolution:** Re-run with `--debug` to capture stack traces and file an issue with a minimal reproduction.
+**Resolution:** Re-run the command to capture stack traces and file an issue with a minimal reproduction.
 
 ## CI job fails intermittently
 **Symptom:** Linting passes locally but fails in CI.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,12 +82,10 @@ npx design-lint src/button.tsx styles/*.css
 
 ## Exit codes
 - `0` – no lint errors
-- `1` – lint errors found
-- `2` – configuration or runtime error
+- `1` – lint errors or runtime/configuration error
 
 ## Troubleshooting
 If the CLI fails or reports unexpected results:
-- Increase verbosity with `--debug`
 - Verify the [configuration](./configuration.md)
 - Consult the [troubleshooting guide](./troubleshooting.md)
 


### PR DESCRIPTION
## Summary
- remove unsupported `--debug` mentions from docs
- fix exit code section and `--output-file` flag reference

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c079a1c14483288ac71e9c02384a6a