### PR TITLE
test: specify token types in smoke fixtures

### DIFF
--- a/tests/fixtures/nested-config/designlint.config.json
+++ b/tests/fixtures/nested-config/designlint.config.json
@@ -1,4 +1,4 @@
 {
-  "tokens": { "colors": { "base": "#000000" } },
+  "tokens": { "colors": { "$type": "color", "base": { "$value": "#000000" } } },
   "rules": { "design-token/colors": "error" }
 }

--- a/tests/fixtures/nested-config/packages/app/designlint.config.json
+++ b/tests/fixtures/nested-config/packages/app/designlint.config.json
@@ -1,4 +1,4 @@
 {
-  "tokens": { "colors": { "primary": "#00ff00" } },
+  "tokens": { "colors": { "$type": "color", "primary": { "$value": "#00ff00" } } },
   "rules": { "design-token/colors": "error" }
 }

--- a/tests/fixtures/sample/designlint.config.json
+++ b/tests/fixtures/sample/designlint.config.json
@@ -1,4 +1,4 @@
 {
-  "tokens": { "colors": { "primary": "#000000" } },
+  "tokens": { "colors": { "$type": "color", "primary": { "$value": "#000000" } } },
   "rules": { "design-token/colors": "error" }
 }

--- a/tests/fixtures/tagged-template/designlint.config.json
+++ b/tests/fixtures/tagged-template/designlint.config.json
@@ -1,4 +1,4 @@
 {
-  "tokens": { "colors": { "primary": "#000000" } },
+  "tokens": { "colors": { "$type": "color", "primary": { "$value": "#000000" } } },
   "rules": { "design-token/colors": "error" }
 }


### PR DESCRIPTION
## Summary
- add `$type` metadata to color tokens in sample, tagged-template, and nested-config fixture configs so smoke tests can load tokens successfully

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b1302c7c83289205552a036c4348