### PR TITLE
ci: update smoke test token format

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -56,7 +56,7 @@ jobs:
           {
             "tokens": {
               "deprecations": { "old": { "replacement": "new" } },
-              "colors": { "primary": "#fff" }
+              "color": { "primary": { "$type": "color", "$value": "#fff" } }
             },
             "rules": {
               "design-system/deprecation": "error",
@@ -100,7 +100,7 @@ jobs:
           module.exports = {
             tokens: {
               deprecations: { old: { replacement: 'new' } },
-              colors: { primary: '#fff' }
+              color: { primary: { $type: 'color', $value: '#fff' } }
             },
             rules: {
               'design-system/deprecation': 'error',
@@ -114,7 +114,7 @@ jobs:
           module.exports = {
             tokens: {
               deprecations: { old: { replacement: 'new' } },
-              colors: { primary: '#fff' }
+              color: { primary: { $type: 'color', $value: '#fff' } }
             },
             rules: {
               'design-system/deprecation': 'error',
@@ -128,7 +128,7 @@ jobs:
           export default {
             tokens: {
               deprecations: { old: { replacement: 'new' } },
-              colors: { primary: '#fff' }
+              color: { primary: { $type: 'color', $value: '#fff' } }
             },
             rules: {
               'design-system/deprecation': 'error',
@@ -144,7 +144,7 @@ jobs:
           export default {
             tokens: {
               deprecations: { old: { replacement: 'new' } },
-              colors: { primary: '#fff' }
+              color: { primary: { $type: 'color', $value: '#fff' } }
             },
             rules: {
               'design-system/deprecation': 'error',
@@ -160,7 +160,7 @@ jobs:
           export default {
             tokens: {
               deprecations: { old: { replacement: 'new' } },
-              colors: { primary: '#fff' }
+              color: { primary: { $type: 'color', $value: '#fff' } }
             },
             rules: {
               'design-system/deprecation': 'error',


### PR DESCRIPTION
## Summary
- update CLI smoke test workflow to use W3C `$type`/`$value` token format
- clean up smoke test config formatting

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18e27464083288730a1e8deacd28d