### PR TITLE
feat(core): add w3c token model scaffolding

### DIFF
--- a/.changeset/flatten-design-tokens-walker.md
+++ b/.changeset/flatten-design-tokens-walker.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+feat(core): add function to flatten W3C Design Tokens tree

--- a/.changeset/handle-alias-cycles.md
+++ b/.changeset/handle-alias-cycles.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+handle alias chains and detect circular references in design token parser

--- a/.changeset/introduce-spec-token-model.md
+++ b/.changeset/introduce-spec-token-model.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+introduce W3C token model scaffolding and export token types

--- a/.changeset/load-token-files-per-theme.md
+++ b/.changeset/load-token-files-per-theme.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+load config tokens from external `.tokens` files

--- a/.changeset/move-token-parser-adapter.md
+++ b/.changeset/move-token-parser-adapter.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor token file parser to Node adapter to keep core environment agnostic

--- a/.changeset/preserve-extension-deprecation.md
+++ b/.changeset/preserve-extension-deprecation.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+preserve $extensions and $deprecated metadata in W3C token parser and flattener

--- a/.changeset/spec-token-parser.md
+++ b/.changeset/spec-token-parser.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+add parser for spec-compliant design token files and validate token/group names

--- a/.changeset/support-composite-types.md
+++ b/.changeset/support-composite-types.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+validate composite design token types like shadow, strokeStyle, gradient and typography

--- a/.changeset/unify-tokens-config-field.md
+++ b/.changeset/unify-tokens-config-field.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+feat: allow config tokens field to accept spec token trees or theme file paths

--- a/.changeset/validate-alias-targets.md
+++ b/.changeset/validate-alias-targets.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+validate alias references in spec token parser

--- a/.changeset/validate-token-types.md
+++ b/.changeset/validate-token-types.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+validate tokens have explicit types and enforce per-type semantics

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -3,3 +3,4 @@ export { createFileDocument } from './file-document.js';
 export { NodePluginLoader } from './plugin-loader.js';
 export { NodeCacheProvider } from './node-cache-provider.js';
 export { createNodeEnvironment } from './environment.js';
+export { parseDesignTokensFile } from './token-parser.js';

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -3,4 +3,4 @@ export { createFileDocument } from './file-document.js';
 export { NodePluginLoader } from './plugin-loader.js';
 export { NodeCacheProvider } from './node-cache-provider.js';
 export { createNodeEnvironment } from './environment.js';
-export { parseDesignTokensFile } from './token-parser.js';
+export { parseDesignTokensFile, readDesignTokensFile } from './token-parser.js';

--- a/src/adapters/node/token-parser.ts
+++ b/src/adapters/node/token-parser.ts
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises';
+import type { DesignTokens } from '../../core/types.js';
+import type { FlattenedToken } from '../../core/token-utils.js';
+import { parseDesignTokens } from '../../core/token-parser.js';
+
+function assertSupportedFile(filePath: string): void {
+  if (!(filePath.endsWith('.tokens') || filePath.endsWith('.tokens.json'))) {
+    throw new Error(`Unsupported design tokens file: ${filePath}`);
+  }
+}
+
+export async function parseDesignTokensFile(
+  filePath: string,
+): Promise<FlattenedToken[]> {
+  assertSupportedFile(filePath);
+  const content = await readFile(filePath, 'utf8');
+  const json = JSON.parse(content) as DesignTokens;
+  return parseDesignTokens(json);
+}

--- a/src/adapters/node/token-parser.ts
+++ b/src/adapters/node/token-parser.ts
@@ -17,3 +17,14 @@ export async function parseDesignTokensFile(
   const json = JSON.parse(content) as DesignTokens;
   return parseDesignTokens(json);
 }
+
+export async function readDesignTokensFile(
+  filePath: string,
+): Promise<DesignTokens> {
+  assertSupportedFile(filePath);
+  const content = await readFile(filePath, 'utf8');
+  const json = JSON.parse(content) as DesignTokens;
+  // Validate the structure but discard the result.
+  parseDesignTokens(json);
+  return json;
+}

--- a/src/adapters/node/token-provider.ts
+++ b/src/adapters/node/token-provider.ts
@@ -1,17 +1,17 @@
 import type { VariableProvider } from '../../core/environment.js';
