### PR TITLE
fix(config): validate tokens and surface parse errors

### DIFF
--- a/.changeset/w3c-token-schema.md
+++ b/.changeset/w3c-token-schema.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+require design token objects in config and surface token parsing errors

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -87,15 +87,33 @@ export async function loadConfig(
     for (const [theme, val] of Object.entries(themes)) {
       if (typeof val === 'string') {
         const filePath = path.resolve(baseDir, val);
-        themes[theme] = await readDesignTokensFile(filePath);
+        try {
+          themes[theme] = await readDesignTokensFile(filePath);
+        } catch (err) {
+          throw new Error(
+            `Failed to read tokens for theme "${theme}": ${(err as Error).message}`,
+          );
+        }
       }
     }
     if (isThemeRecord(themes as Record<string, DesignTokens>)) {
-      for (const t of Object.values(themes)) {
-        parseDesignTokens(t as DesignTokens);
+      for (const [theme, t] of Object.entries(
+        themes as Record<string, DesignTokens>,
+      )) {
+        try {
+          parseDesignTokens(t);
+        } catch (err) {
+          throw new Error(
+            `Failed to parse tokens for theme "${theme}": ${(err as Error).message}`,
+          );
+        }
       }
     } else {
-      parseDesignTokens(themes as unknown as DesignTokens);
+      try {
+        parseDesignTokens(themes as unknown as DesignTokens);
+      } catch (err) {
+        throw err instanceof Error ? err : new Error(String(err));
+      }
     }
   }
   return config;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -49,6 +49,26 @@ void test('throws on malformed JS config', async () => {
   await assert.rejects(loadConfig(tmp), /Transform failed/);
 });
 
+void test('rejects bare string token values', async () => {
+  const tmp = makeTmpDir();
+  const configPath = path.join(tmp, 'designlint.config.json');
+  fs.writeFileSync(configPath, JSON.stringify({ tokens: { color: '#000' } }));
+  await assert.rejects(
+    loadConfig(tmp),
+    /Tokens must be W3C Design Tokens objects/,
+  );
+});
+
+void test('propagates token parsing errors', async () => {
+  const tmp = makeTmpDir();
+  const configPath = path.join(tmp, 'designlint.config.json');
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ tokens: { color: { primary: { $type: 'color' } } } }),
+  );
+  await assert.rejects(loadConfig(tmp), /missing \$value/i);
+});
+
 void test('throws when specified config file is missing', async () => {
   const tmp = makeTmpDir();
   await assert.rejects(


### PR DESCRIPTION
## Summary
- enforce W3C Design Tokens objects in config schema
- surface token parsing failures during config loading
- test token validation and error propagation

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1cb4c908483289ed0d0351d332f75