### PR TITLE
docs: replace token examples with spec-compliant syntax

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,8 @@ Inline example:
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#ff0000" }
+      "primary": { "$type": "color", "$value": "#ff0000" },
+      "secondary": { "$type": "color", "$value": "{color.primary}" }
     }
   }
 }
@@ -66,7 +67,8 @@ To group tokens by theme, supply an object keyed by theme name. Each theme may c
     "light": "./light.tokens.json",
     "dark": {
       "color": {
-        "primary": { "$type": "color", "$value": "#ffffff" }
+        "primary": { "$type": "color", "$value": "#ffffff" },
+        "secondary": { "$type": "color", "$value": "{color.primary}" }
       }
     }
   }
@@ -121,6 +123,7 @@ export default defineConfig({
   tokens: {
     color: {
       primary: { $type: 'color', $value: '#ff0000' },
+      secondary: { $type: 'color', $value: '{color.primary}' },
     },
   },
   rules: { 'design-token/colors': 'error' },

--- a/docs/examples/basic/README.md
+++ b/docs/examples/basic/README.md
@@ -18,7 +18,7 @@ This example introduces design-lint with a single token and rule.
    ```
 
 ## Key files
-- `designlint.config.json` – defines a `primary` color token and enables the `design-token/colors` rule.
+- `designlint.config.json` – defines `primary` and `secondary` color tokens and enables the `design-token/colors` rule.
 
 ## Expected output
 When a file uses `#ff0000`, the linter reports an error suggesting the `primary` token.

--- a/docs/examples/basic/designlint.config.json
+++ b/docs/examples/basic/designlint.config.json
@@ -1,7 +1,8 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#ff0000" }
+      "primary": { "$type": "color", "$value": "#ff0000" },
+      "secondary": { "$type": "color", "$value": "{color.primary}" }
     }
   },
   "rules": {

--- a/docs/rules/design-system/deprecation.md
+++ b/docs/rules/design-system/deprecation.md
@@ -20,7 +20,8 @@ Enable this rule in `designlint.config.*`. See [configuration](../../configurati
         "$value": "#000",
         "$deprecated": "Use {color.new}"
       },
-      "new": { "$type": "color", "$value": "#fff" }
+      "new": { "$type": "color", "$value": "#fff" },
+      "alias": { "$type": "color", "$value": "{color.new}" }
     }
   },
   "rules": { "design-system/deprecation": "error" }

--- a/docs/rules/design-system/no-unused-tokens.md
+++ b/docs/rules/design-system/no-unused-tokens.md
@@ -23,7 +23,7 @@ Given this configuration:
   "tokens": {
     "color": {
       "primary": { "$type": "color", "$value": "#000000" },
-      "unused": { "$type": "color", "$value": "#ff0000" }
+      "unused": { "$type": "color", "$value": "{color.primary}" }
     }
   },
   "rules": { "design-system/no-unused-tokens": "warn" }

--- a/docs/rules/design-token/animation.md
+++ b/docs/rules/design-token/animation.md
@@ -15,8 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "animations": {
-      "$type": "string",
-      "spin": { "$value": "spin 1s linear infinite" }
+      "spin": { "$type": "string", "$value": "spin 1s linear infinite" },
+      "wiggle": { "$type": "string", "$value": "{animations.spin}" }
     }
   },
   "rules": { "design-token/animation": "error" }

--- a/docs/rules/design-token/blur.md
+++ b/docs/rules/design-token/blur.md
@@ -15,8 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "blurs": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
+      "md": { "$type": "dimension", "$value": "{blurs.sm}" }
     }
   },
   "rules": { "design-token/blur": "error" }

--- a/docs/rules/design-token/border-color.md
+++ b/docs/rules/design-token/border-color.md
@@ -14,7 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
-    "borderColors": { "$type": "color", "primary": { "$value": "#ffffff" } }
+    "borderColors": {
+      "primary": { "$type": "color", "$value": "#ffffff" },
+      "secondary": { "$type": "color", "$value": "{borderColors.primary}" }
+    }
   },
   "rules": { "design-token/border-color": "error" }
 }

