### PR TITLE
feat(core): add token validator registry

### DIFF
--- a/.changeset/token-validator-registry.md
+++ b/.changeset/token-validator-registry.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add token validator registry for plugin extensibility

--- a/src/core/token-parser.ts
+++ b/src/core/token-parser.ts
@@ -4,6 +4,12 @@ import type {
   TokenGroup,
   FlattenedToken,
 } from './types.js';
+import {
+  ALIAS_PATTERN,
+  resolveAlias,
+  isRecord,
+} from './token-validators/utils.js';
+import { validatorRegistry } from './token-validators/index.js';
 
 const GROUP_PROPS = new Set([
   '$type',
@@ -21,45 +27,6 @@ const LEGACY_PROPS = new Set([
   'deprecated',
 ]);
 const INVALID_NAME_CHARS = /[{}\.]/;
-const ALIAS_PATTERN = /^\{([^}]+)\}$/;
-
-const STROKE_STYLE_KEYWORDS = new Set([
-  'solid',
-  'dashed',
-  'dotted',
-  'double',
-  'groove',
-  'ridge',
-  'outset',
-  'inset',
-]);
-const STROKE_LINECAPS = new Set(['round', 'butt', 'square']);
-const FONT_WEIGHT_KEYWORDS = new Set([
-  'thin',
-  'hairline',
-  'extra-light',
-  'ultra-light',
-  'light',
-  'normal',
-  'regular',
-  'book',
-  'medium',
-  'semi-bold',
-  'demi-bold',
-  'bold',
-  'extra-bold',
-  'ultra-bold',
-  'black',
-  'heavy',
-  'extra-black',
-  'ultra-black',
-]);
-const DIMENSION_UNITS = new Set(['px', 'rem']);
-const DURATION_UNITS = new Set(['ms', 's']);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function isToken(node: unknown): node is Token {
   return isRecord(node) && '$value' in node;
@@ -67,14 +34,6 @@ function isToken(node: unknown): node is Token {
 
 function isTokenGroup(node: unknown): node is TokenGroup {
   return isRecord(node) && !isToken(node);
-}
-
-function isAlias(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const m = ALIAS_PATTERN.exec(value);
-    return m ? m[1] : null;
-  }
-  return null;
 }
 
 function validateExtensions(value: unknown, path: string): void {
@@ -104,336 +63,6 @@ function validateMetadata(
 ): void {
   validateExtensions(node.$extensions, path);
   validateDeprecated(node.$deprecated, path);
-}
-
-function resolveAlias(
-  targetPath: string,
-  tokenMap: Map<string, Token>,
-  stack: string[],
-): Token {
-  if (stack.includes(targetPath)) {
-    throw new Error(
-      `Circular alias reference: ${[...stack, targetPath].join(' -> ')}`,
-    );
-  }
-  const target = tokenMap.get(targetPath);
-  if (!target) {
-    const source = stack[0];
-    throw new Error(`Token ${source} references unknown token: ${targetPath}`);
-  }
-  const next =
-    typeof target.$value === 'string'
-      ? ALIAS_PATTERN.exec(target.$value)
-      : null;
-  if (next) {
-    return resolveAlias(next[1], tokenMap, [...stack, targetPath]);
-  }
-  if (!target.$type) {
-    const source = stack[0];
-    throw new Error(
-      `Token ${source} references token without $type: ${targetPath}`,
-    );
-  }
-  if (target.$value === undefined) {
-    const source = stack[0];
-    throw new Error(
-      `Token ${source} references token without $value: ${targetPath}`,
-    );
-  }
-  return target;
-}
-
-function expectAlias(
-  value: string,
-  path: string,
-  expected: string,
-  tokenMap: Map<string, Token>,
-): void {
-  const targetPath = isAlias(value);
-  if (!targetPath) {
-    throw new Error(`Token ${path} has invalid ${expected} reference`);
-  }
-  const target = resolveAlias(targetPath, tokenMap, [path]);
-  if (target.$type !== expected) {
-    throw new Error(
-      `Token ${path} references token of type ${String(target.$type)}; expected ${expected}`,
-    );
-  }
-}
-
-function validateColor(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (typeof value === 'string') {
-    const m = ALIAS_PATTERN.exec(value);
-    if (m) expectAlias(value, path, 'color', tokenMap);
-    return;
-  }
-  throw new Error(`Token ${path} has invalid color value`);
-}
-
-function validateDimension(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (
-    isRecord(value) &&
-    typeof value.value === 'number' &&
-    typeof value.unit === 'string' &&
-    DIMENSION_UNITS.has(value.unit)
-  ) {
-    return;
-  }
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'dimension', tokenMap);
-    return;
-  }
-  throw new Error(`Token ${path} has invalid dimension value`);
-}
-
-function validateNumber(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (typeof value === 'number') return;
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'number', tokenMap);
-    return;
-  }
-  throw new Error(`Token ${path} has invalid number value`);
-}
-
-function validateFontFamily(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (typeof value === 'string') {
-    const m = ALIAS_PATTERN.exec(value);
-    if (m) expectAlias(value, path, 'fontFamily', tokenMap);
-    return;
-  }
-  if (Array.isArray(value) && value.every((v) => typeof v === 'string')) return;
-  throw new Error(`Token ${path} has invalid fontFamily value`);
-}
-
-function validateFontWeight(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (typeof value === 'number') {
-    if (value < 1 || value > 1000) {
-      throw new Error(`Token ${path} has invalid fontWeight value`);
-    }
-    return;
-  }
-  if (typeof value === 'string') {
-    const m = ALIAS_PATTERN.exec(value);
-    if (m) {
-      expectAlias(value, path, 'fontWeight', tokenMap);
-      return;
-    }
-    if (FONT_WEIGHT_KEYWORDS.has(value)) return;
-  }
-  throw new Error(`Token ${path} has invalid fontWeight value`);
-}
-
-function validateDuration(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (
-    isRecord(value) &&
-    typeof value.value === 'number' &&
-    typeof value.unit === 'string' &&
-    DURATION_UNITS.has(value.unit)
-  ) {
-    return;
-  }
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'duration', tokenMap);
-    return;
-  }
-  throw new Error(`Token ${path} has invalid duration value`);
-}
-
-function validateShadow(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  const items = Array.isArray(value) ? value : [value];
-  if (!Array.isArray(items)) {
-    throw new Error(`Token ${path} has invalid shadow value`);
-  }
-  for (let i = 0; i < items.length; i++) {
-    const item: unknown = items[i];
-    if (!isRecord(item)) {
-      throw new Error(`Token ${path} has invalid shadow value`);
-    }
-    const allowed = new Set([
-      'color',
-      'offsetX',
-      'offsetY',
-      'blur',
-      'spread',
-      'inset',
-    ]);
-    for (const key of Object.keys(item)) {
-      if (!allowed.has(key)) {
-        throw new Error(`Token ${path} has invalid shadow value`);
-      }
-    }
-    const base = `${path}[${String(i)}]`;
-    validateColor(item.color, `${base}.color`, tokenMap);
-    validateDimension(item.offsetX, `${base}.offsetX`, tokenMap);
-    validateDimension(item.offsetY, `${base}.offsetY`, tokenMap);
-    validateDimension(item.blur, `${base}.blur`, tokenMap);
-    if (item.spread !== undefined) {
-      validateDimension(item.spread, `${base}.spread`, tokenMap);
-    }
-    if ('inset' in item && typeof item.inset !== 'boolean') {
-      throw new Error(`Token ${path} has invalid shadow value`);
-    }
-  }
-}
-
-function validateStrokeStyle(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (typeof value === 'string') {
-    if (!STROKE_STYLE_KEYWORDS.has(value)) {
-      throw new Error(`Token ${path} has invalid strokeStyle value`);
-    }
-    return;
-  }
-  if (isRecord(value)) {
-    const allowed = new Set(['dashArray', 'lineCap']);
-    for (const key of Object.keys(value)) {
-      if (!allowed.has(key)) {
-        throw new Error(`Token ${path} has invalid strokeStyle value`);
-      }
-    }
-    if (!Array.isArray(value.dashArray) || value.dashArray.length === 0) {
-      throw new Error(`Token ${path} has invalid strokeStyle value`);
-    }
-    for (let i = 0; i < value.dashArray.length; i++) {
-      validateDimension(
-        value.dashArray[i],
-        `${path}.dashArray[${String(i)}]`,
-        tokenMap,
-      );
-    }
-    if (
-      typeof value.lineCap !== 'string' ||
-      !STROKE_LINECAPS.has(value.lineCap)
-    ) {
-      throw new Error(`Token ${path} has invalid strokeStyle value`);
-    }
-    return;
-  }
-  throw new Error(`Token ${path} has invalid strokeStyle value`);
-}
-
-function validateGradient(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (!Array.isArray(value) || value.length === 0) {
-    throw new Error(`Token ${path} has invalid gradient value`);
-  }
-  const stops = value;
-  for (let i = 0; i < stops.length; i++) {
-    const stop: unknown = stops[i];
-    if (!isRecord(stop)) {
-      throw new Error(`Token ${path} has invalid gradient value`);
-    }
-    const allowed = new Set(['color', 'position']);
-    for (const key of Object.keys(stop)) {
-      if (!allowed.has(key)) {
-        throw new Error(`Token ${path} has invalid gradient value`);
-      }
-    }
-    validateColor(stop.color, `${path}[${String(i)}].color`, tokenMap);
-    const pos = stop.position;
-    if (typeof pos === 'number') {
-      // allow any number; clamping is handled by consumers
-    } else if (typeof pos === 'string') {
-      expectAlias(pos, `${path}[${String(i)}].position`, 'number', tokenMap);
-    } else {
-      throw new Error(`Token ${path} has invalid gradient value`);
-    }
-  }
-}
-
-function validateTypography(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (!isRecord(value)) {
-    throw new Error(`Token ${path} has invalid typography value`);
-  }
-  const allowed = new Set([
-    'fontFamily',
-    'fontSize',
-    'fontWeight',
-    'lineHeight',
-  ]);
-  for (const key of Object.keys(value)) {
-    if (!allowed.has(key)) {
-      throw new Error(`Token ${path} has invalid typography value`);
-    }
-  }
-  const { fontFamily, fontSize, fontWeight, lineHeight } = value;
-  if (
-    fontFamily === undefined ||
-    fontSize === undefined ||
-    fontWeight === undefined ||
-    lineHeight === undefined
-  ) {
-    throw new Error(`Token ${path} has invalid typography value`);
-  }
-  validateFontFamily(fontFamily, `${path}.fontFamily`, tokenMap);
-  validateDimension(fontSize, `${path}.fontSize`, tokenMap);
-  validateFontWeight(fontWeight, `${path}.fontWeight`, tokenMap);
-  validateNumber(lineHeight, `${path}.lineHeight`, tokenMap);
-}
-
-function validateCubicBezier(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (Array.isArray(value) && value.length === 4) {
-    for (let i = 0; i < 4; i++) {
-      const v: unknown = value[i];
-      if (typeof v === 'number') {
-        if (v < 0 || v > 1) {
-          throw new Error(`Token ${path} has invalid cubicBezier value`);
-        }
-      } else if (typeof v === 'string') {
-        expectAlias(v, `${path}[${String(i)}]`, 'number', tokenMap);
-      } else {
-        throw new Error(`Token ${path} has invalid cubicBezier value`);
-      }
-    }
-    return;
-  }
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'cubicBezier', tokenMap);
-    return;
-  }
-  throw new Error(`Token ${path} has invalid cubicBezier value`);
 }
 
 function validateToken(
@@ -469,42 +98,11 @@ function validateToken(
   if (!token.$type) {
     throw new Error(`Token ${path} is missing $type`);
   }
-
-  switch (token.$type) {
-    case 'color':
-      validateColor(token.$value, path, tokenMap);
-      break;
-    case 'dimension':
-      validateDimension(token.$value, path, tokenMap);
-      break;
-    case 'number':
-      validateNumber(token.$value, path, tokenMap);
-      break;
-    case 'fontFamily':
-      validateFontFamily(token.$value, path, tokenMap);
-      break;
-    case 'fontWeight':
-      validateFontWeight(token.$value, path, tokenMap);
-      break;
-    case 'duration':
-      validateDuration(token.$value, path, tokenMap);
-      break;
-    case 'cubicBezier':
-      validateCubicBezier(token.$value, path, tokenMap);
-      break;
-    case 'shadow':
-      validateShadow(token.$value, path, tokenMap);
-      break;
-    case 'strokeStyle':
-      validateStrokeStyle(token.$value, path, tokenMap);
-      break;
-    case 'gradient':
-      validateGradient(token.$value, path, tokenMap);
-      break;
-    case 'typography':
-      validateTypography(token.$value, path, tokenMap);
-      break;
+  const validator = validatorRegistry.get(token.$type);
+  if (!validator) {
+    throw new Error(`Token ${path} has unsupported $type ${token.$type}`);
   }
+  validator(token.$value, path, tokenMap);
 }
 
 export function parseDesignTokens(tokens: DesignTokens): FlattenedToken[] {

--- a/src/core/token-validators/color.ts
+++ b/src/core/token-validators/color.ts
@@ -1,0 +1,13 @@
+import type { TokenValidator } from './index.js';
+import { ALIAS_PATTERN, expectAlias } from './utils.js';
+
+const validateColor: TokenValidator = (value, path, tokenMap) => {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    if (m) expectAlias(value, path, 'color', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid color value`);
+};
+
+export default validateColor;

--- a/src/core/token-validators/cubicBezier.ts
+++ b/src/core/token-validators/cubicBezier.ts
@@ -1,0 +1,27 @@
+import type { TokenValidator } from './index.js';
+import { expectAlias } from './utils.js';
+
+const validateCubicBezier: TokenValidator = (value, path, tokenMap) => {
+  if (Array.isArray(value) && value.length === 4) {
+    for (let i = 0; i < 4; i++) {
+      const v: unknown = value[i];
+      if (typeof v === 'number') {
+        if (v < 0 || v > 1) {
+          throw new Error(`Token ${path} has invalid cubicBezier value`);
+        }
+      } else if (typeof v === 'string') {
+        expectAlias(v, `${path}[${String(i)}]`, 'number', tokenMap);
+      } else {
+        throw new Error(`Token ${path} has invalid cubicBezier value`);
+      }
+    }
+    return;
+  }
+  if (typeof value === 'string') {
+    expectAlias(value, path, 'cubicBezier', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid cubicBezier value`);
+};
+
+export default validateCubicBezier;

--- a/src/core/token-validators/dimension.ts
+++ b/src/core/token-validators/dimension.ts
@@ -1,0 +1,22 @@
+import type { TokenValidator } from './index.js';
+import { isRecord, expectAlias } from './utils.js';
+
+const DIMENSION_UNITS = new Set(['px', 'rem']);
+
+const validateDimension: TokenValidator = (value, path, tokenMap) => {
+  if (
+    isRecord(value) &&
+    typeof value.value === 'number' &&
+    typeof value.unit === 'string' &&
+    DIMENSION_UNITS.has(value.unit)
+  ) {
+    return;
+  }
+  if (typeof value === 'string') {
+    expectAlias(value, path, 'dimension', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid dimension value`);
+};
+
+export default validateDimension;

--- a/src/core/token-validators/duration.ts
+++ b/src/core/token-validators/duration.ts
@@ -1,0 +1,22 @@
+import type { TokenValidator } from './index.js';
+import { isRecord, expectAlias } from './utils.js';
+
+const DURATION_UNITS = new Set(['ms', 's']);
+
+const validateDuration: TokenValidator = (value, path, tokenMap) => {
+  if (
+    isRecord(value) &&
+    typeof value.value === 'number' &&
+    typeof value.unit === 'string' &&
+    DURATION_UNITS.has(value.unit)
+  ) {
+    return;
+  }
+  if (typeof value === 'string') {
+    expectAlias(value, path, 'duration', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid duration value`);
+};
+
+export default validateDuration;

--- a/src/core/token-validators/fontFamily.ts
+++ b/src/core/token-validators/fontFamily.ts
@@ -1,0 +1,14 @@
+import type { TokenValidator } from './index.js';
+import { ALIAS_PATTERN, expectAlias } from './utils.js';
+
+const validateFontFamily: TokenValidator = (value, path, tokenMap) => {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    if (m) expectAlias(value, path, 'fontFamily', tokenMap);
+    return;
+  }
+  if (Array.isArray(value) && value.every((v) => typeof v === 'string')) return;
+  throw new Error(`Token ${path} has invalid fontFamily value`);
+};
+
+export default validateFontFamily;

--- a/src/core/token-validators/fontWeight.ts
+++ b/src/core/token-validators/fontWeight.ts
@@ -1,0 +1,43 @@
+import type { TokenValidator } from './index.js';
+import { ALIAS_PATTERN, expectAlias } from './utils.js';
+
+const FONT_WEIGHT_KEYWORDS = new Set([
+  'thin',
+  'hairline',
+  'extra-light',
+  'ultra-light',
+  'light',
+  'normal',
+  'regular',
+  'book',
+  'medium',
+  'semi-bold',
+  'demi-bold',
+  'bold',
+  'extra-bold',
+  'ultra-bold',
+  'black',
+  'heavy',
+  'extra-black',
+  'ultra-black',
+]);
+
+const validateFontWeight: TokenValidator = (value, path, tokenMap) => {
+  if (typeof value === 'number') {
+    if (value < 1 || value > 1000) {
+      throw new Error(`Token ${path} has invalid fontWeight value`);
+    }
+    return;
+  }
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    if (m) {
+      expectAlias(value, path, 'fontWeight', tokenMap);
+      return;
+    }
+    if (FONT_WEIGHT_KEYWORDS.has(value)) return;
+  }
+  throw new Error(`Token ${path} has invalid fontWeight value`);
+};
+
+export default validateFontWeight;

--- a/src/core/token-validators/gradient.ts
+++ b/src/core/token-validators/gradient.ts
@@ -1,0 +1,33 @@
+import type { TokenValidator } from './index.js';
+import { isRecord, expectAlias } from './utils.js';
+import validateColor from './color.js';
+
+const validateGradient: TokenValidator = (value, path, tokenMap) => {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`Token ${path} has invalid gradient value`);
+  }
+  const stops = value;
+  for (let i = 0; i < stops.length; i++) {
+    const stop: unknown = stops[i];
+    if (!isRecord(stop)) {
+      throw new Error(`Token ${path} has invalid gradient value`);
+    }
+    const allowed = new Set(['color', 'position']);
+    for (const key of Object.keys(stop)) {
+      if (!allowed.has(key)) {
+        throw new Error(`Token ${path} has invalid gradient value`);
+      }
+    }
+    validateColor(stop.color, `${path}[${String(i)}].color`, tokenMap);
+    const pos = stop.position;
+    if (typeof pos === 'number') {
+      // allow any number; clamping is handled by consumers
+    } else if (typeof pos === 'string') {
+      expectAlias(pos, `${path}[${String(i)}].position`, 'number', tokenMap);
+    } else {
+      throw new Error(`Token ${path} has invalid gradient value`);
+    }
+  }
+};
+
+export default validateGradient;

