### PR TITLE
feat(core): expose design tokens per theme

### DIFF
--- a/.changeset/allow-token-metadata-and-yaml.md
+++ b/.changeset/allow-token-metadata-and-yaml.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+allow $metadata fields in token trees, ignore metadata in token tracking, and accept .tokens.yaml paths in config

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -43,10 +43,13 @@ const tokenFileSchema = z
   .refine(
     (p) =>
       !path.isAbsolute(p) &&
-      (p.endsWith('.tokens') || p.endsWith('.tokens.json')),
+      (p.endsWith('.tokens') ||
+        p.endsWith('.tokens.json') ||
+        p.endsWith('.tokens.yaml') ||
+        p.endsWith('.tokens.yml')),
     {
       message:
-        'Token file paths must be relative and end with .tokens or .tokens.json',
+        'Token file paths must be relative and end with .tokens, .tokens.json, .tokens.yaml, or .tokens.yml',
     },
   );
 

--- a/src/core/token-parser.ts
+++ b/src/core/token-parser.ts
@@ -11,6 +11,7 @@ const GROUP_PROPS = new Set([
   '$extensions',
   '$deprecated',
   '$schema',
+  '$metadata',
 ]);
 const LEGACY_PROPS = new Set([
   'type',

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -114,6 +114,7 @@ function collectTokenValues(
   const values = new Map<string, FlattenedToken>();
   if (!tokensByTheme) return values;
   for (const theme of Object.keys(tokensByTheme)) {
+    if (theme.startsWith('$')) continue;
     for (const flat of getFlattenedTokens(tokensByTheme, theme)) {
       const val = flat.token.$value;
       if (typeof val === 'string') {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -340,6 +340,24 @@ void test('loads tokens from theme file paths', async () => {
   assert.equal(light.color.brand.primary.$value, '#000');
 });
 
+void test('loads tokens from YAML theme file paths', async () => {
+  const tmp = makeTmpDir();
+  fs.writeFileSync(
+    path.join(tmp, 'designlint.config.json'),
+    JSON.stringify({ tokens: { light: './light.tokens.yaml' } }),
+  );
+  fs.writeFileSync(
+    path.join(tmp, 'light.tokens.yaml'),
+    "color:\n  $type: color\n  brand:\n    primary:\n      $value: '#000'\n",
+  );
+  const loaded = await loadConfig(tmp);
+  const tokens = loaded.tokens as Record<string, unknown>;
+  const light = tokens.light as {
+    color: { brand: { primary: { $value: string } } };
+  };
+  assert.equal(light.color.brand.primary.$value, '#000');
+});
+
 void test('resolves token file paths relative to config', async () => {
   const tmp = makeTmpDir();
   const cfgDir = path.join(tmp, 'cfg');

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -77,6 +77,19 @@ void test('parseDesignTokens rejects $schema in nested groups', () => {
   assert.throws(() => parseDesignTokens(tokens), /\$schema is only allowed/);
 });
 
+void test('parseDesignTokens allows $metadata fields', () => {
+  const tokens: DesignTokens = {
+    $metadata: { version: 1 },
+    color: {
+      $type: 'color',
+      $metadata: { note: 'ok' },
+      blue: { $value: '#00f' },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(result[0].path, 'color.blue');
+});
+
 void test('parseDesignTokens rejects names starting with $', () => {
   const tokens = {
     $bad: { $value: 1 },

--- a/tests/core/token-tracker.test.ts
+++ b/tests/core/token-tracker.test.ts
@@ -29,6 +29,30 @@ void test('TokenTracker reports unused tokens', async () => {
   assert.equal(reports[0].messages[0].message.includes('4px'), true);
 });
 
+void test('TokenTracker skips metadata themes when collecting tokens', async () => {
+  const tokens: DesignTokens = {
+    color: { blue: { $value: '#00f', $type: 'color' } },
+  };
+  const provider: TokenProvider = {
+    load: () =>
+      Promise.resolve({
+        default: tokens,
+        $metadata: { foo: true },
+      }),
+  };
+  const tracker = new TokenTracker(provider);
+  await tracker.configure([
+    {
+      rule: { name: 'design-system/no-unused-tokens' },
+      options: {},
+      severity: 'error',
+    },
+  ]);
+  const reports = tracker.generateReports('config');
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].messages[0].message.includes('#00f'), true);
+});
+
 void test('cssVar classifier tracks custom property usage', async () => {
   const tokens: DesignTokens = {
     color: {


### PR DESCRIPTION
## Summary
- allow `$metadata` entries in design token parsing and ignore metadata themes during usage tracking
- support `.tokens.yaml` paths in config schema and add coverage for YAML token files

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1eec834d48328970277cfbb35c2d6