### PR TITLE
fix(node): wrap inline token configs in default theme

### DIFF
--- a/.changeset/fix-inline-token-provider.md
+++ b/.changeset/fix-inline-token-provider.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix NodeTokenProvider default-theme detection for inline token configs

--- a/src/adapters/node/token-provider.ts
+++ b/src/adapters/node/token-provider.ts
@@ -28,10 +28,19 @@ export class NodeTokenProvider implements VariableProvider {
 function isThemeRecord(
   val: DesignTokens | Record<string, DesignTokens>,
 ): val is Record<string, DesignTokens> {
-  return Object.values(val).every(
-    (v) =>
-      v &&
-      typeof v === 'object' &&
-      !('$value' in (v as Record<string, unknown>)),
-  );
+  return Object.values(val).every((v) => {
+    if (!v || typeof v !== 'object') {
+      return false;
+    }
+    // Treat `v` as a theme only when its immediate children do not look like
+    // tokens (i.e. none expose a `$value` property). This allows single-theme
+    // token objects such as `{ color: { primary: { $value: '#fff' } } }` to be
+    // wrapped in a default theme while still accepting explicit theme maps.
+    return !Object.values(v as Record<string, unknown>).some(
+      (child) =>
+        child &&
+        typeof child === 'object' &&
+        '$value' in (child as Record<string, unknown>),
+    );
+  });
 }

--- a/tests/node-token-provider.test.ts
+++ b/tests/node-token-provider.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { NodeTokenProvider } from '../src/adapters/node/token-provider.ts';
+
+const tokens = {
+  color: {
+    primary: { $type: 'color', $value: '#fff' },
+  },
+};
+
+void test('wraps tokens in default theme when no theme map is provided', async () => {
+  const provider = new NodeTokenProvider(tokens);
+  const result = await provider.load();
+  assert.deepEqual(result.default, tokens);
+});
+
+void test('accepts explicit theme records without modification', async () => {
+  const themes = { light: tokens, dark: tokens };
+  const provider = new NodeTokenProvider(themes);
+  const result = await provider.load();
+  assert.deepEqual(result, themes);
+});


### PR DESCRIPTION
## Summary
- handle single-theme token objects by wrapping them in a default theme when no explicit theme map is provided
- add regression tests for NodeTokenProvider and record a patch-level changeset

## Testing
- `npm run lint`
- `npm run build`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7acb5ac832886474bba059802cc