### PR TITLE
refactor: modularize token parser pipeline

### DIFF
--- a/.changeset/split-token-parser-into-modules.md
+++ b/.changeset/split-token-parser-into-modules.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor token parser into modular pipeline
+

--- a/src/config/config-token-provider.ts
+++ b/src/config/config-token-provider.ts
@@ -1,6 +1,6 @@
 import type { Config } from '../core/linter.js';
 import type { DesignTokens } from '../core/types.js';
-import { parseDesignTokens } from '../core/token-parser.js';
+import { parseDesignTokens } from '../core/parser/index.js';
 
 export class ConfigTokenProvider {
   private config: Config;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -6,7 +6,7 @@ import type { Config } from '../core/linter.js';
 import { configSchema } from './schema.js';
 import { realpathIfExists } from '../adapters/node/utils/paths.js';
 import { readDesignTokensFile } from '../adapters/node/token-parser.js';
-import { parseDesignTokens } from '../core/token-parser.js';
+import { parseDesignTokens } from '../core/parser/index.js';
 import type { DesignTokens } from '../core/types.js';
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -31,4 +31,4 @@ export {
   getFlattenedTokens,
   type TokenPattern,
 } from './token-utils.js';
-export { parseDesignTokens } from './token-parser.js';
+export { parseDesignTokens } from './parser/index.js';

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -1,0 +1,11 @@
+import type { DesignTokens, FlattenedToken } from '../types.js';
+import { buildParseTree } from './parse-tree.js';
+import { normalizeTokens } from './normalize.js';
+import { validateTokens } from './validate.js';
+
+export function parseDesignTokens(tokens: DesignTokens): FlattenedToken[] {
+  const tree = buildParseTree(tokens);
+  normalizeTokens(tree);
+  validateTokens(tree);
+  return tree;
+}

--- a/src/core/parser/normalize.ts
+++ b/src/core/parser/normalize.ts
@@ -1,0 +1,95 @@
+import type { Token, FlattenedToken } from '../types.js';
+
+const ALIAS_PATTERN = /^\{([^}]+)\}$/;
+
+export function isAlias(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    return m ? m[1] : null;
+  }
+  return null;
+}
+
+function resolveAlias(
+  targetPath: string,
+  tokenMap: Map<string, Token>,
+  stack: string[],
+): Token {
+  if (stack.includes(targetPath)) {
+    throw new Error(
+      `Circular alias reference: ${[...stack, targetPath].join(' -> ')}`,
+    );
+  }
+  const target = tokenMap.get(targetPath);
+  if (!target) {
+    const source = stack[0];
+    throw new Error(`Token ${source} references unknown token: ${targetPath}`);
+  }
+  const next =
+    typeof target.$value === 'string'
+      ? ALIAS_PATTERN.exec(target.$value)
+      : null;
+  if (next) {
+    return resolveAlias(next[1], tokenMap, [...stack, targetPath]);
+  }
+  if (!target.$type) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $type: ${targetPath}`,
+    );
+  }
+  if (target.$value === undefined) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $value: ${targetPath}`,
+    );
+  }
+  return target;
+}
+
+export function expectAlias(
+  value: string,
+  path: string,
+  expected: string,
+  tokenMap: Map<string, Token>,
+): void {
+  const targetPath = isAlias(value);
+  if (!targetPath) {
+    throw new Error(`Token ${path} has invalid ${expected} reference`);
+  }
+  const target = resolveAlias(targetPath, tokenMap, [path]);
+  if (target.$type !== expected) {
+    throw new Error(
+      `Token ${path} references token of type ${String(
+        target.$type,
+      )}; expected ${expected}`,
+    );
+  }
+}
+
+export function normalizeTokens(tokens: FlattenedToken[]): FlattenedToken[] {
+  const tokenMap = new Map(tokens.map((t) => [t.path, t.token]));
+  for (const { path, token } of tokens) {
+    if (typeof token.$value === 'string') {
+      const match = ALIAS_PATTERN.exec(token.$value);
+      if (match) {
+        const target = resolveAlias(match[1], tokenMap, [path]);
+        const aliasType = target.$type;
+        if (!aliasType) {
+          throw new Error(
+            `Token ${path} references token without $type: ${match[1]}`,
+          );
+        }
+        if (!token.$type) {
+          token.$type = aliasType;
+        } else if (token.$type !== aliasType) {
+          throw new Error(
+            `Token ${path} has mismatched $type ${token.$type}; expected ${aliasType}`,
+          );
+        }
+        token.$value = target.$value;
+      }
+    }
+  }
+  return tokens;
+}

