### PR TITLE
feat(parser): add contextual token parse diagnostics

### DIFF
--- a/.changeset/parser-diagnostics.md
+++ b/.changeset/parser-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+improve token parser diagnostics with file locations and CLI output

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -136,7 +136,10 @@ void test('parseDesignTokensFile reports location on parse error', async () => {
 
   await assert.rejects(
     () => parseDesignTokensFile(file),
-    (err: Error) => err.message.includes(file) && /\(1:\d+\)/.test(err.message),
+    (err: Error) =>
+      err.message.startsWith(`${file}:1:`) &&
+      err.message.includes('{ "color": { $type: "color", }') &&
+      /\n\s*\^\n/.test(err.message),
   );
 });
 


### PR DESCRIPTION
## Summary
- record Momoa node locations and format parser errors with line excerpts
- attach location data to parse-tree errors for richer diagnostics
- surface token parse diagnostics through the CLI

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c1fda4baec83289301bacd64790802