--- a/docs/rules/design-token/border-radius.md
+++ b/docs/rules/design-token/border-radius.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "borderRadius": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 2, "unit": "px" } },
-      "lg": { "$value": { "value": 8, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 2, "unit": "px" } },
+      "lg": { "$type": "dimension", "$value": "{borderRadius.sm}" }
     }
   },
   "rules": { "design-token/border-radius": "error" }

--- a/docs/rules/design-token/border-width.md
+++ b/docs/rules/design-token/border-width.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "borderWidths": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 1, "unit": "px" } },
-      "lg": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 1, "unit": "px" } },
+      "lg": { "$type": "dimension", "$value": "{borderWidths.sm}" }
     }
   },
   "rules": { "design-token/border-width": "error" }

--- a/docs/rules/design-token/box-shadow.md
+++ b/docs/rules/design-token/box-shadow.md
@@ -15,15 +15,16 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "shadows": {
-      "$type": "shadow",
       "sm": {
+        "$type": "shadow",
         "$value": {
           "offsetX": { "value": 0, "unit": "px" },
           "offsetY": { "value": 1, "unit": "px" },
           "blur": { "value": 2, "unit": "px" },
           "color": "rgba(0,0,0,0.1)"
         }
-      }
+      },
+      "md": { "$type": "shadow", "$value": "{shadows.sm}" }
     }
   },
   "rules": { "design-token/box-shadow": "error" }

