### PR TITLE
fix(node): handle primitive token groups in NodeTokenProvider

### DIFF
--- a/.changeset/fix-node-provider-theme-metadata.md
+++ b/.changeset/fix-node-provider-theme-metadata.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix NodeTokenProvider misclassifying theme records with primitive metadata entries
+

--- a/src/adapters/node/token-provider.ts
+++ b/src/adapters/node/token-provider.ts
@@ -28,12 +28,16 @@ export class NodeTokenProvider implements VariableProvider {
 function isThemeRecord(
   val: DesignTokens | Record<string, DesignTokens>,
 ): val is Record<string, DesignTokens> {
-  return Object.values(val).every((v) => {
-    if (!v || typeof v !== 'object') {
+  return Object.entries(val).every(([themeName, theme]) => {
+    if (themeName.startsWith('$')) {
+      return true;
+    }
+
+    if (!theme || typeof theme !== 'object') {
       return false;
     }
 
-    return Object.entries(v as Record<string, unknown>).every(
+    return Object.entries(theme as Record<string, unknown>).every(
       ([key, child]) =>
         key.startsWith('$') ||
         (child &&

--- a/tests/node-token-provider.test.ts
+++ b/tests/node-token-provider.test.ts
@@ -34,3 +34,14 @@ void test('accepts explicit theme records without modification', async () => {
   const result = await provider.load();
   assert.deepEqual(result, themes);
 });
+
+void test('accepts theme records with primitive metadata fields', async () => {
+  const themesWithMetadata = {
+    light: tokens,
+    dark: tokens,
+    $metadata: { tokenSetOrder: ['light', 'dark'], version: 1 },
+  };
+  const provider = new NodeTokenProvider(themesWithMetadata);
+  const result = await provider.load();
+  assert.deepEqual(result, themesWithMetadata);
+});


### PR DESCRIPTION
## Summary
- correctly detect primitive token groups and wrap them under a default theme in NodeTokenProvider
- add regression test for primitive token group handling

## Testing
- `npm run lint`
- `npm run build`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c1463a04832885fcff2ac072af98