### PR TITLE
refactor: remove eslint disables

### DIFF
--- a/.changeset/remove-eslint-disables.md
+++ b/.changeset/remove-eslint-disables.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+remove eslint-disable-next-line comments and address lint issues

--- a/scripts/bench/fs.js
+++ b/scripts/bench/fs.js
@@ -13,6 +13,6 @@ const targets = process.argv.slice(2);
   const start = performance.now();
   await linter.lintTargets(targets.length ? targets : ['.']);
   const end = performance.now();
-  // eslint-disable-next-line no-console
-  console.log(`Linted in ${(end - start).toFixed(2)}ms`);
+  const duration = (end - start).toFixed(2);
+  process.stdout.write(`Linted in ${duration}ms\n`);
 })();

--- a/src/adapters/node/token-parser.ts
+++ b/src/adapters/node/token-parser.ts
@@ -18,6 +18,10 @@ function assertSupportedFile(filePath: string): void {
   }
 }
 
+function isDesignTokens(value: unknown): value is DesignTokens {
+  return typeof value === 'object' && value !== null;
+}
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -30,14 +34,12 @@ function parseTokensContent(filePath: string, content: string): DesignTokens {
         ? yamlToMomoa(content)
         : parseJson(content, { mode: 'json', ranges: true });
     const result = evaluate(doc.body);
-    if (!isObject(result)) {
+    if (!isDesignTokens(result)) {
       throw new Error(
         `Error parsing ${filePath}: root value must be an object`,
       );
     }
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const json = result as unknown as DesignTokens;
-    return json;
+    return result;
   } catch (error: unknown) {
     let line: number | undefined;
     let column: number | undefined;

--- a/src/cli/init-config.ts
+++ b/src/cli/init-config.ts
@@ -4,6 +4,10 @@ import writeFileAtomic from 'write-file-atomic';
 
 const supported = new Set(['json', 'js', 'cjs', 'mjs', 'ts', 'mts']);
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 export function detectInitFormat(initFormat?: string): string {
   if (initFormat && !supported.has(initFormat)) {
     throw new Error(
@@ -20,13 +24,20 @@ export function detectInitFormat(initFormat?: string): string {
       if (fs.existsSync(pkgPath)) {
         try {
           const pkgText = fs.readFileSync(pkgPath, 'utf8');
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const pkg: {
-            dependencies?: Record<string, unknown>;
-            devDependencies?: Record<string, unknown>;
-          } = JSON.parse(pkgText);
-          if (pkg.dependencies?.typescript || pkg.devDependencies?.typescript) {
-            format = 'ts';
+          const pkgData: unknown = JSON.parse(pkgText);
+          if (isRecord(pkgData)) {
+            const deps = isRecord(pkgData.dependencies)
+              ? pkgData.dependencies
+              : undefined;
+            const devDeps = isRecord(pkgData.devDependencies)
+              ? pkgData.devDependencies
+              : undefined;
+            if (
+              (deps && 'typescript' in deps) ||
+              (devDeps && 'typescript' in devDeps)
+            ) {
+              format = 'ts';
+            }
           }
         } catch {}
       }

--- a/src/core/parsers/css-parser.ts
+++ b/src/core/parsers/css-parser.ts
@@ -1,5 +1,5 @@
-import postcss, { type Root } from 'postcss';
-import { parse as scssParse } from 'postcss-scss';
+import postcss from 'postcss';
+import { parse as scssParser } from 'postcss-scss';
 import lessSyntax from 'postcss-less';
 import type { CSSDeclaration, LintMessage, RuleModule } from '../types.js';
 
@@ -10,14 +10,11 @@ export function parseCSS(
 ): CSSDeclaration[] {
   const decls: CSSDeclaration[] = [];
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const root: Root =
+    const root =
       lang === 'scss' || lang === 'sass'
-        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          scssParse(text)
+        ? scssParser(text)
         : lang === 'less'
-          ? // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            lessSyntax.parse(text)
+          ? lessSyntax.parse(text)
           : postcss.parse(text);
     root.walkDecls((d) => {
       decls.push({

--- a/src/types/postcss-less.d.ts
+++ b/src/types/postcss-less.d.ts
@@ -1,0 +1,5 @@
+declare module 'postcss-less' {
+  import type { Parser } from 'postcss';
+  const less: { parse: Parser };
+  export default less;
+}

--- a/src/types/postcss-scss.d.ts
+++ b/src/types/postcss-scss.d.ts
@@ -1,0 +1,4 @@
+declare module 'postcss-scss' {
+  import type { Parser } from 'postcss';
+  export const parse: Parser;
+}

--- a/src/utils/jsx.ts
+++ b/src/utils/jsx.ts
@@ -1,17 +1,17 @@
 import ts from 'typescript';
 
 export function isInNonStyleJsx(node: ts.Node): boolean {
-  let curr: ts.Node | undefined = node.parent;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  while (curr) {
+  for (
+    let curr: ts.Node = node.parent;
+    !ts.isSourceFile(curr);
+    curr = curr.parent
+  ) {
     if (ts.isJsxAttribute(curr)) {
       return curr.name.getText() !== 'style';
     }
     if (ts.isPropertyAssignment(curr)) {
       if (curr.name.getText() === 'style') return false;
-      let p: ts.Node | undefined = curr.parent;
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      while (p) {
+      for (let p: ts.Node = curr.parent; !ts.isSourceFile(p); p = p.parent) {
         if (ts.isPropertyAssignment(p) && p.name.getText() === 'style') {
           return false;
         }
@@ -34,7 +34,6 @@ export function isInNonStyleJsx(node: ts.Node): boolean {
           }
           break;
         }
-        p = p.parent;
       }
     }
     if (
@@ -44,7 +43,6 @@ export function isInNonStyleJsx(node: ts.Node): boolean {
     ) {
       return true;
     }
-    curr = curr.parent;
   }
   return false;
 }

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -1,16 +1,12 @@
 import ts from 'typescript';
 
 export function isStyleValue(node: ts.Node): boolean {
-  let curr: ts.Node | undefined = node;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  while (curr) {
+  for (let curr: ts.Node = node; !ts.isSourceFile(curr); curr = curr.parent) {
     if (ts.isJsxAttribute(curr)) {
       return curr.name.getText() === 'style';
     }
     if (ts.isPropertyAssignment(curr) && curr.name.getText() === 'style') {
-      let p: ts.Node | undefined = curr.parent;
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      while (p) {
+      for (let p: ts.Node = curr.parent; !ts.isSourceFile(p); p = p.parent) {
         if (ts.isCallExpression(p)) {
           const expr = p.expression;
           if (
@@ -25,11 +21,9 @@ export function isStyleValue(node: ts.Node): boolean {
         if (ts.isJsxAttribute(p) && p.name.getText() === 'style') {
           return true;
         }
-        p = p.parent;
       }
       return false;
     }
-    curr = curr.parent;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- remove eslint-disable comments and replace unsafe patterns
- add typings for external parsers

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1e9f2fb3483288c0c2da3a49b5ad3