### PR TITLE
feat: track token locations in flattened tokens

### DIFF
--- a/.changeset/add-token-location.md
+++ b/.changeset/add-token-location.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add location data to flattened tokens and expose getTokenLocation helper
+

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -31,4 +31,4 @@ export {
   getFlattenedTokens,
   type TokenPattern,
 } from './token-utils.js';
-export { parseDesignTokens } from './parser/index.js';
+export { parseDesignTokens, getTokenLocation } from './parser/index.js';

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -3,8 +3,13 @@ import { buildParseTree } from './parse-tree.js';
 import { normalizeTokens } from './normalize.js';
 import { validateTokens } from './validate.js';
 
-export function parseDesignTokens(tokens: DesignTokens): FlattenedToken[] {
-  const tree = buildParseTree(tokens);
+export { getTokenLocation } from './parse-tree.js';
+
+export function parseDesignTokens(
+  tokens: DesignTokens,
+  getLoc?: (path: string) => { line: number; column: number },
+): FlattenedToken[] {
+  const tree = buildParseTree(tokens, getLoc);
   normalizeTokens(tree);
   validateTokens(tree);
   return tree;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -42,6 +42,7 @@ export type DesignTokens = RootTokenGroup;
 export interface FlattenedToken {
   path: string;
   token: Token;
+  loc: { line: number; column: number };
 }
 
 export interface LintMessage {

--- a/src/rules/token-opacity.ts
+++ b/src/rules/token-opacity.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule, FlattenedToken } from '../core/types.js';
 import { isStyleValue } from '../utils/style.js';
 
 export const opacityRule: RuleModule = {
@@ -11,7 +11,7 @@ export const opacityRule: RuleModule = {
     const allowed = new Set(
       opacityTokens
         .filter(
-          (t): t is { path: string; token: { $value: number } } =>
+          (t): t is FlattenedToken & { token: { $value: number } } =>
             t.path.startsWith('opacity.') && typeof t.token.$value === 'number',
         )
         .map((t) => t.token.$value),

--- a/tests/core/flatten-design-tokens.test.ts
+++ b/tests/core/flatten-design-tokens.test.ts
@@ -5,7 +5,7 @@ import type { DesignTokens } from '../../src/core/types.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
 
 void test('flattenDesignTokens collects token paths and inherits types', () => {
-  registerTokenValidator('special', () => {});
+  registerTokenValidator('special', () => undefined);
   const tokens: DesignTokens = {
     colors: {
       $type: 'color',
@@ -24,18 +24,25 @@ void test('flattenDesignTokens collects token paths and inherits types', () => {
   };
   const flat = flattenDesignTokens(tokens);
   assert.deepEqual(flat, [
-    { path: 'colors.red', token: { $value: '#ff0000', $type: 'color' } },
+    {
+      path: 'colors.red',
+      token: { $value: '#ff0000', $type: 'color' },
+      loc: { line: 1, column: 1 },
+    },
     {
       path: 'colors.accent',
       token: { $value: '#00ff00', $type: 'special' },
+      loc: { line: 1, column: 1 },
     },
     {
       path: 'colors.nested.green',
       token: { $value: '#00ff00', $type: 'color' },
+      loc: { line: 1, column: 1 },
     },
     {
       path: 'size.spacing.small',
       token: { $value: { value: 4, unit: 'px' }, $type: 'dimension' },
+      loc: { line: 1, column: 1 },
     },
   ]);
 });
@@ -75,8 +82,16 @@ void test('flattenDesignTokens resolves alias references', () => {
   };
   const flat = flattenDesignTokens(tokens);
   assert.deepEqual(flat, [
-    { path: 'color.base', token: { $value: '#fff', $type: 'color' } },
-    { path: 'color.primary', token: { $value: '#fff', $type: 'color' } },
+    {
+      path: 'color.base',
+      token: { $value: '#fff', $type: 'color' },
+      loc: { line: 1, column: 1 },
+    },
+    {
+      path: 'color.primary',
+      token: { $value: '#fff', $type: 'color' },
+      loc: { line: 1, column: 1 },
+    },
   ]);
 });
 

--- a/tests/core/get-flattened-tokens.test.ts
+++ b/tests/core/get-flattened-tokens.test.ts
@@ -29,6 +29,7 @@ void test('getFlattenedTokens flattens tokens for specified theme and preserves 
     {
       path: 'palette.primary',
       token: { $value: '#fff', $type: 'color', $deprecated: 'use new palette' },
+      loc: { line: 1, column: 1 },
     },
     {
       path: 'palette.secondary',
@@ -38,6 +39,7 @@ void test('getFlattenedTokens flattens tokens for specified theme and preserves 
         $deprecated: 'use new palette',
         $extensions: { 'vendor.example': { note: true } },
       },
+      loc: { line: 1, column: 1 },
     },
   ]);
 });
@@ -51,6 +53,7 @@ void test('getFlattenedTokens defaults to the "default" theme', () => {
     {
       path: 'palette.primary',
       token: { $value: '#fff', $type: 'color' },
+      loc: { line: 1, column: 1 },
     },
   ]);
 });
@@ -67,8 +70,16 @@ void test('getFlattenedTokens resolves aliases', () => {
   };
   const flat = getFlattenedTokens(tokens, 'default');
   assert.deepEqual(flat, [
-    { path: 'palette.base', token: { $value: '#f00', $type: 'color' } },
-    { path: 'palette.primary', token: { $value: '#f00', $type: 'color' } },
+    {
+      path: 'palette.base',
+      token: { $value: '#f00', $type: 'color' },
+      loc: { line: 1, column: 1 },
+    },
+    {
+      path: 'palette.primary',
+      token: { $value: '#f00', $type: 'color' },
+      loc: { line: 1, column: 1 },
+    },
   ]);
 });
 

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -110,10 +110,10 @@ void test('parseDesignTokensFile reads a .tokens.json file', async () => {
   await writeFile(file, JSON.stringify(tokens), 'utf8');
 
   const result = await parseDesignTokensFile(file);
-  assert.deepEqual(result[0], {
-    path: 'color.blue',
-    token: { $value: '#00f', $type: 'color' },
-  });
+  assert.equal(result[0].path, 'color.blue');
+  assert.deepEqual(result[0].token, { $value: '#00f', $type: 'color' });
+  assert.equal(typeof result[0].loc.line, 'number');
+  assert.equal(typeof result[0].loc.column, 'number');
 });
 
 void test('parseDesignTokensFile reads a .tokens.yaml file', async () => {
@@ -123,10 +123,10 @@ void test('parseDesignTokensFile reads a .tokens.yaml file', async () => {
   await writeFile(file, yaml, 'utf8');
 
   const result = await parseDesignTokensFile(file);
-  assert.deepEqual(result[0], {
-    path: 'color.blue',
-    token: { $value: '#00f', $type: 'color' },
-  });
+  assert.equal(result[0].path, 'color.blue');
+  assert.deepEqual(result[0].token, { $value: '#00f', $type: 'color' });
+  assert.equal(typeof result[0].loc.line, 'number');
+  assert.equal(typeof result[0].loc.column, 'number');
 });
 
 void test('parseDesignTokensFile reports location on parse error', async () => {

--- a/tests/rules/animation.test.ts
+++ b/tests/rules/animation.test.ts
@@ -5,7 +5,7 @@ import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
 
-registerTokenValidator('string', () => {});
+registerTokenValidator('string', () => undefined);
 
 const tokens = {
   animations: {

--- a/tests/rules/outline.test.ts
+++ b/tests/rules/outline.test.ts
@@ -5,7 +5,7 @@ import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
 
-registerTokenValidator('string', () => {});
+registerTokenValidator('string', () => undefined);
 
 const tokens = {
   outlines: { $type: 'string', focus: { $value: '2px solid #000' } },

--- a/tests/token-utils.test.ts
+++ b/tests/token-utils.test.ts
@@ -4,6 +4,7 @@ import {
   matchToken,
   closestToken,
   extractVarName,
+  flattenDesignTokens,
 } from '../src/core/token-utils.ts';
 
 void test('matchToken handles regexp and glob patterns and missing matches', () => {
@@ -27,4 +28,12 @@ void test('extractVarName parses var() and ignores invalid values', () => {
   assert.equal(extractVarName('var(  --x  )'), '--x');
   assert.equal(extractVarName('--x'), null);
   assert.equal(extractVarName('var(--foo.bar)'), null);
+});
+
+void test('flattenDesignTokens provides location information', () => {
+  const tokens = {
+    color: { $type: 'color', blue: { $value: '#00f' } },
+  };
+  const result = flattenDesignTokens(tokens);
+  assert.deepEqual(result[0].loc, { line: 1, column: 1 });
 });


### PR DESCRIPTION
## Summary
- include source line and column in `FlattenedToken`
- propagate Momoa node locations through parsing and expose `getTokenLocation`
- test flatten utils for location data

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1f8ac913c8328ad0c544286720be1