### PR TITLE
feat(core): expose design tokens per theme

### DIFF
--- a/src/types/humanwhocodes__momoa.d.ts
+++ b/src/types/humanwhocodes__momoa.d.ts
@@ -1,0 +1,7 @@
+declare module '@humanwhocodes/momoa' {
+  export function parse(
+    source: string,
+    options?: { mode?: 'json'; ranges?: boolean },
+  ): unknown;
+  export function evaluate(ast: unknown): unknown;
+}

--- a/src/types/yaml-to-momoa.d.ts
+++ b/src/types/yaml-to-momoa.d.ts
@@ -1,0 +1,3 @@
+declare module 'yaml-to-momoa' {
+  export default function yamlToMomoa(source: string): unknown;
+}

--- a/tests/core/flatten-design-tokens.test.ts
+++ b/tests/core/flatten-design-tokens.test.ts
@@ -5,7 +5,7 @@ import type { DesignTokens } from '../../src/core/types.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
 
 void test('flattenDesignTokens collects token paths and inherits types', () => {
-  registerTokenValidator('special', () => {});
+  registerTokenValidator('special', () => undefined);
   const tokens: DesignTokens = {
     colors: {
       $type: 'color',

--- a/tests/rules/animation.test.ts
+++ b/tests/rules/animation.test.ts
@@ -5,7 +5,7 @@ import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
 
-registerTokenValidator('string', () => {});
+registerTokenValidator('string', () => undefined);
 
 const tokens = {
   animations: {

--- a/tests/rules/outline.test.ts
+++ b/tests/rules/outline.test.ts
@@ -5,7 +5,7 @@ import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
 
-registerTokenValidator('string', () => {});
+registerTokenValidator('string', () => undefined);
 
 const tokens = {
   outlines: { $type: 'string', focus: { $value: '2px solid #000' } },


### PR DESCRIPTION
## Summary
- supply per-theme design tokens to the linter and expose `getFlattenedTokens` for rule modules
- collect unused-token candidates from flattened DesignTokens in the token tracker
- provide a Node token provider that returns spec-compliant token records
- avoid reporting alias tokens as unused in the token usage tracker
- drop legacy token normalization helpers in favor of flattened DesignTokens
- refactor color enforcement rules to read design tokens via `getFlattenedTokens`
- refactor opacity rule to consume flattened number tokens via `getFlattenedTokens`
- refactor spacing rule to read dimension tokens via `getFlattenedTokens`
- refactor border-radius rule to read dimension tokens via `getFlattenedTokens`
- update token suggestion test to use font-size tokens
- exercise `getFlattenedTokens` in plugin fixtures to verify plugin integration
- document `getFlattenedTokens` access for plugin rules
- remove `LegacyDesignTokens` type in favor of spec `DesignTokens`
- resolve aliases when flattening design tokens and drop alias filtering in the token tracker
- include token metadata in unused token reports
- Ensure inline configuration tokens are available to rules by wrapping them in a default provider when no external token source is supplied, and safeguard rule lookups against malformed token definitions
- Initialize CLI token export objects with explicit typings to avoid unsafe assignments during token file generation
- Forward the parent `--config` option to the `tokens` subcommand so the CLI correctly resolves configuration files when run outside the config directory
- Add a regression test confirming that the `tokens` command can export tokens using a config path that lives outside the current working directory
- Record the fix with a patch-level changeset entry
- Updated fixture configs to include `$type` metadata for color tokens, ensuring smoke tests consume spec-compliant tokens without runtime errors
- Improved theme detection in `NodeTokenProvider` by checking for `$value` on immediate children, ensuring single-theme token objects are automatically wrapped under a default theme for rule consumption
- Added a regression test covering primitive token groups, confirming they’re wrapped in the default theme and that explicit theme records remain unchanged
- Recognized `$metadata` as a valid group property so design-token files can include metadata without parse errors
- Ignored metadata keys during token collection to prevent unused-token tracking from attempting to flatten non-token entries
- Expanded configuration validation to accept `.tokens.yaml` and `.tokens.yml` paths and verified YAML token loading in config tests
- Add type stubs for momoa parser and replace empty validator helpers in tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1f907b08c832896750a46860ccb34