-import type { DesignTokens } from '../../core/types.js';
+import type { LegacyDesignTokens } from '../../core/types.js';
 import {
   normalizeTokens,
   type NormalizedTokens,
 } from '../../core/token-utils.js';
 
 export class NodeTokenProvider implements VariableProvider {
-  private tokens?: DesignTokens | Record<string, DesignTokens>;
+  private tokens?: LegacyDesignTokens | Record<string, LegacyDesignTokens>;
   private wrapVar: boolean;
   private normalized?: NormalizedTokens;
 
   constructor(
-    tokens?: DesignTokens | Record<string, DesignTokens>,
+    tokens?: LegacyDesignTokens | Record<string, LegacyDesignTokens>,
     wrapTokensWithVar = false,
   ) {
     this.tokens = tokens;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { Config } from '../core/linter.js';
-import type { DesignTokens } from '../core/types.js';
+import type { LegacyDesignTokens } from '../core/types.js';
 
 const severitySchema = z.union([
   z.literal('error'),
@@ -25,7 +25,7 @@ const tokenGroup = <T extends z.ZodType>(
 ): z.ZodType<Record<string, z.infer<T>> | (string | RegExp)[]> =>
   z.union([z.record(z.string(), schema), tokenPatternArray]);
 
-const baseTokensSchema: z.ZodType<DesignTokens> = z
+const baseTokensSchema: z.ZodType<LegacyDesignTokens> = z
   .object({
     colors: tokenGroup(z.string()).optional(),
     spacing: tokenGroup(z.number()).optional(),
@@ -50,8 +50,9 @@ const baseTokensSchema: z.ZodType<DesignTokens> = z
   })
   .catchall(z.unknown());
 
-const tokensSchema: z.ZodType<DesignTokens | Record<string, DesignTokens>> =
-  z.union([baseTokensSchema, z.record(z.string(), baseTokensSchema)]);
+const tokensSchema: z.ZodType<
+  LegacyDesignTokens | Record<string, LegacyDesignTokens>
+> = z.union([baseTokensSchema, z.record(z.string(), baseTokensSchema)]);
 
 export const configSchema: z.ZodType<Config> = z
   .object({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { Config } from '../core/linter.js';
-import type { LegacyDesignTokens } from '../core/types.js';
+import type { DesignTokens, LegacyDesignTokens } from '../core/types.js';
 
 const severitySchema = z.union([
   z.literal('error'),
@@ -16,43 +16,20 @@ const ruleSettingSchema = z.union([
   z.tuple([severitySchema, z.unknown()]),
 ]);
 
-const numberOrString = z.union([z.number(), z.string()]);
-
-const tokenPatternArray = z.array(z.union([z.string(), z.instanceof(RegExp)]));
-
-const tokenGroup = <T extends z.ZodType>(
-  schema: T,
-): z.ZodType<Record<string, z.infer<T>> | (string | RegExp)[]> =>
-  z.union([z.record(z.string(), schema), tokenPatternArray]);
-
-const baseTokensSchema: z.ZodType<LegacyDesignTokens> = z
-  .object({
-    colors: tokenGroup(z.string()).optional(),
-    spacing: tokenGroup(z.number()).optional(),
-    zIndex: tokenGroup(z.number()).optional(),
-    borderRadius: tokenGroup(numberOrString).optional(),
-    borderWidths: tokenGroup(numberOrString).optional(),
-    shadows: tokenGroup(z.string()).optional(),
-    durations: tokenGroup(numberOrString).optional(),
-    animations: tokenGroup(z.string()).optional(),
-    blurs: tokenGroup(numberOrString).optional(),
-    borderColors: tokenGroup(z.string()).optional(),
-    opacity: tokenGroup(numberOrString).optional(),
-    outlines: tokenGroup(z.string()).optional(),
-    fontSizes: tokenGroup(numberOrString).optional(),
-    fonts: tokenGroup(z.string()).optional(),
-    lineHeights: tokenGroup(numberOrString).optional(),
-    fontWeights: tokenGroup(numberOrString).optional(),
-    letterSpacings: tokenGroup(numberOrString).optional(),
-    deprecations: z
-      .record(z.string(), z.object({ replacement: z.string().optional() }))
-      .optional(),
-  })
-  .catchall(z.unknown());
+const designTokensSchema = z.record(
+  z.string(),
+  z.unknown(),
+) as unknown as z.ZodType<DesignTokens>;
 
 const tokensSchema: z.ZodType<
-  LegacyDesignTokens | Record<string, LegacyDesignTokens>
-> = z.union([baseTokensSchema, z.record(z.string(), baseTokensSchema)]);
+  | DesignTokens
+  | Record<string, DesignTokens | string>
+  | LegacyDesignTokens
+  | Record<string, LegacyDesignTokens | string>
+> = z.union([
+  designTokensSchema,
+  z.record(z.string(), z.union([designTokensSchema, z.string()])),
+]);
 
 export const configSchema: z.ZodType<Config> = z
   .object({

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,6 +16,9 @@ export type {
   RuleContext,
   RuleListener,
   DesignTokens,
+  Token,
+  TokenGroup,
+  LegacyDesignTokens,
   PluginModule,
   CSSDeclaration,
   Fix,
@@ -26,6 +29,9 @@ export {
   extractVarName,
   mergeTokens,
   normalizeTokens,
+  flattenDesignTokens,
   type TokenPattern,
   type NormalizedTokens,
+  type FlattenedToken,
 } from './token-utils.js';
+export { parseDesignTokens } from './token-parser.js';

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -3,6 +3,7 @@ import type {
   LegacyDesignTokens,
   LintMessage,
   RuleContext,
+  DesignTokens,
 } from './types.js';
 import { mergeTokens, extractVarName } from './token-utils.js';
 export { defaultIgnore } from './ignore.js';
@@ -17,7 +18,11 @@ import type {
 import { parserRegistry } from './parser-registry.js';
 
 export interface Config {
-  tokens?: LegacyDesignTokens | Record<string, LegacyDesignTokens>;
+  tokens?:
+    | LegacyDesignTokens
+    | Record<string, LegacyDesignTokens>
+    | DesignTokens
+    | Record<string, DesignTokens | string>;
   rules?: Record<string, unknown>;
   ignoreFiles?: string[];
   plugins?: string[];

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -1,6 +1,6 @@
 import type {
   LintResult,
-  DesignTokens,
+  LegacyDesignTokens,
   LintMessage,
   RuleContext,
 } from './types.js';
@@ -17,7 +17,7 @@ import type {
 import { parserRegistry } from './parser-registry.js';
 
 export interface Config {
-  tokens?: DesignTokens | Record<string, DesignTokens>;
+  tokens?: LegacyDesignTokens | Record<string, LegacyDesignTokens>;
   rules?: Record<string, unknown>;
   ignoreFiles?: string[];
   plugins?: string[];
@@ -28,7 +28,7 @@ export interface Config {
 }
 
 interface ResolvedConfig extends Omit<Config, 'tokens'> {
-  tokens: DesignTokens;
+  tokens: LegacyDesignTokens;
 }
 
 /**
@@ -36,7 +36,7 @@ interface ResolvedConfig extends Omit<Config, 'tokens'> {
  */
 export class Linter {
   private config: ResolvedConfig;
-  private tokensByTheme: Record<string, DesignTokens> = {};
+  private tokensByTheme: Record<string, LegacyDesignTokens> = {};
   private ruleRegistry: RuleRegistry;
   private tokenTracker: TokenTracker;
   private source: Environment['documentSource'];
@@ -49,9 +49,9 @@ export class Linter {
         Promise.resolve({
           themes: (config.tokens ? { default: config.tokens } : {}) as Record<
             string,
-            DesignTokens
+            LegacyDesignTokens
           >,
-          merged: (config.tokens ?? {}) as DesignTokens,
+          merged: (config.tokens ?? {}) as LegacyDesignTokens,
         }),
     };
     this.config = { ...config, tokens: {} };

--- a/src/core/token-parser.ts
+++ b/src/core/token-parser.ts
@@ -1,0 +1,467 @@
+import type { DesignTokens, Token, TokenGroup } from './types.js';
+import type { FlattenedToken } from './token-utils.js';
+
+const GROUP_PROPS = new Set([
+  '$type',
+  '$description',
+  '$extensions',
+  '$deprecated',
+  '$schema',
+]);
+const INVALID_NAME_CHARS = /[{}\.]/;
+const ALIAS_PATTERN = /^\{([^}]+)\}$/;
+
+const STROKE_STYLE_KEYWORDS = new Set([
+  'solid',
+  'dashed',
+  'dotted',
+  'double',
+  'groove',
+  'ridge',
+  'outset',
+  'inset',
+]);
+const STROKE_LINECAPS = new Set(['round', 'butt', 'square']);
+const FONT_WEIGHT_KEYWORDS = new Set([
+  'thin',
+  'hairline',
+  'extra-light',
+  'ultra-light',
+  'light',
+  'normal',
+  'regular',
+  'book',
+  'medium',
+  'semi-bold',
+  'demi-bold',
+  'bold',
+  'extra-bold',
+  'ultra-bold',
+  'black',
+  'heavy',
+  'extra-black',
+  'ultra-black',
+]);
+
+function isToken(node: Token | TokenGroup): node is Token {
+  return '$value' in node;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isAlias(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    return m ? m[1] : null;
+  }
+  return null;
+}
+
+function validateExtensions(value: unknown, path: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    throw new Error(`Token or group ${path} has invalid $extensions`);
+  }
+  for (const key of Object.keys(value)) {
+    if (!key.includes('.')) {
+      throw new Error(
+        `Token or group ${path} has invalid $extensions key: ${key}`,
+      );
+    }
+  }
+}
+
+function validateDeprecated(value: unknown, path: string): void {
+  if (value === undefined) return;
+  if (typeof value !== 'boolean' && typeof value !== 'string') {
+    throw new Error(`Token or group ${path} has invalid $deprecated`);
+  }
+}
+
+function validateMetadata(
+  node: { $extensions?: unknown; $deprecated?: unknown },
+  path: string,
+): void {
+  validateExtensions(node.$extensions, path);
+  validateDeprecated(node.$deprecated, path);
+}
+
+function resolveAlias(
+  targetPath: string,
+  tokenMap: Map<string, Token>,
+  stack: string[],
+): Token {
+  if (stack.includes(targetPath)) {
+    throw new Error(
+      `Circular alias reference: ${[...stack, targetPath].join(' -> ')}`,
+    );
+  }
+  const target = tokenMap.get(targetPath);
+  if (!target) {
+    const source = stack[0];
+    throw new Error(`Token ${source} references unknown token: ${targetPath}`);
+  }
+  const next =
+    typeof target.$value === 'string'
+      ? ALIAS_PATTERN.exec(target.$value)
+      : null;
+  if (next) {
+    return resolveAlias(next[1], tokenMap, [...stack, targetPath]);
+  }
+  if (!target.$type) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $type: ${targetPath}`,
+    );
+  }
+  if (target.$value === undefined) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $value: ${targetPath}`,
+    );
+  }
+  return target;
+}
+
+function expectAlias(
+  value: string,
+  path: string,
+  expected: string,
+  tokenMap: Map<string, Token>,
+): void {
+  const targetPath = isAlias(value);
+  if (!targetPath) {
+    throw new Error(`Token ${path} has invalid ${expected} reference`);
+  }
+  const target = resolveAlias(targetPath, tokenMap, [path]);
+  if (target.$type !== expected) {
+    throw new Error(
+      `Token ${path} references token of type ${String(target.$type)}; expected ${expected}`,
+    );
+  }
+}
+
+function validateColor(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    if (m) expectAlias(value, path, 'color', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid color value`);
+}
+
+function validateDimension(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (
+    isRecord(value) &&
+    typeof value.value === 'number' &&
+    typeof value.unit === 'string'
+  ) {
+    return;
+  }
+  if (typeof value === 'string') {
+    expectAlias(value, path, 'dimension', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid dimension value`);
+}
+
+function validateNumber(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (typeof value === 'number') return;
+  if (typeof value === 'string') {
+    expectAlias(value, path, 'number', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid number value`);
+}
+
+function validateFontFamily(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    if (m) expectAlias(value, path, 'fontFamily', tokenMap);
+    return;
+  }
+  if (Array.isArray(value) && value.every((v) => typeof v === 'string')) return;
+  throw new Error(`Token ${path} has invalid fontFamily value`);
+}
+
+function validateFontWeight(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (typeof value === 'number') {
+    if (value < 1 || value > 1000) {
+      throw new Error(`Token ${path} has invalid fontWeight value`);
+    }
+    return;
+  }
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    if (m) {
+      expectAlias(value, path, 'fontWeight', tokenMap);
+      return;
+    }
+    if (FONT_WEIGHT_KEYWORDS.has(value)) return;
+  }
+  throw new Error(`Token ${path} has invalid fontWeight value`);
+}
+
+function validateShadow(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  const items = Array.isArray(value) ? (value as unknown[]) : [value];
+  if (!Array.isArray(items)) {
+    throw new Error(`Token ${path} has invalid shadow value`);
+  }
+  for (let i = 0; i < items.length; i++) {
+    const item: unknown = items[i];
+    if (!isRecord(item)) {
+      throw new Error(`Token ${path} has invalid shadow value`);
+    }
+    const base = `${path}[${String(i)}]`;
+    validateColor(item.color, `${base}.color`, tokenMap);
+    validateDimension(item.offsetX, `${base}.offsetX`, tokenMap);
+    validateDimension(item.offsetY, `${base}.offsetY`, tokenMap);
+    validateDimension(item.blur, `${base}.blur`, tokenMap);
+    validateDimension(item.spread, `${base}.spread`, tokenMap);
+    if ('inset' in item && typeof item.inset !== 'boolean') {
+      throw new Error(`Token ${path} has invalid shadow value`);
+    }
+  }
+}
+
+function validateStrokeStyle(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (typeof value === 'string') {
+    if (!STROKE_STYLE_KEYWORDS.has(value)) {
+      throw new Error(`Token ${path} has invalid strokeStyle value`);
+    }
+    return;
+  }
+  if (isRecord(value)) {
+    if (!Array.isArray(value.dashArray) || value.dashArray.length === 0) {
+      throw new Error(`Token ${path} has invalid strokeStyle value`);
+    }
+    for (let i = 0; i < value.dashArray.length; i++) {
+      validateDimension(
+        value.dashArray[i],
+        `${path}.dashArray[${String(i)}]`,
+        tokenMap,
+      );
+    }
+    if (
+      typeof value.lineCap !== 'string' ||
+      !STROKE_LINECAPS.has(value.lineCap)
+    ) {
+      throw new Error(`Token ${path} has invalid strokeStyle value`);
+    }
+    return;
+  }
+  throw new Error(`Token ${path} has invalid strokeStyle value`);
+}
+
+function validateGradient(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Token ${path} has invalid gradient value`);
+  }
+  const stops = value as unknown[];
+  for (let i = 0; i < stops.length; i++) {
+    const stop: unknown = stops[i];
+    if (!isRecord(stop)) {
+      throw new Error(`Token ${path} has invalid gradient value`);
+    }
+    validateColor(stop.color, `${path}[${String(i)}].color`, tokenMap);
+    const pos = stop.position;
+    if (typeof pos === 'number') {
+      // allow any number; clamping is handled by consumers
+    } else if (typeof pos === 'string') {
+      expectAlias(pos, `${path}[${String(i)}].position`, 'number', tokenMap);
+    } else {
+      throw new Error(`Token ${path} has invalid gradient value`);
+    }
+  }
+}
+
+function validateTypography(
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+): void {
+  if (!isRecord(value)) {
+    throw new Error(`Token ${path} has invalid typography value`);
+  }
+  const { fontFamily, fontSize, fontWeight, lineHeight } = value;
+  if (
+    fontFamily === undefined ||
+    fontSize === undefined ||
+    fontWeight === undefined ||
+    lineHeight === undefined
+  ) {
+    throw new Error(`Token ${path} has invalid typography value`);
+  }
+  validateFontFamily(fontFamily, `${path}.fontFamily`, tokenMap);
+  validateDimension(fontSize, `${path}.fontSize`, tokenMap);
+  validateFontWeight(fontWeight, `${path}.fontWeight`, tokenMap);
+  validateNumber(lineHeight, `${path}.lineHeight`, tokenMap);
+}
+
+function validateToken(
+  path: string,
+  token: Token,
+  tokenMap: Map<string, Token>,
+): void {
+  validateMetadata(token, path);
+  if (typeof token.$value === 'string') {
+    const match = ALIAS_PATTERN.exec(token.$value);
+    if (match) {
+      const target = resolveAlias(match[1], tokenMap, [path]);
+      const aliasType = target.$type;
+      if (!aliasType) {
+        throw new Error(
+          `Token ${path} references token without $type: ${match[1]}`,
+        );
+      }
+      if (!token.$type) {
+        token.$type = aliasType;
+      } else if (token.$type !== aliasType) {
+        throw new Error(
+          `Token ${path} has mismatched $type ${token.$type}; expected ${aliasType}`,
+        );
+      }
+    }
+  }
+
+  if (!token.$type) {
+    throw new Error(`Token ${path} is missing $type`);
+  }
+
+  switch (token.$type) {
+    case 'color':
+      validateColor(token.$value, path, tokenMap);
+      break;
+    case 'dimension':
+      validateDimension(token.$value, path, tokenMap);
+      break;
+    case 'number':
+      validateNumber(token.$value, path, tokenMap);
+      break;
+    case 'fontFamily':
+      validateFontFamily(token.$value, path, tokenMap);
+      break;
+    case 'fontWeight':
+      validateFontWeight(token.$value, path, tokenMap);
+      break;
+    case 'shadow':
+      validateShadow(token.$value, path, tokenMap);
+      break;
+    case 'strokeStyle':
+      validateStrokeStyle(token.$value, path, tokenMap);
+      break;
+    case 'gradient':
+      validateGradient(token.$value, path, tokenMap);
+      break;
+    case 'typography':
+      validateTypography(token.$value, path, tokenMap);
+      break;
+  }
+}
+
+export function parseDesignTokens(tokens: DesignTokens): FlattenedToken[] {
+  const result: FlattenedToken[] = [];
+  const seenPaths = new Map<string, string>();
+
+  function walk(
+    group: TokenGroup,
+    prefix: string[],
+    inheritedType?: string,
+    inheritedDeprecated?: boolean | string,
+  ): void {
+    const pathLabel = prefix.length ? prefix.join('.') : '(root)';
+    validateMetadata(group, pathLabel);
+    const currentType = group.$type ?? inheritedType;
+    const currentDeprecated = group.$deprecated ?? inheritedDeprecated;
+    const seenNames = new Map<string, string>();
+
+    for (const name of Object.keys(group)) {
+      if (GROUP_PROPS.has(name)) continue;
+      if (name.startsWith('$')) {
+        throw new Error(`Invalid token or group name: ${name}`);
+      }
+      if (INVALID_NAME_CHARS.test(name)) {
+        throw new Error(`Invalid token or group name: ${name}`);
+      }
+      const lower = name.toLowerCase();
+      const existing = seenNames.get(lower);
+      if (existing) {
+        if (existing === name) {
+          throw new Error(`Duplicate token name: ${name}`);
+        }
+        throw new Error(
+          `Duplicate token name differing only by case: ${existing} vs ${name}`,
+        );
+      }
+      seenNames.set(lower, name);
+
+      const node = (group as Record<string, TokenGroup | Token | undefined>)[
+        name
+      ];
+      if (node === undefined) continue;
+      const pathParts = [...prefix, name];
+      const pathId = pathParts.join('.');
+      const lowerPath = pathId.toLowerCase();
+      const existingPath = seenPaths.get(lowerPath);
+      if (existingPath) {
+        if (existingPath === pathId) {
+          throw new Error(`Duplicate token path: ${pathId}`);
+        }
+        throw new Error(
+          `Duplicate token path differing only by case: ${existingPath} vs ${pathId}`,
+        );
+      }
+      seenPaths.set(lowerPath, pathId);
+
+      if (isToken(node)) {
+        const token: Token = { ...node, $type: node.$type ?? currentType };
+        const tokenDeprecated = token.$deprecated ?? currentDeprecated;
+        if (tokenDeprecated !== undefined) token.$deprecated = tokenDeprecated;
+        result.push({ path: pathId, token });
+      } else {
+        walk(node, pathParts, currentType, currentDeprecated);
+      }
+    }
+  }
+
+  walk(tokens, [], undefined, undefined);
+  const tokenMap = new Map(result.map((t) => [t.path, t.token]));
+  for (const { path, token } of result) {
+    validateToken(path, token, tokenMap);
+  }
+  return result;
+}

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -1,4 +1,4 @@
-import type { DesignTokens, LintResult } from './types.js';
+import type { LegacyDesignTokens, LintResult } from './types.js';
 import type { TokenProvider } from './environment.js';
 
 type TokenType = 'cssVar' | 'hexColor' | 'numeric' | 'string';
@@ -102,7 +102,7 @@ export class TokenTracker {
   }
 }
 
-function collectTokenValues(tokens?: DesignTokens): Set<string> {
+function collectTokenValues(tokens?: LegacyDesignTokens): Set<string> {
   const values = new Set<string>();
   if (!tokens) return values;
   for (const [group, defs] of Object.entries(tokens)) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,7 +6,38 @@ export interface VariableDefinition {
   aliasOf?: string;
 }
 
-export interface DesignTokens {
+/**
+ * W3C Design Tokens Format token node.
+ */
+export interface Token {
+  $value: unknown;
+  $type?: string;
+  $description?: string;
+  $extensions?: Record<string, unknown>;
+  $deprecated?: boolean | string;
+}
+
+/**
+ * W3C Design Tokens Format group node.
+ */
+export type TokenGroup = {
+  $type?: string;
+  $description?: string;
+  $extensions?: Record<string, unknown>;
+  $deprecated?: boolean | string;
+} & {
+  [name: string]: TokenGroup | Token | undefined;
+};
+
+/**
+ * W3C Design Tokens tree.
+ */
+export type DesignTokens = TokenGroup;
+
+/**
+ * Legacy token configuration model.
+ */
+export interface LegacyDesignTokens {
   /** Color tokens. */
   colors?: Record<string, string> | (string | RegExp)[];
   /** Spacing scale tokens. */
@@ -69,7 +100,7 @@ export interface LintResult {
 
 export interface RuleContext<TOptions = unknown> {
   report: (msg: Omit<LintMessage, 'ruleId' | 'severity'>) => void;
-  tokens: DesignTokens;
+  tokens: LegacyDesignTokens;
   options?: TOptions;
   metadata?: Record<string, unknown>;
   sourceId: string;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -251,6 +251,38 @@ void test('loads config with multi-theme tokens', async () => {
   assert.equal(light?.colors?.primary, '#fff');
 });
 
+void test('loads config with spec token tree', async () => {
+  const tmp = makeTmpDir();
+  fs.writeFileSync(
+    path.join(tmp, 'designlint.config.json'),
+    JSON.stringify({
+      tokens: {
+        color: { brand: { primary: { $type: 'color', $value: '#000' } } },
+      },
+    }),
+  );
+  const loaded = await loadConfig(tmp);
+  const tokens = loaded.tokens as {
+    color: { brand: { primary: { $value: string } } };
+  };
+  assert.equal(tokens.color.brand.primary.$value, '#000');
+});
+
+void test('allows theme token file paths', async () => {
+  const tmp = makeTmpDir();
+  fs.writeFileSync(
+    path.join(tmp, 'designlint.config.json'),
+    JSON.stringify({ tokens: { light: './light.tokens.json' } }),
+  );
+  fs.writeFileSync(
+    path.join(tmp, 'light.tokens.json'),
+    JSON.stringify({ color: { brand: { primary: { $value: '#000' } } } }),
+  );
+  const loaded = await loadConfig(tmp);
+  const tokens = loaded.tokens as Record<string, unknown>;
+  assert.equal(tokens.light, './light.tokens.json');
+});
+
 void test('surfaces errors thrown by ts config', async () => {
   const tmp = makeTmpDir();
   const configPath = path.join(tmp, 'designlint.config.ts');

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -268,7 +268,7 @@ void test('loads config with spec token tree', async () => {
   assert.equal(tokens.color.brand.primary.$value, '#000');
 });
 
-void test('allows theme token file paths', async () => {
+void test('loads tokens from theme file paths', async () => {
   const tmp = makeTmpDir();
   fs.writeFileSync(
     path.join(tmp, 'designlint.config.json'),
@@ -280,7 +280,33 @@ void test('allows theme token file paths', async () => {
   );
   const loaded = await loadConfig(tmp);
   const tokens = loaded.tokens as Record<string, unknown>;
-  assert.equal(tokens.light, './light.tokens.json');
+  const light = tokens.light as {
+    color: { brand: { primary: { $value: string } } };
+  };
+  assert.equal(light.color.brand.primary.$value, '#000');
+});
+
+void test('resolves token file paths relative to config', async () => {
+  const tmp = makeTmpDir();
+  const cfgDir = path.join(tmp, 'cfg');
+  fs.mkdirSync(cfgDir);
+  fs.writeFileSync(
+    path.join(cfgDir, 'designlint.config.json'),
+    JSON.stringify({ tokens: { light: './tokens.tokens.json' } }),
+  );
+  fs.writeFileSync(
+    path.join(cfgDir, 'tokens.tokens.json'),
+    JSON.stringify({ color: { brand: { primary: { $value: '#111' } } } }),
+  );
+  const loaded = await loadConfig(
+    tmp,
+    path.join('cfg', 'designlint.config.json'),
+  );
+  const tokens = loaded.tokens as Record<string, unknown>;
+  const light = tokens.light as {
+    color: { brand: { primary: { $value: string } } };
+  };
+  assert.equal(light.color.brand.primary.$value, '#111');
 });
 
 void test('surfaces errors thrown by ts config', async () => {

--- a/tests/core/flatten-design-tokens.test.ts
+++ b/tests/core/flatten-design-tokens.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { flattenDesignTokens } from '../../src/core/token-utils.ts';
+import type { DesignTokens } from '../../src/core/types.ts';
+
+void test('flattenDesignTokens collects token paths and inherits types', () => {
+  const tokens: DesignTokens = {
+    colors: {
+      $type: 'color',
+      red: { $value: '#ff0000' },
+      accent: { $value: '#00ff00', $type: 'special' },
+      nested: {
+        green: { $value: '#00ff00' },
+      },
+    },
+    size: {
+      spacing: {
+        $type: 'dimension',
+        small: { $value: 4 },
+      },
+    },
+  };
+  const flat = flattenDesignTokens(tokens);
+  assert.deepEqual(flat, [
+    { path: 'colors.red', token: { $value: '#ff0000', $type: 'color' } },
+    {
+      path: 'colors.accent',
+      token: { $value: '#00ff00', $type: 'special' },
+    },
+    {
+      path: 'colors.nested.green',
+      token: { $value: '#00ff00', $type: 'color' },
+    },
+    { path: 'size.spacing.small', token: { $value: 4, $type: 'dimension' } },
+  ]);
+});
+
+void test('flattenDesignTokens preserves $extensions and inherits $deprecated', () => {
+  const ext = { 'org.example.tool': { foo: 1 } };
+  const tokens: DesignTokens = {
+    theme: {
+      $type: 'color',
+      $deprecated: true,
+      base: { $value: '#000', $extensions: ext },
+      active: { $value: '#fff', $deprecated: false },
+    },
+  };
+  const flat = flattenDesignTokens(tokens);
+  assert.deepEqual(
+    flat.find((t) => t.path === 'theme.base')?.token.$extensions,
+    ext,
+  );
+  assert.equal(
+    flat.find((t) => t.path === 'theme.base')?.token.$deprecated,
+    true,
+  );
+  assert.equal(
+    flat.find((t) => t.path === 'theme.active')?.token.$deprecated,
+    false,
+  );
+});

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -1,0 +1,351 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { parseDesignTokens } from '../../src/core/token-parser.ts';
+import { parseDesignTokensFile } from '../../src/adapters/node/token-parser.ts';
+import type { DesignTokens } from '../../src/core/types.js';
+
+void test('parseDesignTokens flattens tokens with paths in declaration order', () => {
+  const tokens: DesignTokens = {
+    color: {
+      $type: 'color',
+      blue: { $value: '#00f' },
+      red: { $value: '#f00' },
+    },
+    spacing: {
+      $type: 'dimension',
+      sm: { $value: { value: 4, unit: 'px' } },
+    },
+  };
+
+  const result = parseDesignTokens(tokens);
+  assert.deepEqual(
+    result.map((t) => t.path),
+    ['color.blue', 'color.red', 'spacing.sm'],
+  );
+});
+
+void test('parseDesignTokens rejects duplicate names differing only by case', () => {
+  const tokens = {
+    color: {
+      Blue: { $value: '#00f' },
+      blue: { $value: '#00f' },
+    },
+  } as unknown as DesignTokens;
+
+  assert.throws(() => parseDesignTokens(tokens), /differing only by case/i);
+});
+
+void test('parseDesignTokens rejects token names with forbidden characters', () => {
+  const tokens = {
+    'bad.name': { $value: 1 },
+  } as unknown as DesignTokens;
+
+  assert.throws(
+    () => parseDesignTokens(tokens),
+    /invalid token or group name/i,
+  );
+});
+
+void test('parseDesignTokens rejects names starting with $', () => {
+  const tokens = {
+    $bad: { $value: 1 },
+  } as unknown as DesignTokens;
+
+  assert.throws(
+    () => parseDesignTokens(tokens),
+    /invalid token or group name/i,
+  );
+});
+
+void test('parseDesignTokensFile reads a .tokens.json file', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'tokens-'));
+  const file = path.join(dir, 'theme.tokens.json');
+  const tokens: DesignTokens = {
+    color: { $type: 'color', blue: { $value: '#00f' } },
+  };
+  await writeFile(file, JSON.stringify(tokens), 'utf8');
+
+  const result = await parseDesignTokensFile(file);
+  assert.deepEqual(result[0], {
+    path: 'color.blue',
+    token: { $value: '#00f', $type: 'color' },
+  });
+});
+
+void test('parseDesignTokens rejects tokens missing explicit type', () => {
+  const tokens = { foo: { $value: 1 } } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /missing \$type/i);
+});
+
+void test('parseDesignTokens resolves alias token types', () => {
+  const tokens: DesignTokens = {
+    color: {
+      blue: { $value: '#00f', $type: 'color' },
+      brand: { $value: '{color.blue}' },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(
+    result.find((t) => t.path === 'color.brand')?.token.$type,
+    'color',
+  );
+});
+
+void test('parseDesignTokens validates dimension tokens', () => {
+  const tokens = {
+    size: { $type: 'dimension', sm: { $value: { value: 4, unit: 'px' } } },
+  } as unknown as DesignTokens;
+  const result = parseDesignTokens(tokens);
+  assert.equal(result[0].token.$type, 'dimension');
+
+  const invalid = {
+    size: { $type: 'dimension', sm: { $value: { value: 0 } } },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(invalid), /invalid dimension value/i);
+});
+void test('parseDesignTokens inherits types from parent groups', () => {
+  const tokens: DesignTokens = {
+    theme: {
+      $type: 'color',
+      brand: { $value: '#00f' },
+      nested: {
+        accent: { $value: '#f0f' },
+        size: {
+          $type: 'dimension',
+          sm: { $value: { value: 4, unit: 'px' } },
+        },
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(
+    result.find((t) => t.path === 'theme.brand')?.token.$type,
+    'color',
+  );
+  assert.equal(
+    result.find((t) => t.path === 'theme.nested.accent')?.token.$type,
+    'color',
+  );
+  assert.equal(
+    result.find((t) => t.path === 'theme.nested.size.sm')?.token.$type,
+    'dimension',
+  );
+});
+
+void test('parseDesignTokens rejects aliases referencing unknown tokens', () => {
+  const tokens = {
+    color: {
+      $type: 'color',
+      brand: { $value: '{color.missing}' },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /references unknown token/i);
+});
+
+void test('parseDesignTokens resolves alias chains', () => {
+  const tokens: DesignTokens = {
+    color: {
+      base: { $value: '#00f', $type: 'color' },
+      mid: { $value: '{color.base}' },
+      top: { $value: '{color.mid}' },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(
+    result.find((t) => t.path === 'color.top')?.token.$type,
+    'color',
+  );
+});
+
+void test('parseDesignTokens detects circular aliases', () => {
+  const tokens: DesignTokens = {
+    color: {
+      $type: 'color',
+      a: { $value: '{color.b}' },
+      b: { $value: '{color.a}' },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /circular alias/i);
+});
+
+void test('parseDesignTokens rejects alias chains with unknown targets', () => {
+  const tokens: DesignTokens = {
+    color: {
+      $type: 'color',
+      a: { $value: '{color.b}' },
+      b: { $value: '{color.missing}' },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /references unknown token/i);
+});
+
+void test('parseDesignTokens rejects alias chains when final target lacks $type', () => {
+  const tokens = {
+    a: { $value: '{b}' },
+    b: { $value: '#00f' },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /without \$type/i);
+});
+
+void test('parseDesignTokens validates shadow composite tokens', () => {
+  const tokens: DesignTokens = {
+    size: { $type: 'dimension', sm: { $value: { value: 1, unit: 'px' } } },
+    shadow: {
+      $type: 'shadow',
+      small: {
+        $value: {
+          color: '#000',
+          offsetX: '{size.sm}',
+          offsetY: '{size.sm}',
+          blur: { value: 2, unit: 'px' },
+          spread: { value: 0, unit: 'px' },
+        },
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(
+    result.find((t) => t.path === 'shadow.small')?.token.$type,
+    'shadow',
+  );
+
+  const invalid = {
+    shadow: {
+      $type: 'shadow',
+      bad: { $value: { color: '#000' } },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(invalid), /invalid dimension value/i);
+});
+
+void test('parseDesignTokens validates strokeStyle composite tokens', () => {
+  const tokens: DesignTokens = {
+    stroke: {
+      $type: 'strokeStyle',
+      dashed: { $value: 'dashed' },
+      custom: {
+        $value: {
+          dashArray: [{ value: 1, unit: 'px' }],
+          lineCap: 'round',
+        },
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(
+    result.find((t) => t.path === 'stroke.custom')?.token.$type,
+    'strokeStyle',
+  );
+
+  const invalid = {
+    stroke: {
+      $type: 'strokeStyle',
+      bad: { $value: { dashArray: [], lineCap: 'foo' } },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(invalid), /invalid strokeStyle value/i);
+});
+
+void test('parseDesignTokens validates gradient composite tokens', () => {
+  const tokens: DesignTokens = {
+    gradient: {
+      $type: 'gradient',
+      primary: {
+        $value: [
+          { color: '#000', position: 0 },
+          { color: '#fff', position: 1 },
+        ],
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(
+    result.find((t) => t.path === 'gradient.primary')?.token.$type,
+    'gradient',
+  );
+
+  const invalid = {
+    gradient: {
+      $type: 'gradient',
+      bad: { $value: [{ color: '#000' }] },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(invalid), /invalid gradient value/i);
+});
+
+void test('parseDesignTokens validates typography composite tokens', () => {
+  const tokens: DesignTokens = {
+    typography: {
+      $type: 'typography',
+      body: {
+        $value: {
+          fontFamily: 'Arial',
+          fontSize: { value: 16, unit: 'px' },
+          fontWeight: 400,
+          lineHeight: 1.5,
+        },
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(
+    result.find((t) => t.path === 'typography.body')?.token.$type,
+    'typography',
+  );
+
+  const invalid = {
+    typography: {
+      $type: 'typography',
+      bad: { $value: { fontFamily: 'Arial' } },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(invalid), /invalid typography value/i);
+});
+
+void test('parseDesignTokens preserves $extensions and $deprecated metadata', () => {
+  const ext = { 'org.example.tool': { flag: true } };
+  const tokens: DesignTokens = {
+    theme: {
+      $type: 'color',
+      $deprecated: 'use new theme',
+      brand: { $value: '#000', $extensions: ext },
+      active: { $value: '#fff', $deprecated: false },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.deepEqual(
+    result.find((t) => t.path === 'theme.brand')?.token.$extensions,
+    ext,
+  );
+  assert.equal(
+    result.find((t) => t.path === 'theme.brand')?.token.$deprecated,
+    'use new theme',
+  );
+  assert.equal(
+    result.find((t) => t.path === 'theme.active')?.token.$deprecated,
+    false,
+  );
+});
+
+void test('parseDesignTokens rejects invalid $extensions keys', () => {
+  const tokens = {
+    color: {
+      $type: 'color',
+      blue: { $value: '#00f', $extensions: { foo: 1 } },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /invalid \$extensions key/i);
+});
+
+void test('parseDesignTokens rejects invalid $deprecated values', () => {
+  const tokens = {
+    color: {
+      $type: 'color',
+      blue: { $value: '#00f', $deprecated: 123 as unknown as boolean },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /invalid \$deprecated/i);
+});

--- a/tests/core/token-tracker.test.ts
+++ b/tests/core/token-tracker.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { TokenTracker } from '../../src/core/token-tracker.ts';
-import type { DesignTokens } from '../../src/core/types.ts';
+import type { LegacyDesignTokens } from '../../src/core/types.ts';
 import type { TokenProvider } from '../../src/core/environment.ts';
 
-function makeProvider(tokens: DesignTokens): TokenProvider {
+function makeProvider(tokens: LegacyDesignTokens): TokenProvider {
   return {
     load: () =>
       Promise.resolve({ themes: { default: tokens }, merged: tokens }),
@@ -12,7 +12,7 @@ function makeProvider(tokens: DesignTokens): TokenProvider {
 }
 
 void test('TokenTracker reports unused tokens', async () => {
-  const tokens: DesignTokens = {
+  const tokens: LegacyDesignTokens = {
     colors: { red: 'var(--red)' },
     spacing: ['4px'],
   };
@@ -31,7 +31,7 @@ void test('TokenTracker reports unused tokens', async () => {
 });
 
 void test('cssVar classifier tracks custom property usage', async () => {
-  const tokens: DesignTokens = {
+  const tokens: LegacyDesignTokens = {
     colors: { used: 'var(--used)', unused: 'var(--unused)' },
   };
   const tracker = new TokenTracker(makeProvider(tokens));
@@ -49,7 +49,7 @@ void test('cssVar classifier tracks custom property usage', async () => {
 });
 
 void test('hexColor classifier is case-insensitive', async () => {
-  const tokens: DesignTokens = {
+  const tokens: LegacyDesignTokens = {
     colors: { brand: '#ABCDEF', other: '#123456' },
   };
   const tracker = new TokenTracker(makeProvider(tokens));
@@ -67,7 +67,7 @@ void test('hexColor classifier is case-insensitive', async () => {
 });
 
 void test('numeric classifier matches number tokens', async () => {
-  const tokens: DesignTokens = {
+  const tokens: LegacyDesignTokens = {
     spacing: ['4px', '8px'],
   };
   const tracker = new TokenTracker(makeProvider(tokens));
@@ -85,7 +85,7 @@ void test('numeric classifier matches number tokens', async () => {
 });
 
 void test('string classifier matches plain string tokens', async () => {
-  const tokens: DesignTokens = {
+  const tokens: LegacyDesignTokens = {
     colors: { used: 'red', unused: 'blue' },
   };
   const tracker = new TokenTracker(makeProvider(tokens));


### PR DESCRIPTION
## Summary
- add W3C Design Token `Token` and `TokenGroup` types
- rename existing token configuration to `LegacyDesignTokens`
- update internals to import legacy tokens
- add function to flatten spec-compliant token trees
- export token and token group types via core index
- add parser for `.tokens`/`.tokens.json` files that resolves token paths, inherits `$type`, guards against case-insensitive duplicates, and validates token/group names against reserved characters
- move `.tokens` file parser to Node adapter to keep core environment agnostic
- validate tokens have explicit `$type` and enforce type-specific semantics such as required `unit` for `dimension` tokens
- validate alias references in spec token parser and cover type inheritance/alias errors with tests
- validate composite token types like `shadow`, `strokeStyle`, `gradient`, and `typography`
- resolve alias chains lazily and detect circular references when parsing tokens
- preserve `$extensions` objects and `$deprecated` flags, inheriting deprecations from groups and verifying vendor-style keys

## Testing
- `npm run format`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c08aa72cd0832889bca3be25e9683f