--- a/src/core/token-validators/index.ts
+++ b/src/core/token-validators/index.ts
@@ -1,0 +1,41 @@
+import type { Token } from '../types.js';
+import color from './color.js';
+import dimension from './dimension.js';
+import number from './number.js';
+import fontFamily from './fontFamily.js';
+import fontWeight from './fontWeight.js';
+import duration from './duration.js';
+import cubicBezier from './cubicBezier.js';
+import shadow from './shadow.js';
+import strokeStyle from './strokeStyle.js';
+import gradient from './gradient.js';
+import typography from './typography.js';
+import stringValidator from './string.js';
+
+export type TokenValidator = (
+  value: unknown,
+  path: string,
+  tokenMap: Map<string, Token>,
+) => void;
+
+export const validatorRegistry = new Map<string, TokenValidator>();
+
+export function registerTokenValidator(
+  type: string,
+  validator: TokenValidator,
+): void {
+  validatorRegistry.set(type, validator);
+}
+
+registerTokenValidator('color', color);
+registerTokenValidator('dimension', dimension);
+registerTokenValidator('number', number);
+registerTokenValidator('fontFamily', fontFamily);
+registerTokenValidator('fontWeight', fontWeight);
+registerTokenValidator('duration', duration);
+registerTokenValidator('cubicBezier', cubicBezier);
+registerTokenValidator('shadow', shadow);
+registerTokenValidator('strokeStyle', strokeStyle);
+registerTokenValidator('gradient', gradient);
+registerTokenValidator('typography', typography);
+registerTokenValidator('string', stringValidator);

