### PR TITLE
feat(parser): add token transform registry

### DIFF
--- a/.changeset/token-transform-registry.md
+++ b/.changeset/token-transform-registry.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add token transform registry and parseDesignTokens transform support
+

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run with `--fix` to automatically replace deprecated tokens or components and ti
 Lint JavaScript, TypeScript, CSS, SCSS, Sass and Less, including inline styles and tagged template literals.
 
 ### Extensible
-Extend behaviour with custom rules, formatters and plugins for your design system.
+Extend behaviour with custom rules, formatters, and token transforms for your design system.
 
 | Advantage | @lapidist/design-lint | Generic linters |
 | --- | --- | --- |

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,6 +59,15 @@ Key methods:
 - `defineConfig(config)` – provide type checking for config files.
 - `getFormatter(name)` – load a formatter by name or path.
 - `applyFixes(text, messages)` – apply non-overlapping fixes.
+- `registerTokenTransform(transform)` – convert design tokens before validation;
+  returns an unregister function.
+
+### Token transforms
+Design token objects may originate from sources like Figma or Tokens Studio.
+Use `registerTokenTransform()` to supply converters that adapt these formats
+to the [W3C Design Tokens specification](./glossary.md#design-tokens).
+Transforms run before token normalization and validation.
+`parseDesignTokens()` also accepts a `transforms` array for per-call transforms.
 
 ## Types
 design-lint ships with TypeScript definitions for `Config`, `LintResult`, `RuleModule`, and more:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,7 +66,28 @@ export default {
 };
 ```
 
-### 3. Test the plugin
+### 3. Register token transforms
+If your plugin consumes design tokens from other tools, provide a transform
+to convert them to the W3C format. Register the transform during plugin
+initialisation:
+
+```ts
+import { registerTokenTransform, type DesignTokens } from '@lapidist/design-lint';
+
+export function setup(): void {
+  const unregister = registerTokenTransform((tokens: DesignTokens) =>
+    convertFromFigma(tokens),
+  );
+  // call unregister() during teardown if the transform is temporary
+}
+
+function convertFromFigma(tokens: DesignTokens): DesignTokens {
+  // convert tokens here
+  return tokens;
+}
+```
+
+### 4. Test the plugin
 ```ts
 import test from 'node:test';
 import assert from 'node:assert/strict';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -31,4 +31,9 @@ export {
   getFlattenedTokens,
   type TokenPattern,
 } from './token-utils.js';
-export { parseDesignTokens, getTokenLocation } from './parser/index.js';
+export {
+  parseDesignTokens,
+  getTokenLocation,
+  registerTokenTransform,
+  type TokenTransform,
+} from './parser/index.js';

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -4,10 +4,23 @@ import { normalizeTokens } from './normalize.js';
 import { normalizeColorValues, type ColorSpace } from './normalize-colors.js';
 import { validateTokens } from './validate.js';
 
+export type TokenTransform = (tokens: DesignTokens) => DesignTokens;
+
+const tokenTransformRegistry: TokenTransform[] = [];
+
+export function registerTokenTransform(transform: TokenTransform): () => void {
+  tokenTransformRegistry.push(transform);
+  return () => {
+    const idx = tokenTransformRegistry.indexOf(transform);
+    if (idx >= 0) tokenTransformRegistry.splice(idx, 1);
+  };
+}
+
 export { getTokenLocation } from './parse-tree.js';
 
 export interface ParseDesignTokensOptions {
   colorSpace?: ColorSpace;
+  transforms?: TokenTransform[];
 }
 
 export function parseDesignTokens(
@@ -15,7 +28,15 @@ export function parseDesignTokens(
   getLoc?: (path: string) => { line: number; column: number },
   options?: ParseDesignTokensOptions,
 ): FlattenedToken[] {
-  const tree = buildParseTree(tokens, getLoc);
+  let transformed = tokens;
+  const transforms = [
+    ...tokenTransformRegistry,
+    ...(options?.transforms ?? []),
+  ];
+  for (const transform of transforms) {
+    transformed = transform(transformed);
+  }
+  const tree = buildParseTree(transformed, getLoc);
   normalizeTokens(tree);
   if (options?.colorSpace) {
     normalizeColorValues(tree, options.colorSpace);


### PR DESCRIPTION
## Summary
- allow plugins to register token transforms
- run custom transforms before token normalization and validation
- document token transform API

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c201da545c832884eb565e1dffd8d9