### PR TITLE
docs: forbid eslint ignore and casting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,5 @@ This repository requires Node.js >= 22 and follows strict [Semantic Versioning](
 
 - Use `npm run format` to automatically format files when needed.
 - Run `npm run build` when modifying source files to ensure the TypeScript build succeeds.
+- Do not use `eslint ignore` or disable rules with `eslint-disable` comments; all code must satisfy ESLint rules without overrides.
+- Use clean TypeScript types and avoid type casting or assertions such as `as any`.


### PR DESCRIPTION
## Summary
- forbid use of eslint ignore and eslint-disable comments
- instruct contributors to avoid TypeScript casting and keep types clean

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea1d08a0832889becee98e51b8f8