### PR TITLE
feat(parser): add detailed token parse diagnostics

### DIFF
--- a/.changeset/token-parser-diagnostics.md
+++ b/.changeset/token-parser-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": patch
+---
+
+add detailed parser diagnostics with file locations

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -3,4 +3,8 @@ export { createFileDocument } from './file-document.js';
 export { NodePluginLoader } from './plugin-loader.js';
 export { NodeCacheProvider } from './node-cache-provider.js';
 export { createNodeEnvironment } from './environment.js';
-export { parseDesignTokensFile, readDesignTokensFile } from './token-parser.js';
+export {
+  parseDesignTokensFile,
+  readDesignTokensFile,
+  TokenParseError,
+} from './token-parser.js';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { Command } from 'commander';
 import chalk, { supportsColor } from 'chalk';
+import { TokenParseError } from '../adapters/node/token-parser.js';
 import { prepareEnvironment, type PrepareEnvironmentOptions } from './env.js';
 import { executeLint, type ExecuteOptions } from './execute.js';
 import { watchMode } from './watch.js';
@@ -134,8 +135,13 @@ export async function run(argv = process.argv.slice(2)) {
       process.exitCode = exitCode;
       if (options.watch) await watchMode(patterns, options, services);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(useColor ? chalk.red(message) : message);
+      if (err instanceof TokenParseError) {
+        const out = err.format();
+        console.error(useColor ? chalk.red(out) : out);
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(useColor ? chalk.red(message) : message);
+      }
       process.exitCode = 1;
     }
   });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -5,7 +5,10 @@ import { TypeScriptLoader } from 'cosmiconfig-typescript-loader';
 import type { Config } from '../core/linter.js';
 import { configSchema } from './schema.js';
 import { realpathIfExists } from '../adapters/node/utils/paths.js';
-import { readDesignTokensFile } from '../adapters/node/token-parser.js';
+import {
+  readDesignTokensFile,
+  TokenParseError,
+} from '../adapters/node/token-parser.js';
 import { parseDesignTokens } from '../core/parser/index.js';
 import type { DesignTokens } from '../core/types.js';
 
@@ -90,6 +93,7 @@ export async function loadConfig(
         try {
           themes[theme] = await readDesignTokensFile(filePath);
         } catch (err) {
+          if (err instanceof TokenParseError) throw err;
           const message = err instanceof Error ? err.message : String(err);
           throw new Error(
             `Failed to read tokens for theme "${theme}": ${message}`,
@@ -104,6 +108,7 @@ export async function loadConfig(
         try {
           parseDesignTokens(t);
         } catch (err) {
+          if (err instanceof TokenParseError) throw err;
           const message = err instanceof Error ? err.message : String(err);
           throw new Error(
             `Failed to parse tokens for theme "${theme}": ${message}`,
@@ -115,6 +120,7 @@ export async function loadConfig(
       try {
         parseDesignTokens(themes);
       } catch (err) {
+        if (err instanceof TokenParseError) throw err;
         throw err instanceof Error ? err : new Error(String(err));
       }
       config.tokens = themes;

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -8,7 +8,10 @@ import {
   registerTokenTransform,
   type TokenTransform,
 } from '../../src/core/parser/index.ts';
-import { parseDesignTokensFile } from '../../src/adapters/node/token-parser.ts';
+import {
+  parseDesignTokensFile,
+  TokenParseError,
+} from '../../src/adapters/node/token-parser.ts';
 import type { DesignTokens } from '../../src/core/types.js';
 
 void test('parseDesignTokens flattens tokens with paths in declaration order', () => {
@@ -140,7 +143,14 @@ void test('parseDesignTokensFile reports location on parse error', async () => {
 
   await assert.rejects(
     () => parseDesignTokensFile(file),
-    (err: Error) => err.message.includes(file) && /\(1:\d+\)/.test(err.message),
+    (err: unknown) => {
+      assert.ok(err instanceof TokenParseError);
+      assert.equal(err.filePath, file);
+      assert.ok(err.line >= 1);
+      assert.ok(err.column >= 1);
+      assert.ok(err.format().includes('^'));
+      return true;
+    },
   );
 });
 


### PR DESCRIPTION
## Summary
- record file and location for design token parser errors and format a caret diagnostic
- surface token parse diagnostics in the CLI

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c204e65080832882b00cfaa63dc997