### PR TITLE
fix: drop legacy token fallbacks

### DIFF
--- a/.changeset/remove-legacy-token-fallback.md
+++ b/.changeset/remove-legacy-token-fallback.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": patch
+---
+
+remove legacy token fallbacks and surface token parse errors

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -51,14 +51,10 @@ export class Linter {
     const provider: TokenProvider = env.tokenProvider ?? {
       load: () => {
         if (inlineTokens) {
-          try {
-            flattenTokens({ default: inlineTokens as DesignTokens });
-            return Promise.resolve({
-              default: inlineTokens as DesignTokens,
-            });
-          } catch {
-            return Promise.resolve({});
-          }
+          flattenTokens({ default: inlineTokens as DesignTokens });
+          return Promise.resolve({
+            default: inlineTokens as DesignTokens,
+          });
         }
         return Promise.resolve({});
       },
@@ -171,14 +167,10 @@ export class Linter {
         metadata,
         report: (m) => messages.push({ ...m, severity, ruleId: rule.name }),
         getFlattenedTokens: (type?: string, theme?: string) => {
-          try {
-            const tokens = flattenTokens(this.tokensByTheme, theme);
-            return type
-              ? tokens.filter(({ token }) => token.$type === type)
-              : tokens;
-          } catch {
-            return [];
-          }
+          const tokens = flattenTokens(this.tokensByTheme, theme);
+          return type
+            ? tokens.filter(({ token }) => token.$type === type)
+            : tokens;
         },
       };
       return rule.create(ctx);

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -11,14 +11,7 @@ export const blurRule: RuleModule<BlurRuleOptions> = {
   create(context) {
     const blurTokens = context.getFlattenedTokens('dimension');
     const parse = (val: unknown): number | null => {
-      if (typeof val === 'number') return val;
       if (isRecord(val) && typeof val.value === 'number') return val.value;
-      if (typeof val === 'string') {
-        const parsed = valueParser.unit(val);
-        if (parsed) return parseFloat(parsed.number);
-        const num = Number(val);
-        if (!isNaN(num)) return num;
-      }
       return null;
     };
     const allowed = new Set<number>();

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -19,15 +19,7 @@ export const borderRadiusRule: RuleModule<BorderRadiusOptions> = {
     for (const { path, token } of radiusTokens) {
       if (!path.startsWith('radius.')) continue;
       const val = token.$value;
-      if (typeof val === 'number') {
-        allowed.add(val);
-      } else if (typeof val === 'string') {
-        const parsed = valueParser.unit(val);
-        if (parsed) {
-          const num = parseFloat(parsed.number);
-          if (!isNaN(num)) allowed.add(num);
-        }
-      } else if (
+      if (
         val &&
         typeof val === 'object' &&
         'value' in (val as Record<string, unknown>) &&

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -16,14 +16,7 @@ export const borderWidthRule: RuleModule<BorderWidthOptions> = {
   create(context) {
     const widthTokens = context.getFlattenedTokens('dimension');
     const parse = (val: unknown): number | null => {
-      if (typeof val === 'number') return val;
       if (isRecord(val) && typeof val.value === 'number') return val.value;
-      if (typeof val === 'string') {
-        const parsed = valueParser.unit(val);
-        if (parsed) return parseFloat(parsed.number);
-        const num = Number(val);
-        if (!isNaN(num)) return num;
-      }
       return null;
     };
     const allowed = new Set<number>();

--- a/src/rules/token-font-size.ts
+++ b/src/rules/token-font-size.ts
@@ -6,7 +6,6 @@ export const fontSizeRule: RuleModule = {
   create(context) {
     const fontSizes = context.getFlattenedTokens('dimension');
     const parseSize = (val: unknown): number | null => {
-      if (typeof val === 'number') return val;
       if (
         isRecord(val) &&
         typeof val.value === 'number' &&

--- a/src/rules/token-letter-spacing.ts
+++ b/src/rules/token-letter-spacing.ts
@@ -11,7 +11,6 @@ export const letterSpacingRule: RuleModule = {
   create(context) {
     const letterSpacings = context.getFlattenedTokens('dimension');
     const parse = (val: unknown): number | null => {
-      if (typeof val === 'number') return val;
       if (
         isRecord(val) &&
         typeof val.value === 'number' &&
@@ -40,9 +39,7 @@ export const letterSpacingRule: RuleModule = {
       const val = token.$value;
       const num = parse(val);
       if (num !== null) numeric.add(num);
-      if (typeof val === 'string' || typeof val === 'number') {
-        values.add(String(val).trim());
-      } else if (
+      if (
         isRecord(val) &&
         typeof val.value === 'number' &&
         typeof val.unit === 'string'

--- a/src/rules/token-line-height.ts
+++ b/src/rules/token-line-height.ts
@@ -7,30 +7,26 @@ export const lineHeightRule: RuleModule = {
   meta: { description: 'enforce line-height tokens', category: 'design-token' },
   create(context) {
     const lineHeights = context.getFlattenedTokens('number');
-    const parse = (val: unknown): number | null => {
-      if (typeof val === 'number') return val;
-      if (typeof val === 'string') {
-        const v = val.trim();
-        const unitMatch = /^(\d*\.?\d+)(px|rem|em)%?$/.exec(v);
-        if (unitMatch) {
-          const [, num, unit] = unitMatch;
-          const n = parseFloat(num);
-          const factor =
-            unit === 'px' ? 1 : unit === 'rem' || unit === 'em' ? 16 : 1;
-          return n * factor;
-        }
-        const pctMatch = /^(\d*\.?\d+)%$/.exec(v);
-        if (pctMatch) return parseFloat(pctMatch[1]) / 100;
-        const num = Number(v);
-        if (!isNaN(num)) return num;
+    const parse = (val: string): number | null => {
+      const v = val.trim();
+      const unitMatch = /^(\d*\.?\d+)(px|rem|em)%?$/.exec(v);
+      if (unitMatch) {
+        const [, num, unit] = unitMatch;
+        const n = parseFloat(num);
+        const factor =
+          unit === 'px' ? 1 : unit === 'rem' || unit === 'em' ? 16 : 1;
+        return n * factor;
       }
-      return null;
+      const pctMatch = /^(\d*\.?\d+)%$/.exec(v);
+      if (pctMatch) return parseFloat(pctMatch[1]) / 100;
+      const num = Number(v);
+      return isNaN(num) ? null : num;
     };
     const allowed = new Set<number>();
     for (const { path, token } of lineHeights) {
       if (!path.startsWith('lineHeights.')) continue;
-      const num = parse(token.$value);
-      if (num !== null) allowed.add(num);
+      const val = token.$value;
+      if (typeof val === 'number') allowed.add(val);
     }
     if (allowed.size === 0) {
       context.report({

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -17,15 +17,7 @@ export const spacingRule: RuleModule<SpacingOptions> = {
     for (const { path, token } of spacingTokens) {
       if (!path.startsWith('spacing.')) continue;
       const val = token.$value;
-      if (typeof val === 'number') {
-        allowed.add(val);
-      } else if (typeof val === 'string') {
-        const parsed = valueParser.unit(val.trim());
-        if (parsed) {
-          const num = parseFloat(parsed.number);
-          if (!isNaN(num)) allowed.add(num);
-        }
-      } else if (
+      if (
         val &&
         typeof val === 'object' &&
         'value' in (val as Record<string, unknown>) &&

--- a/src/rules/token-z-index.ts
+++ b/src/rules/token-z-index.ts
@@ -10,8 +10,7 @@ export const zIndexRule: RuleModule = {
     for (const { path, token } of zTokens) {
       if (!path.startsWith('zIndex.')) continue;
       const val = token.$value;
-      const num = typeof val === 'number' ? val : Number(val);
-      if (!Number.isNaN(num)) allowed.add(num);
+      if (typeof val === 'number') allowed.add(val);
     }
     if (allowed.size === 0) {
       context.report({


### PR DESCRIPTION
## Summary
- remove legacy token fallbacks from dimension-based rules
- surface token parsing errors by eliminating silent getFlattenedTokens fallbacks

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d0c659c08328a684ee5187c10795