--- a/docs/rules/design-token/colors.md
+++ b/docs/rules/design-token/colors.md
@@ -13,7 +13,12 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 
 ```json
 {
-  "tokens": { "color": { "primary": { "$type": "color", "$value": "#ff0000" } } },
+  "tokens": {
+    "color": {
+      "primary": { "$type": "color", "$value": "#ff0000" },
+      "secondary": { "$type": "color", "$value": "{color.primary}" }
+    }
+  },
   "rules": {
     "design-token/colors": ["error", { "allow": ["named"] }]
   }

--- a/docs/rules/design-token/duration.md
+++ b/docs/rules/design-token/duration.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "durations": {
-      "$type": "duration",
-      "short": { "$value": { "value": 100, "unit": "ms" } },
-      "long": { "$value": { "value": 0.25, "unit": "s" } }
+      "short": { "$type": "duration", "$value": { "value": 100, "unit": "ms" } },
+      "long": { "$type": "duration", "$value": "{durations.short}" }
     }
   },
   "rules": { "design-token/duration": "error" }

--- a/docs/rules/design-token/font-family.md
+++ b/docs/rules/design-token/font-family.md
@@ -14,7 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Inter, sans-serif" } }
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Inter, sans-serif" },
+      "alt": { "$type": "fontFamily", "$value": "{fonts.sans}" }
+    }
   },
   "rules": { "design-token/font-family": "error" }
 }

--- a/docs/rules/design-token/font-size.md
+++ b/docs/rules/design-token/font-size.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "fontSizes": {
-      "$type": "dimension",
-      "base": { "$value": { "value": 1, "unit": "rem" } },
-      "lg": { "$value": { "value": 20, "unit": "px" } }
+      "base": { "$type": "dimension", "$value": { "value": 1, "unit": "rem" } },
+      "lg": { "$type": "dimension", "$value": "{fontSizes.base}" }
     }
   },
   "rules": { "design-token/font-size": "error" }

--- a/docs/rules/design-token/font-weight.md
+++ b/docs/rules/design-token/font-weight.md
@@ -15,10 +15,9 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "fontWeights": {
-      "$type": "fontWeight",
-      "regular": { "$value": 400 },
-      "bold": { "$value": 700 },
-      "emphasis": { "$value": "bold" }
+      "regular": { "$type": "fontWeight", "$value": 400 },
+      "bold": { "$type": "fontWeight", "$value": 700 },
+      "emphasis": { "$type": "fontWeight", "$value": "{fontWeights.bold}" }
     }
   },
   "rules": { "design-token/font-weight": "error" }

--- a/docs/rules/design-token/letter-spacing.md
+++ b/docs/rules/design-token/letter-spacing.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "letterSpacings": {
-      "$type": "dimension",
-      "tight": { "$value": { "value": -0.05, "unit": "em" } },
-      "loose": { "$value": { "value": 0.1, "unit": "em" } }
+      "tight": { "$type": "dimension", "$value": { "value": -0.05, "unit": "em" } },
+      "loose": { "$type": "dimension", "$value": "{letterSpacings.tight}" }
     }
   },
   "rules": { "design-token/letter-spacing": "error" }

--- a/docs/rules/design-token/line-height.md
+++ b/docs/rules/design-token/line-height.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "lineHeights": {
-      "$type": "number",
-      "base": { "$value": 1.5 },
-      "tight": { "$value": 2 }
+      "base": { "$type": "number", "$value": 1.5 },
+      "tight": { "$type": "number", "$value": "{lineHeights.base}" }
     }
   },
   "rules": { "design-token/line-height": "error" }

--- a/docs/rules/design-token/opacity.md
+++ b/docs/rules/design-token/opacity.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "opacity": {
-      "$type": "number",
-      "low": { "$value": 0.2 },
-      "high": { "$value": 0.8 }
+      "low": { "$type": "number", "$value": 0.2 },
+      "high": { "$type": "number", "$value": "{opacity.low}" }
     }
   },
   "rules": { "design-token/opacity": "error" }

--- a/docs/rules/design-token/outline.md
+++ b/docs/rules/design-token/outline.md
@@ -14,7 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
-    "outlines": { "$type": "string", "focus": { "$value": "2px solid #000" } }
+    "outlines": {
+      "focus": { "$type": "string", "$value": "2px solid #000" },
+      "active": { "$type": "string", "$value": "{outlines.focus}" }
+    }
   },
   "rules": { "design-token/outline": "error" }
 }

--- a/docs/rules/design-token/spacing.md
+++ b/docs/rules/design-token/spacing.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } },
-      "md": { "$value": { "value": 8, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
+      "md": { "$type": "dimension", "$value": "{spacing.sm}" }
     }
   },
   "rules": {

--- a/docs/rules/design-token/z-index.md
+++ b/docs/rules/design-token/z-index.md
@@ -15,9 +15,8 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "zIndex": {
-      "$type": "number",
-      "modal": { "$value": 1000 },
-      "dropdown": { "$value": 2000 }
+      "modal": { "$type": "number", "$value": 1000 },
+      "dropdown": { "$type": "number", "$value": "{zIndex.modal}" }
     }
   },
   "rules": { "design-token/z-index": "error" }

--- a/tests/fixtures/nested-config/designlint.config.json
+++ b/tests/fixtures/nested-config/designlint.config.json
@@ -1,4 +1,8 @@
 {
-  "tokens": { "colors": { "$type": "color", "base": { "$value": "#000000" } } },
+  "tokens": {
+    "color": {
+      "base": { "$type": "color", "$value": "#000000" }
+    }
+  },
   "rules": { "design-token/colors": "error" }
 }

--- a/tests/fixtures/nested-config/packages/app/designlint.config.json
+++ b/tests/fixtures/nested-config/packages/app/designlint.config.json
@@ -1,4 +1,8 @@
 {
-  "tokens": { "colors": { "$type": "color", "primary": { "$value": "#00ff00" } } },
+  "tokens": {
+    "color": {
+      "primary": { "$type": "color", "$value": "#00ff00" }
+    }
+  },
   "rules": { "design-token/colors": "error" }
 }

--- a/tests/fixtures/nextjs/designlint.config.json
+++ b/tests/fixtures/nextjs/designlint.config.json
@@ -1,15 +1,17 @@
 {
   "tokens": {
-    "color": { "$type": "color", "primary": { "$value": "#000000" } },
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    },
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
     },
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Arial" } },
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Arial" }
+    },
     "old-token": {
       "$type": "color",
       "$value": "#000000",

--- a/tests/fixtures/nuxt/designlint.config.json
+++ b/tests/fixtures/nuxt/designlint.config.json
@@ -1,15 +1,17 @@
 {
   "tokens": {
-    "color": { "$type": "color", "primary": { "$value": "#000000" } },
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    },
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
     },
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Arial" } },
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Arial" }
+    },
     "old-token": {
       "$type": "color",
       "$value": "#000000",

--- a/tests/fixtures/react-vite-css-modules/designlint.config.json
+++ b/tests/fixtures/react-vite-css-modules/designlint.config.json
@@ -1,19 +1,18 @@
 {
   "tokens": {
     "color": {
-      "$type": "color",
-      "primary": { "$value": "#000000" },
-      "unused": { "$value": "#ffffff" }
+      "primary": { "$type": "color", "$value": "#000000" },
+      "unused": { "$type": "color", "$value": "#ffffff" }
     },
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
     },
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Arial" } },
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Arial" }
+    },
     "old-token": {
       "$type": "color",
       "$value": "#000000",

--- a/tests/fixtures/remix/designlint.config.json
+++ b/tests/fixtures/remix/designlint.config.json
@@ -1,15 +1,17 @@
 {
   "tokens": {
-    "color": { "$type": "color", "primary": { "$value": "#000000" } },
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    },
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
     },
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Arial" } },
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Arial" }
+    },
     "old-token": {
       "$type": "color",
       "$value": "#000000",

--- a/tests/fixtures/sample/designlint.config.json
+++ b/tests/fixtures/sample/designlint.config.json
@@ -1,4 +1,8 @@
 {
-  "tokens": { "colors": { "$type": "color", "primary": { "$value": "#000000" } } },
+  "tokens": {
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    }
+  },
   "rules": { "design-token/colors": "error" }
 }

--- a/tests/fixtures/svelte/designlint.config.json
+++ b/tests/fixtures/svelte/designlint.config.json
@@ -1,15 +1,17 @@
 {
   "tokens": {
-    "color": { "$type": "color", "primary": { "$value": "#000000" } },
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    },
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
     },
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Arial" } },
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Arial" }
+    },
     "old-token": {
       "$type": "color",
       "$value": "#000000",

--- a/tests/fixtures/tagged-template/designlint.config.json
+++ b/tests/fixtures/tagged-template/designlint.config.json
@@ -1,4 +1,8 @@
 {
-  "tokens": { "colors": { "$type": "color", "primary": { "$value": "#000000" } } },
+  "tokens": {
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    }
+  },
   "rules": { "design-token/colors": "error" }
 }

--- a/tests/fixtures/vue/designlint.config.json
+++ b/tests/fixtures/vue/designlint.config.json
@@ -1,15 +1,17 @@
 {
   "tokens": {
-    "color": { "$type": "color", "primary": { "$value": "#000000" } },
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    },
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
     },
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Arial" } },
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Arial" }
+    },
     "old-token": {
       "$type": "color",
       "$value": "#000000",

--- a/tests/fixtures/web-components/designlint.config.json
+++ b/tests/fixtures/web-components/designlint.config.json
@@ -1,15 +1,17 @@
 {
   "tokens": {
-    "color": { "$type": "color", "primary": { "$value": "#000000" } },
+    "color": {
+      "primary": { "$type": "color", "$value": "#000000" }
+    },
     "spacing": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "$type": "dimension",
-      "sm": { "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
     },
-    "fonts": { "$type": "fontFamily", "sans": { "$value": "Arial" } },
+    "fonts": {
+      "sans": { "$type": "fontFamily", "$value": "Arial" }
+    },
     "old-token": {
       "$type": "color",
       "$value": "#000000",


### PR DESCRIPTION
## Summary
- replace legacy token fixtures with `$type`/`$value`
- document `$type`/`$value` and alias usage in all examples

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd665a888328bdf002ee1fba0815