### PR TITLE
refactor: reject legacy token shorthand

### DIFF
--- a/.changeset/reject-legacy-tokens.md
+++ b/.changeset/reject-legacy-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+reject legacy shorthand token syntax and enforce $type/$value

--- a/src/config/config-token-provider.ts
+++ b/src/config/config-token-provider.ts
@@ -33,6 +33,7 @@ function isThemeRecord(
     (v) =>
       v &&
       typeof v === 'object' &&
-      !('$value' in (v as Record<string, unknown>)),
+      !('$value' in (v as Record<string, unknown>)) &&
+      !('value' in (v as Record<string, unknown>)),
   );
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -6,6 +6,8 @@ import type { Config } from '../core/linter.js';
 import { configSchema } from './schema.js';
 import { realpathIfExists } from '../adapters/node/utils/paths.js';
 import { readDesignTokensFile } from '../adapters/node/token-parser.js';
+import { parseDesignTokens } from '../core/token-parser.js';
+import type { DesignTokens } from '../core/types.js';
 
 /**
  * Resolve and load configuration for the linter.
@@ -88,6 +90,25 @@ export async function loadConfig(
         themes[theme] = await readDesignTokensFile(filePath);
       }
     }
+    if (isThemeRecord(themes as Record<string, DesignTokens>)) {
+      for (const t of Object.values(themes)) {
+        parseDesignTokens(t as DesignTokens);
+      }
+    } else {
+      parseDesignTokens(themes as unknown as DesignTokens);
+    }
   }
   return config;
+}
+
+function isThemeRecord(
+  val: DesignTokens | Record<string, DesignTokens>,
+): val is Record<string, DesignTokens> {
+  return Object.values(val).every(
+    (v) =>
+      v &&
+      typeof v === 'object' &&
+      !('$value' in (v as Record<string, unknown>)) &&
+      !('value' in (v as Record<string, unknown>)),
+  );
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -382,6 +382,15 @@ void test('rejects unresolved token aliases', async () => {
   await assert.rejects(loadConfig(tmp), /references unknown token/);
 });
 
+void test('rejects inline tokens using legacy shorthand', async () => {
+  const tmp = makeTmpDir();
+  fs.writeFileSync(
+    path.join(tmp, 'designlint.config.json'),
+    JSON.stringify({ tokens: { color: { $type: 'color', blue: '#00f' } } }),
+  );
+  await assert.rejects(loadConfig(tmp), /must be an object with \$value/);
+});
+
 void test('rejects non-token file paths in config', async () => {
   const tmp = makeTmpDir();
   fs.writeFileSync(

--- a/tests/core/get-flattened-tokens.test.ts
+++ b/tests/core/get-flattened-tokens.test.ts
@@ -72,14 +72,15 @@ void test('getFlattenedTokens resolves aliases', () => {
   ]);
 });
 
-void test('getFlattenedTokens handles primitive token values', () => {
+void test('getFlattenedTokens rejects primitive token values', () => {
   const tokens = {
     default: {
       colors: { primary: '#fff' },
       deprecations: { old: { replacement: 'new' } },
     },
   } as unknown as Record<string, DesignTokens>;
-  assert.doesNotThrow(() => {
-    getFlattenedTokens(tokens, 'default');
-  });
+  assert.throws(
+    () => getFlattenedTokens(tokens, 'default'),
+    /must be an object with \$value/i,
+  );
 });

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -115,6 +115,23 @@ void test('parseDesignTokens rejects tokens missing $value', () => {
   assert.throws(() => parseDesignTokens(tokens), /missing \$value/i);
 });
 
+void test('parseDesignTokens rejects legacy shorthand token values', () => {
+  const tokens = {
+    color: { $type: 'color', blue: '#00f' },
+  } as unknown as DesignTokens;
+  assert.throws(
+    () => parseDesignTokens(tokens),
+    /must be an object with \$value/i,
+  );
+});
+
+void test('parseDesignTokens rejects legacy token properties', () => {
+  const tokens = {
+    color: { blue: { value: '#00f', type: 'color' } },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /legacy property/i);
+});
+
 void test('parseDesignTokens rejects tokens with mismatched $type and value', () => {
   const tokens = {
     color: { $type: 'color', bad: { $value: 123 as unknown as string } },


### PR DESCRIPTION
## Summary
- reject legacy token properties and primitive token values
- validate inline tokens in config loader
- add tests covering legacy shorthand rejection

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1be59df388328acec1117589b7a0b