### PR TITLE
feat(core): support figma and tokens studio formats

### DIFF
--- a/.changeset/figma-tokens-support.md
+++ b/.changeset/figma-tokens-support.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add support for Figma and Tokens Studio token formats
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,7 @@ The file may be `designlint.config.json`, `.js`, `.ts`, `.mjs`, or `.mts`.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `tokens` | object | `undefined` | A [W3C Design Tokens](./glossary.md#design-tokens) tree or a map of themes. Theme values may be inline token objects or paths to `.tokens` files. |
+| `tokens` | object | `undefined` | A design tokens tree (W3C, Figma, or Tokens Studio) or a map of themes. Theme values may be inline token objects or paths to `.tokens` files. |
 | `rules` | object | `undefined` | Enables [rules](./rules/index.md) and sets their severity. |
 | `plugins` | string[] | `[]` | Loads additional [plugins](./plugins.md). |
 | `ignoreFiles` | string[] | `[]` | Glob patterns ignored during linting. |
@@ -44,7 +44,7 @@ The file may be `designlint.config.json`, `.js`, `.ts`, `.mjs`, or `.mts`.
 
 
 ## Tokens
-Tokens describe the design system in a machine-readable form. Provide a W3C Design Tokens object directly or supply a map of theme names.
+Tokens describe the design system in a machine-readable form. Provide a W3C Design Tokens object directly, pass Figma or Tokens Studio exports, or supply a map of theme names.
 
 Inline example:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -18,7 +18,7 @@ Key concepts used throughout the documentation.
 - [See also](#see-also)
 
 ## Design tokens
-Named values such as colours, spacing, or typography that describe your design system. design-lint uses the [W3C Design Tokens Community Group format](https://design-tokens.github.io/community-group/technical-reports/format/) for all token files.
+Named values such as colours, spacing, or typography that describe your design system. design-lint uses the [W3C Design Tokens Community Group format](https://design-tokens.github.io/community-group/technical-reports/format/) for all token files and can convert Figma and Tokens Studio exports to that format automatically.
 
 ## Rule
 A check that validates code against the design system. Rules may be built-in or provided by plugins.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # @lapidist/design-lint
 
-@lapidist/design-lint keeps code and style sheets aligned with your design system. It understands design tokens, knows about modern frameworks, and runs wherever Node.js \>=22 is available. The project exclusively supports the [W3C Design Tokens format](./glossary.md#design-tokens), making it a reference implementation of the standard.
+@lapidist/design-lint keeps code and style sheets aligned with your design system. It understands design tokens, knows about modern frameworks, and runs wherever Node.js \>=22 is available. While the tool works natively with the [W3C Design Tokens format](./glossary.md#design-tokens), it can also ingest Figma and Tokens Studio exports by converting them to the standard.
 
 ## Table of contents
 - [Why design-lint?](#why-design-lint)

--- a/src/core/formats/figma.ts
+++ b/src/core/formats/figma.ts
@@ -1,0 +1,124 @@
+import type { DesignTokens, TokenGroup, Token } from '../types.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+}
+
+function isRGB(value: unknown): value is RGB {
+  return (
+    isRecord(value) &&
+    typeof value.r === 'number' &&
+    typeof value.g === 'number' &&
+    typeof value.b === 'number'
+  );
+}
+
+function toHex(n: number): string {
+  return n.toString(16).padStart(2, '0');
+}
+
+function convertColor(value: unknown): string {
+  if (isRGB(value)) {
+    const r = Math.round(value.r * 255);
+    const g = Math.round(value.g * 255);
+    const b = Math.round(value.b * 255);
+    const a = typeof value.a === 'number' ? value.a : 1;
+    if (a === 1) return '#' + toHex(r) + toHex(g) + toHex(b);
+    return `rgba(${String(r)}, ${String(g)}, ${String(b)}, ${String(a)})`;
+  }
+  return String(value);
+}
+
+function mapValue(value: unknown, type: string): unknown {
+  switch (type) {
+    case 'COLOR':
+      return convertColor(value);
+    case 'FLOAT':
+      return typeof value === 'number' ? String(value) + 'px' : value;
+    default:
+      return value;
+  }
+}
+
+function mapType(type: string): string | undefined {
+  switch (type) {
+    case 'COLOR':
+      return 'color';
+    case 'FLOAT':
+      return 'dimension';
+    case 'STRING':
+      return 'string';
+    case 'BOOLEAN':
+      return 'boolean';
+    default:
+      return undefined;
+  }
+}
+
+function isTokenGroupNode(value: unknown): value is TokenGroup {
+  return (
+    isRecord(value) && !Object.prototype.hasOwnProperty.call(value, '$value')
+  );
+}
+
+export function figmaToDTCG(data: unknown): DesignTokens | undefined {
+  if (!isRecord(data) || !Array.isArray(data.collections)) return undefined;
+  const result: TokenGroup = {};
+  for (const collection of data.collections) {
+    if (!isRecord(collection)) continue;
+    const variables = Array.isArray(collection.variables)
+      ? collection.variables
+      : [];
+    for (const variable of variables) {
+      if (!isRecord(variable)) continue;
+      const name =
+        typeof variable.name === 'string' ? variable.name : undefined;
+      const type =
+        typeof variable.type === 'string' ? variable.type : undefined;
+      if (!name || !type) continue;
+      const description =
+        typeof variable.description === 'string'
+          ? variable.description
+          : undefined;
+      const valuesByMode = isRecord(variable.valuesByMode)
+        ? variable.valuesByMode
+        : undefined;
+      const resolvedValuesByMode = isRecord(variable.resolvedValuesByMode)
+        ? variable.resolvedValuesByMode
+        : undefined;
+      const parts = name.split(/[\/]/);
+      let group: TokenGroup = result;
+      for (let i = 0; i < parts.length - 1; i++) {
+        const part = parts[i];
+        const node = group[part];
+        if (isTokenGroupNode(node)) {
+          group = node;
+        } else {
+          const child: TokenGroup = {};
+          group[part] = child;
+          group = child;
+        }
+      }
+      const last = parts[parts.length - 1];
+      let raw: unknown = variable.resolvedValue;
+      if (raw === undefined) {
+        const byMode = resolvedValuesByMode ?? valuesByMode;
+        const first = byMode ? Object.keys(byMode)[0] : undefined;
+        raw = first ? byMode?.[first] : undefined;
+      }
+      const token: Token = { $value: mapValue(raw, type) };
+      const mappedType = mapType(type);
+      if (mappedType) token.$type = mappedType;
+      if (description) token.$description = description;
+      group[last] = token;
+    }
+  }
+  return result;
+}

--- a/src/core/formats/tokens-studio.ts
+++ b/src/core/formats/tokens-studio.ts
@@ -1,0 +1,84 @@
+import type { DesignTokens, TokenGroup, Token } from '../types.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function detectTokensStudio(obj: unknown): boolean {
+  if (!isRecord(obj)) return false;
+  const stack: unknown[] = [obj];
+  while (stack.length) {
+    const current = stack.pop();
+    if (isRecord(current)) {
+      if ('value' in current && 'type' in current && !('$value' in current)) {
+        return true;
+      }
+      for (const v of Object.values(current)) {
+        stack.push(v);
+      }
+    }
+  }
+  return false;
+}
+
+interface LegacyToken {
+  value: unknown;
+  type: string;
+  description?: string;
+  extensions?: Record<string, unknown>;
+  deprecated?: boolean | string;
+}
+
+function isLegacyToken(value: unknown): value is LegacyToken {
+  return (
+    isRecord(value) &&
+    'value' in value &&
+    'type' in value &&
+    typeof value.type === 'string'
+  );
+}
+
+function convertGroup(group: Record<string, unknown>): TokenGroup {
+  const result: TokenGroup = {};
+  for (const [key, value] of Object.entries(group)) {
+    if (key === 'type' && !('$type' in group) && typeof value === 'string') {
+      result.$type = value;
+      continue;
+    }
+    if (
+      key === 'description' &&
+      !('$description' in group) &&
+      typeof value === 'string'
+    ) {
+      result.$description = value;
+      continue;
+    }
+    if (key === 'extensions' && !('$extensions' in group) && isRecord(value)) {
+      result.$extensions = value;
+      continue;
+    }
+    if (
+      key === 'deprecated' &&
+      !('$deprecated' in group) &&
+      (typeof value === 'boolean' || typeof value === 'string')
+    ) {
+      result.$deprecated = value;
+      continue;
+    }
+    if (isLegacyToken(value)) {
+      const token: Token = { $value: value.value, $type: value.type };
+      if (value.description) token.$description = value.description;
+      if (value.extensions) token.$extensions = value.extensions;
+      if (value.deprecated !== undefined) token.$deprecated = value.deprecated;
+      result[key] = token;
+    } else if (isRecord(value)) {
+      result[key] = convertGroup(value);
+    }
+  }
+  return result;
+}
+
+export function tokensStudioToDTCG(data: unknown): DesignTokens | undefined {
+  if (!detectTokensStudio(data) || !isRecord(data)) return undefined;
+  return convertGroup(data);
+}

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -2,6 +2,8 @@ import type { DesignTokens, FlattenedToken } from '../types.js';
 import { buildParseTree } from './parse-tree.js';
 import { normalizeTokens } from './normalize.js';
 import { validateTokens } from './validate.js';
+import { figmaToDTCG } from '../formats/figma.js';
+import { tokensStudioToDTCG } from '../formats/tokens-studio.js';
 
 export { getTokenLocation } from './parse-tree.js';
 
@@ -9,7 +11,16 @@ export function parseDesignTokens(
   tokens: DesignTokens,
   getLoc?: (path: string) => { line: number; column: number },
 ): FlattenedToken[] {
-  const tree = buildParseTree(tokens, getLoc);
+  const transforms = [figmaToDTCG, tokensStudioToDTCG];
+  let normalized: DesignTokens = tokens;
+  for (const transform of transforms) {
+    const result = transform(normalized);
+    if (result) {
+      normalized = result;
+      break;
+    }
+  }
+  const tree = buildParseTree(normalized, getLoc);
   normalizeTokens(tree);
   validateTokens(tree);
   return tree;

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -162,13 +162,6 @@ void test('parseDesignTokens rejects legacy shorthand token values', () => {
   );
 });
 
-void test('parseDesignTokens rejects legacy token properties', () => {
-  const tokens = {
-    color: { blue: { value: '#00f', type: 'color' } },
-  } as unknown as DesignTokens;
-  assert.throws(() => parseDesignTokens(tokens), /legacy property/i);
-});
-
 void test('parseDesignTokens rejects tokens with mismatched $type and value', () => {
   const tokens = {
     color: { $type: 'color', bad: { $value: 123 as unknown as string } },
@@ -555,4 +548,38 @@ void test('parseDesignTokens rejects invalid $deprecated values', () => {
     },
   } as unknown as DesignTokens;
   assert.throws(() => parseDesignTokens(tokens), /invalid \$deprecated/i);
+});
+
+void test('parseDesignTokens transforms Tokens Studio format', () => {
+  const tokens = {
+    color: {
+      blue: { value: '#00f', type: 'color' },
+    },
+  } as unknown as DesignTokens;
+  const result = parseDesignTokens(tokens);
+  assert.equal(result[0].path, 'color.blue');
+  assert.deepEqual(result[0].token, { $value: '#00f', $type: 'color' });
+});
+
+void test('parseDesignTokens transforms Figma variables format', () => {
+  const tokens = {
+    collections: [
+      {
+        name: 'colors',
+        modes: [{ modeId: 'light', name: 'Light' }],
+        variables: [
+          {
+            name: 'color/blue',
+            type: 'COLOR',
+            valuesByMode: {
+              light: { r: 0, g: 0, b: 1, a: 1 },
+            },
+          },
+        ],
+      },
+    ],
+  } as unknown as DesignTokens;
+  const result = parseDesignTokens(tokens);
+  assert.equal(result[0].path, 'color.blue');
+  assert.deepEqual(result[0].token, { $value: '#0000ff', $type: 'color' });
 });


### PR DESCRIPTION
## Summary
- add converters for Figma and Tokens Studio token schemas
- normalize external formats before validation
- document additional token formats

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1fcfb3d7c83288e858622ec0f8064