### PR TITLE
ci(smoke): use new token format

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -52,18 +52,20 @@ jobs:
             test -f "designlint.config.$fmt"
           done
           rm -f designlint.config.*
-          cat > designlint.config.json <<'EOF'
-          {
-            "tokens": {
-              "deprecations": { "old": { "replacement": "new" } },
-              "color": { "primary": { "$type": "color", "$value": "#fff" } }
-            },
-            "rules": {
-              "design-system/deprecation": "error",
-              "design-token/colors": "warn"
+            cat > designlint.config.json <<'EOF'
+            {
+              "tokens": {
+                "color": {
+                  "old": { "$type": "color", "$value": "#000", "$deprecated": "Use {color.new}" },
+                  "new": { "$type": "color", "$value": "#fff" }
+                }
+              },
+              "rules": {
+                "design-system/deprecation": "error",
+                "design-token/colors": "warn"
+              }
             }
-          }
-          EOF
+            EOF
           echo "const a = 'old'; const b = '#000';" > file.ts
           echo "const a = 'old';" > ignored.ts
           echo "ignored.ts" > .extraignore
@@ -96,80 +98,90 @@ jobs:
           export default (results) => JSON.stringify(results)
           EOF
           npx design-lint file.ts --config designlint.config.json --format ./formatter.mjs || true
-          cat > designlint.config.js <<'EOF'
-          module.exports = {
-            tokens: {
-              deprecations: { old: { replacement: 'new' } },
-              color: { primary: { $type: 'color', $value: '#fff' } }
-            },
-            rules: {
-              'design-system/deprecation': 'error',
-              'design-token/colors': 'warn'
-            }
-          };
-          EOF
+            cat > designlint.config.js <<'EOF'
+            module.exports = {
+              tokens: {
+                color: {
+                  old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
+                  new: { $type: 'color', $value: '#fff' }
+                }
+              },
+              rules: {
+                'design-system/deprecation': 'error',
+                'design-token/colors': 'warn'
+              }
+            };
+            EOF
           npx design-lint file.ts --config designlint.config.js --format json || true
           rm designlint.config.js
-          cat > designlint.config.cjs <<'EOF'
-          module.exports = {
-            tokens: {
-              deprecations: { old: { replacement: 'new' } },
-              color: { primary: { $type: 'color', $value: '#fff' } }
-            },
-            rules: {
-              'design-system/deprecation': 'error',
-              'design-token/colors': 'warn'
-            }
-          };
-          EOF
+            cat > designlint.config.cjs <<'EOF'
+            module.exports = {
+              tokens: {
+                color: {
+                  old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
+                  new: { $type: 'color', $value: '#fff' }
+                }
+              },
+              rules: {
+                'design-system/deprecation': 'error',
+                'design-token/colors': 'warn'
+              }
+            };
+            EOF
           npx design-lint file.ts --config designlint.config.cjs --format json || true
           rm designlint.config.cjs
-          cat > designlint.config.mjs <<'EOF'
-          export default {
-            tokens: {
-              deprecations: { old: { replacement: 'new' } },
-              color: { primary: { $type: 'color', $value: '#fff' } }
-            },
-            rules: {
-              'design-system/deprecation': 'error',
-              'design-token/colors': 'warn'
-            }
-          };
-          EOF
+            cat > designlint.config.mjs <<'EOF'
+            export default {
+              tokens: {
+                color: {
+                  old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
+                  new: { $type: 'color', $value: '#fff' }
+                }
+              },
+              rules: {
+                'design-system/deprecation': 'error',
+                'design-token/colors': 'warn'
+              }
+            };
+            EOF
           npx design-lint file.ts --config designlint.config.mjs --format json || true
           rm designlint.config.mjs
-          cat > designlint.config.mts <<'EOF'
-          import type { Config } from '@lapidist/design-lint';
+            cat > designlint.config.mts <<'EOF'
+            import type { Config } from '@lapidist/design-lint';
 
-          export default {
-            tokens: {
-              deprecations: { old: { replacement: 'new' } },
-              color: { primary: { $type: 'color', $value: '#fff' } }
-            },
-            rules: {
-              'design-system/deprecation': 'error',
-              'design-token/colors': 'warn'
-            }
-          } satisfies Config;
-          EOF
+            export default {
+              tokens: {
+                color: {
+                  old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
+                  new: { $type: 'color', $value: '#fff' }
+                }
+              },
+              rules: {
+                'design-system/deprecation': 'error',
+                'design-token/colors': 'warn'
+              }
+            } satisfies Config;
+            EOF
           npx design-lint file.ts --config designlint.config.mts --format json || true
           rm designlint.config.mts
-          cat > designlint.config.ts <<'EOF'
-          import type { Config } from '@lapidist/design-lint';
+            cat > designlint.config.ts <<'EOF'
+            import type { Config } from '@lapidist/design-lint';
 
-          export default {
-            tokens: {
-              deprecations: { old: { replacement: 'new' } },
-              color: { primary: { $type: 'color', $value: '#fff' } }
-            },
-            rules: {
-              'design-system/deprecation': 'error',
-              'design-token/colors': 'warn'
-            }
-          } satisfies Config;
-          EOF
-          npx design-lint file.ts --config designlint.config.ts --format json || true
-          rm designlint.config.json
+            export default {
+              tokens: {
+                color: {
+                  old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
+                  new: { $type: 'color', $value: '#fff' }
+                }
+              },
+              rules: {
+                'design-system/deprecation': 'error',
+                'design-token/colors': 'warn'
+              }
+            } satisfies Config;
+            EOF
+            npx design-lint file.ts --config designlint.config.ts --format json || true
+            rm designlint.config.ts
             cat > suggestion.config.json <<'EOF'
             {
               "tokens": {


### PR DESCRIPTION
## Summary
- ensure smoke tests use tokens with `$deprecated` and `$type: color`
- fix EOF indentation in suggestion config block

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c19509cb488328b9c2b247da3ac3cd