--- a/src/core/token-validators/number.ts
+++ b/src/core/token-validators/number.ts
@@ -1,0 +1,13 @@
+import type { TokenValidator } from './index.js';
+import { expectAlias } from './utils.js';
+
+const validateNumber: TokenValidator = (value, path, tokenMap) => {
+  if (typeof value === 'number') return;
+  if (typeof value === 'string') {
+    expectAlias(value, path, 'number', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid number value`);
+};
+
+export default validateNumber;

--- a/src/core/token-validators/shadow.ts
+++ b/src/core/token-validators/shadow.ts
@@ -1,0 +1,43 @@
+import type { TokenValidator } from './index.js';
+import { isRecord } from './utils.js';
+import validateColor from './color.js';
+import validateDimension from './dimension.js';
+
+const validateShadow: TokenValidator = (value, path, tokenMap) => {
+  const items = Array.isArray(value) ? value : [value];
+  if (!Array.isArray(items)) {
+    throw new Error(`Token ${path} has invalid shadow value`);
+  }
+  for (let i = 0; i < items.length; i++) {
+    const item: unknown = items[i];
+    if (!isRecord(item)) {
+      throw new Error(`Token ${path} has invalid shadow value`);
+    }
+    const allowed = new Set([
+      'color',
+      'offsetX',
+      'offsetY',
+      'blur',
+      'spread',
+      'inset',
+    ]);
+    for (const key of Object.keys(item)) {
+      if (!allowed.has(key)) {
+        throw new Error(`Token ${path} has invalid shadow value`);
+      }
+    }
+    const base = `${path}[${String(i)}]`;
+    validateColor(item.color, `${base}.color`, tokenMap);
+    validateDimension(item.offsetX, `${base}.offsetX`, tokenMap);
+    validateDimension(item.offsetY, `${base}.offsetY`, tokenMap);
+    validateDimension(item.blur, `${base}.blur`, tokenMap);
+    if (item.spread !== undefined) {
+      validateDimension(item.spread, `${base}.spread`, tokenMap);
+    }
+    if ('inset' in item && typeof item.inset !== 'boolean') {
+      throw new Error(`Token ${path} has invalid shadow value`);
+    }
+  }
+};
+
+export default validateShadow;

--- a/src/core/token-validators/string.ts
+++ b/src/core/token-validators/string.ts
@@ -1,0 +1,13 @@
+import type { TokenValidator } from './index.js';
+import { ALIAS_PATTERN, expectAlias } from './utils.js';
+
+const validateString: TokenValidator = (value, path, tokenMap) => {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    if (m) expectAlias(value, path, 'string', tokenMap);
+    return;
+  }
+  throw new Error(`Token ${path} has invalid string value`);
+};
+
+export default validateString;

--- a/src/core/token-validators/strokeStyle.ts
+++ b/src/core/token-validators/strokeStyle.ts
@@ -1,0 +1,53 @@
+import type { TokenValidator } from './index.js';
+import { isRecord } from './utils.js';
+import validateDimension from './dimension.js';
+
+const STROKE_STYLE_KEYWORDS = new Set([
+  'solid',
+  'dashed',
+  'dotted',
+  'double',
+  'groove',
+  'ridge',
+  'outset',
+  'inset',
+]);
+
+const STROKE_LINECAPS = new Set(['round', 'butt', 'square']);
+
+const validateStrokeStyle: TokenValidator = (value, path, tokenMap) => {
+  if (typeof value === 'string') {
+    if (!STROKE_STYLE_KEYWORDS.has(value)) {
+      throw new Error(`Token ${path} has invalid strokeStyle value`);
+    }
+    return;
+  }
+  if (isRecord(value)) {
+    const allowed = new Set(['dashArray', 'lineCap']);
+    for (const key of Object.keys(value)) {
+      if (!allowed.has(key)) {
+        throw new Error(`Token ${path} has invalid strokeStyle value`);
+      }
+    }
+    if (!Array.isArray(value.dashArray) || value.dashArray.length === 0) {
+      throw new Error(`Token ${path} has invalid strokeStyle value`);
+    }
+    for (let i = 0; i < value.dashArray.length; i++) {
+      validateDimension(
+        value.dashArray[i],
+        `${path}.dashArray[${String(i)}]`,
+        tokenMap,
+      );
+    }
+    if (
+      typeof value.lineCap !== 'string' ||
+      !STROKE_LINECAPS.has(value.lineCap)
+    ) {
+      throw new Error(`Token ${path} has invalid strokeStyle value`);
+    }
+    return;
+  }
+  throw new Error(`Token ${path} has invalid strokeStyle value`);
+};
+
+export default validateStrokeStyle;

--- a/src/core/token-validators/typography.ts
+++ b/src/core/token-validators/typography.ts
@@ -1,0 +1,38 @@
+import type { TokenValidator } from './index.js';
+import { isRecord } from './utils.js';
+import validateFontFamily from './fontFamily.js';
+import validateDimension from './dimension.js';
+import validateFontWeight from './fontWeight.js';
+import validateNumber from './number.js';
+
+const validateTypography: TokenValidator = (value, path, tokenMap) => {
+  if (!isRecord(value)) {
+    throw new Error(`Token ${path} has invalid typography value`);
+  }
+  const allowed = new Set([
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'lineHeight',
+  ]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      throw new Error(`Token ${path} has invalid typography value`);
+    }
+  }
+  const { fontFamily, fontSize, fontWeight, lineHeight } = value;
+  if (
+    fontFamily === undefined ||
+    fontSize === undefined ||
+    fontWeight === undefined ||
+    lineHeight === undefined
+  ) {
+    throw new Error(`Token ${path} has invalid typography value`);
+  }
+  validateFontFamily(fontFamily, `${path}.fontFamily`, tokenMap);
+  validateDimension(fontSize, `${path}.fontSize`, tokenMap);
+  validateFontWeight(fontWeight, `${path}.fontWeight`, tokenMap);
+  validateNumber(lineHeight, `${path}.lineHeight`, tokenMap);
+};
+
+export default validateTypography;

--- a/src/core/token-validators/utils.ts
+++ b/src/core/token-validators/utils.ts
@@ -1,0 +1,72 @@
+import type { Token } from '../types.js';
+
+export const ALIAS_PATTERN = /^\{([^}]+)\}$/;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isAlias(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const m = ALIAS_PATTERN.exec(value);
+    return m ? m[1] : null;
+  }
+  return null;
+}
+
+export function resolveAlias(
+  targetPath: string,
+  tokenMap: Map<string, Token>,
+  stack: string[],
+): Token {
+  if (stack.includes(targetPath)) {
+    throw new Error(
+      `Circular alias reference: ${[...stack, targetPath].join(' -> ')}`,
+    );
+  }
+  const target = tokenMap.get(targetPath);
+  if (!target) {
+    const source = stack[0];
+    throw new Error(`Token ${source} references unknown token: ${targetPath}`);
+  }
+  const next =
+    typeof target.$value === 'string'
+      ? ALIAS_PATTERN.exec(target.$value)
+      : null;
+  if (next) {
+    return resolveAlias(next[1], tokenMap, [...stack, targetPath]);
+  }
+  if (!target.$type) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $type: ${targetPath}`,
+    );
+  }
+  if (target.$value === undefined) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $value: ${targetPath}`,
+    );
+  }
+  return target;
+}
+
+export function expectAlias(
+  value: string,
+  path: string,
+  expected: string,
+  tokenMap: Map<string, Token>,
+): void {
+  const targetPath = isAlias(value);
+  if (!targetPath) {
+    throw new Error(`Token ${path} has invalid ${expected} reference`);
+  }
+  const target = resolveAlias(targetPath, tokenMap, [path]);
+  if (target.$type !== expected) {
+    throw new Error(
+      `Token ${path} references token of type ${String(
+        target.$type,
+      )}; expected ${expected}`,
+    );
+  }
+}

--- a/tests/core/flatten-design-tokens.test.ts
+++ b/tests/core/flatten-design-tokens.test.ts
@@ -1,9 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { flattenDesignTokens } from '../../src/core/token-utils.ts';
+import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
 import type { DesignTokens } from '../../src/core/types.ts';
 
 void test('flattenDesignTokens collects token paths and inherits types', () => {
+  registerTokenValidator('special', (value) => {
+    if (typeof value !== 'string') {
+      throw new Error('invalid');
+    }
+  });
   const tokens: DesignTokens = {
     colors: {
       $type: 'color',


### PR DESCRIPTION
## Summary
- refactor token validation into dedicated modules with a registry
- expose registerTokenValidator for extensible token types
- resolve validators via registry and add built-in string validator

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1f1593fc88328b958b7e03b896813