### PR TITLE
feat: parse tokens with Momoa and YAML

### DIFF
--- a/.changeset/parse-tokens-with-momoa.md
+++ b/.changeset/parse-tokens-with-momoa.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+use Momoa to parse design token files with YAML support and clearer errors
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@lapidist/design-lint",
-  "version": "4.10.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lapidist/design-lint",
-      "version": "4.10.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
+        "@humanwhocodes/momoa": "3.3.9",
         "@vue/compiler-sfc": "3.5.21",
         "chalk": "5.6.2",
         "chokidar": "4.0.3",
@@ -31,6 +32,7 @@
         "tempy": "3.1.0",
         "typescript": "5.9.2",
         "write-file-atomic": "6.0.0",
+        "yaml-to-momoa": "0.0.6",
         "zod": "4.1.5"
       },
       "bin": {
@@ -1458,6 +1460,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.9.tgz",
+      "integrity": "sha512-LHw6Op4bJb3/3KZgOgwflJx5zY9XOy0NU1NuyUFKGdTwHYmP+PbnQGCYQJ8NVNlulLfQish34b0VuUlLYP3AXA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@humanwhocodes/retry": {
@@ -7917,6 +7928,28 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yaml-to-momoa": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaml-to-momoa/-/yaml-to-momoa-0.0.6.tgz",
+      "integrity": "sha512-H6OxymcTIB5fTCQV7/+ETO9Wh6v1vpBDpmW94XnscKE+jQl6x58us/G6r6z5IiPCi5wuSvJ+0wipUsp0s2/Yyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@humanwhocodes/momoa": "^3.3.8",
+        "yaml": "^2.7.1"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "homepage": "https://design-lint.lapidist.net",
   "license": "MIT",
   "dependencies": {
+    "@humanwhocodes/momoa": "3.3.9",
     "@vue/compiler-sfc": "3.5.21",
     "chalk": "5.6.2",
     "chokidar": "4.0.3",
@@ -77,6 +78,7 @@
     "tempy": "3.1.0",
     "typescript": "5.9.2",
     "write-file-atomic": "6.0.0",
+    "yaml-to-momoa": "0.0.6",
     "zod": "4.1.5"
   },
   "devDependencies": {

--- a/src/adapters/node/token-parser.ts
+++ b/src/adapters/node/token-parser.ts
@@ -1,10 +1,76 @@
 import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { evaluate, parse as parseJson } from '@humanwhocodes/momoa';
+import yamlToMomoa from 'yaml-to-momoa';
 import type { DesignTokens, FlattenedToken } from '../../core/types.js';
 import { parseDesignTokens } from '../../core/token-parser.js';
 
 function assertSupportedFile(filePath: string): void {
-  if (!(filePath.endsWith('.tokens') || filePath.endsWith('.tokens.json'))) {
+  if (
+    !(
+      filePath.endsWith('.tokens') ||
+      filePath.endsWith('.tokens.json') ||
+      filePath.endsWith('.tokens.yaml') ||
+      filePath.endsWith('.tokens.yml')
+    )
+  ) {
     throw new Error(`Unsupported design tokens file: ${filePath}`);
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseTokensContent(filePath: string, content: string): DesignTokens {
+  const ext = path.extname(filePath).toLowerCase();
+  try {
+    const doc =
+      ext === '.yaml' || ext === '.yml'
+        ? yamlToMomoa(content)
+        : parseJson(content, { mode: 'json', ranges: true });
+    const result = evaluate(doc.body);
+    if (!isObject(result)) {
+      throw new Error(
+        `Error parsing ${filePath}: root value must be an object`,
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const json = result as unknown as DesignTokens;
+    return json;
+  } catch (error: unknown) {
+    let line: number | undefined;
+    let column: number | undefined;
+    if (
+      isObject(error) &&
+      'node' in error &&
+      isObject(error.node) &&
+      'loc' in error.node &&
+      isObject(error.node.loc) &&
+      'start' in error.node.loc &&
+      isObject(error.node.loc.start) &&
+      typeof error.node.loc.start.line === 'number' &&
+      typeof error.node.loc.start.column === 'number'
+    ) {
+      line = error.node.loc.start.line;
+      column = error.node.loc.start.column;
+    } else if (
+      isObject(error) &&
+      'line' in error &&
+      typeof error.line === 'number' &&
+      'column' in error &&
+      typeof error.column === 'number'
+    ) {
+      line = error.line;
+      column = error.column;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    if (line !== undefined && column !== undefined) {
+      throw new Error(
+        `Error parsing ${filePath} (${String(line)}:${String(column)}): ${message}`,
+      );
+    }
+    throw new Error(`Error parsing ${filePath}: ${message}`);
   }
 }
 
@@ -13,8 +79,7 @@ export async function parseDesignTokensFile(
 ): Promise<FlattenedToken[]> {
   assertSupportedFile(filePath);
   const content = await readFile(filePath, 'utf8');
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const json: DesignTokens = JSON.parse(content);
+  const json = parseTokensContent(filePath, content);
   return parseDesignTokens(json);
 }
 
@@ -23,8 +88,7 @@ export async function readDesignTokensFile(
 ): Promise<DesignTokens> {
   assertSupportedFile(filePath);
   const content = await readFile(filePath, 'utf8');
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const json: DesignTokens = JSON.parse(content);
+  const json = parseTokensContent(filePath, content);
   // Validate the structure but discard the result.
   parseDesignTokens(json);
   return json;


### PR DESCRIPTION
## Summary
- parse design token files with Momoa, supporting YAML and detailed parse errors
- test YAML token files and parse error diagnostics
- add momoa-based dependencies

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1e629ffac832896c7ab3c526dbc78