--- a/src/core/parser/parse-tree.ts
+++ b/src/core/parser/parse-tree.ts
@@ -1,0 +1,161 @@
+import type {
+  DesignTokens,
+  Token,
+  TokenGroup,
+  FlattenedToken,
+} from '../types.js';
+
+const GROUP_PROPS = new Set([
+  '$type',
+  '$description',
+  '$extensions',
+  '$deprecated',
+  '$schema',
+  '$metadata',
+]);
+const LEGACY_PROPS = new Set([
+  'type',
+  'value',
+  'description',
+  'extensions',
+  'deprecated',
+]);
+const INVALID_NAME_CHARS = /[{}\.]/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isToken(node: unknown): node is Token {
+  return isRecord(node) && '$value' in node;
+}
+
+function isTokenGroup(node: unknown): node is TokenGroup {
+  return isRecord(node) && !isToken(node);
+}
+
+function validateExtensions(value: unknown, path: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) {
+    throw new Error(`Token or group ${path} has invalid $extensions`);
+  }
+  for (const key of Object.keys(value)) {
+    if (!key.includes('.')) {
+      throw new Error(
+        `Token or group ${path} has invalid $extensions key: ${key}`,
+      );
+    }
+  }
+}
+
+function validateDeprecated(value: unknown, path: string): void {
+  if (value === undefined) return;
+  if (typeof value !== 'boolean' && typeof value !== 'string') {
+    throw new Error(`Token or group ${path} has invalid $deprecated`);
+  }
+}
+
+function validateMetadata(
+  node: { $extensions?: unknown; $deprecated?: unknown },
+  path: string,
+): void {
+  validateExtensions(node.$extensions, path);
+  validateDeprecated(node.$deprecated, path);
+}
+
+export function buildParseTree(tokens: DesignTokens): FlattenedToken[] {
+  const result: FlattenedToken[] = [];
+  const seenPaths = new Map<string, string>();
+
+  function walk(
+    group: TokenGroup,
+    prefix: string[],
+    inheritedType?: string,
+    inheritedDeprecated?: boolean | string,
+  ): void {
+    const pathLabel = prefix.length ? prefix.join('.') : '(root)';
+    validateMetadata(group, pathLabel);
+    if (prefix.length === 0) {
+      if (
+        '$schema' in group &&
+        typeof Reflect.get(group, '$schema') !== 'string'
+      ) {
+        throw new Error('Root group has invalid $schema');
+      }
+    } else if ('$schema' in group) {
+      throw new Error('$schema is only allowed on the root group');
+    }
+    const currentType = group.$type ?? inheritedType;
+    const currentDeprecated = group.$deprecated ?? inheritedDeprecated;
+    const seenNames = new Map<string, string>();
+
+    for (const name of Object.keys(group)) {
+      if (GROUP_PROPS.has(name)) continue;
+      if (name.startsWith('$')) {
+        throw new Error(`Invalid token or group name: ${name}`);
+      }
+      if (INVALID_NAME_CHARS.test(name)) {
+        throw new Error(`Invalid token or group name: ${name}`);
+      }
+      const lower = name.toLowerCase();
+      const existing = seenNames.get(lower);
+      if (existing) {
+        if (existing === name) {
+          throw new Error(`Duplicate token name: ${name}`);
+        }
+        throw new Error(
+          `Duplicate token name differing only by case: ${existing} vs ${name}`,
+        );
+      }
+      seenNames.set(lower, name);
+
+      const node = group[name];
+      if (node === undefined) continue;
+      const pathParts = [...prefix, name];
+      const pathId = pathParts.join('.');
+      const lowerPath = pathId.toLowerCase();
+      const existingPath = seenPaths.get(lowerPath);
+      if (existingPath) {
+        if (existingPath === pathId) {
+          throw new Error(`Duplicate token path: ${pathId}`);
+        }
+        throw new Error(
+          `Duplicate token path differing only by case: ${existingPath} vs ${pathId}`,
+        );
+      }
+      seenPaths.set(lowerPath, pathId);
+
+      if (isRecord(node)) {
+        if (isToken(node)) {
+          const token: Token = { ...node, $type: node.$type ?? currentType };
+          const tokenDeprecated = token.$deprecated ?? currentDeprecated;
+          if (tokenDeprecated !== undefined)
+            token.$deprecated = tokenDeprecated;
+          result.push({ path: pathId, token });
+        } else if (isTokenGroup(node)) {
+          for (const key of Object.keys(node)) {
+            if (LEGACY_PROPS.has(key)) {
+              throw new Error(
+                `Token ${pathId} uses legacy property ${key}; expected $${key}`,
+              );
+            }
+          }
+          const childKeys = Object.keys(node).filter(
+            (k) => !GROUP_PROPS.has(k),
+          );
+          if ('$type' in node && childKeys.length === 0) {
+            throw new Error(`Token ${pathId} is missing $value`);
+          }
+          walk(node, pathParts, currentType, currentDeprecated);
+        } else {
+          throw new Error(`Token ${pathId} must be an object with $value`);
+        }
+      } else {
+        throw new Error(`Token ${pathId} must be an object with $value`);
+      }
+    }
+  }
+
+  walk(tokens, [], undefined, undefined);
+  return result;
+}

--- a/src/core/token-utils.ts
+++ b/src/core/token-utils.ts
@@ -1,7 +1,7 @@
 import type { DesignTokens, FlattenedToken } from './types.js';
 import picomatch from 'picomatch';
 import leven from 'leven';
-import { parseDesignTokens } from './token-parser.js';
+import { parseDesignTokens } from './parser/index.js';
 
 export type TokenPattern = string | RegExp;
 

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { parseDesignTokens } from '../../src/core/token-parser.ts';
+import { parseDesignTokens } from '../../src/core/parser/index.ts';
 import { parseDesignTokensFile } from '../../src/adapters/node/token-parser.ts';
 import type { DesignTokens } from '../../src/core/types.js';
 


### PR DESCRIPTION
## Summary
- split token parser into parse-tree, normalize, and validate modules
- add orchestrator that runs build/normalize/validate pipeline
- update consumers to import new parser entry

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1f144574c8328bae3a614e63c2cd0