### PR TITLE
feat(core): resolve nested token aliases

### DIFF
--- a/.changeset/alias-utility-nested-aliases.md
+++ b/.changeset/alias-utility-nested-aliases.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+resolve nested token aliases and record references

--- a/src/core/parser/alias.ts
+++ b/src/core/parser/alias.ts
@@ -1,0 +1,99 @@
+import type { Token } from '../types.js';
+
+const ALIAS_GLOBAL = /\{([^}]+)\}/g;
+const ALIAS_EXACT = /^\{([^}]+)\}$/;
+
+function resolveAlias(
+  targetPath: string,
+  tokenMap: Map<string, Token>,
+  stack: string[],
+): Token {
+  if (stack.includes(targetPath)) {
+    throw new Error(
+      `Circular alias reference: ${[...stack, targetPath].join(' -> ')}`,
+    );
+  }
+  const target = tokenMap.get(targetPath);
+  if (!target) {
+    const source = stack[0];
+    throw new Error(`Token ${source} references unknown token: ${targetPath}`);
+  }
+  const next =
+    typeof target.$value === 'string' ? ALIAS_EXACT.exec(target.$value) : null;
+  if (next) {
+    return resolveAlias(next[1], tokenMap, [...stack, targetPath]);
+  }
+  if (!target.$type) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $type: ${targetPath}`,
+    );
+  }
+  if (target.$value === undefined) {
+    const source = stack[0];
+    throw new Error(
+      `Token ${source} references token without $value: ${targetPath}`,
+    );
+  }
+  return target;
+}
+
+export interface AliasResult {
+  value: unknown;
+  refs: string[];
+}
+
+export function resolveAliases(
+  value: unknown,
+  path: string,
+  token: Token,
+  tokenMap: Map<string, Token>,
+): AliasResult {
+  const refs: string[] = [];
+
+  function walk(val: unknown, expectedType?: string): unknown {
+    if (typeof val === 'string') {
+      const exact = ALIAS_EXACT.exec(val);
+      if (exact) {
+        refs.push(exact[1]);
+        const target = resolveAlias(exact[1], tokenMap, [path]);
+        const aliasType = target.$type;
+        if (expectedType) {
+          if (!aliasType) {
+            throw new Error(
+              `Token ${path} references token without $type: ${exact[1]}`,
+            );
+          }
+          if (aliasType !== expectedType) {
+            throw new Error(
+              `Token ${path} has mismatched $type ${expectedType}; expected ${aliasType}`,
+            );
+          }
+        } else if (!token.$type && aliasType) {
+          token.$type = aliasType;
+        }
+        return target.$value;
+      }
+      return val.replace(ALIAS_GLOBAL, (_, ref: string) => {
+        refs.push(ref);
+        const target = resolveAlias(ref, tokenMap, [path]);
+        return String(target.$value);
+      });
+    }
+    if (Array.isArray(val)) {
+      return val.map((v) => walk(v));
+    }
+    if (typeof val === 'object' && val !== null) {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(val)) {
+        out[k] = walk(v);
+      }
+      return out;
+    }
+    return val;
+  }
+
+  return { value: walk(value, token.$type), refs };
+}
+
+export { resolveAlias };

--- a/src/core/parser/normalize.ts
+++ b/src/core/parser/normalize.ts
@@ -1,94 +1,13 @@
-import type { Token, FlattenedToken } from '../types.js';
-
-const ALIAS_PATTERN = /^\{([^}]+)\}$/;
-
-export function isAlias(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const m = ALIAS_PATTERN.exec(value);
-    return m ? m[1] : null;
-  }
-  return null;
-}
-
-function resolveAlias(
-  targetPath: string,
-  tokenMap: Map<string, Token>,
-  stack: string[],
-): Token {
-  if (stack.includes(targetPath)) {
-    throw new Error(
-      `Circular alias reference: ${[...stack, targetPath].join(' -> ')}`,
-    );
-  }
-  const target = tokenMap.get(targetPath);
-  if (!target) {
-    const source = stack[0];
-    throw new Error(`Token ${source} references unknown token: ${targetPath}`);
-  }
-  const next =
-    typeof target.$value === 'string'
-      ? ALIAS_PATTERN.exec(target.$value)
-      : null;
-  if (next) {
-    return resolveAlias(next[1], tokenMap, [...stack, targetPath]);
-  }
-  if (!target.$type) {
-    const source = stack[0];
-    throw new Error(
-      `Token ${source} references token without $type: ${targetPath}`,
-    );
-  }
-  if (target.$value === undefined) {
-    const source = stack[0];
-    throw new Error(
-      `Token ${source} references token without $value: ${targetPath}`,
-    );
-  }
-  return target;
-}
-
-export function expectAlias(
-  value: string,
-  path: string,
-  expected: string,
-  tokenMap: Map<string, Token>,
-): void {
-  const targetPath = isAlias(value);
-  if (!targetPath) {
-    throw new Error(`Token ${path} has invalid ${expected} reference`);
-  }
-  const target = resolveAlias(targetPath, tokenMap, [path]);
-  if (target.$type !== expected) {
-    throw new Error(
-      `Token ${path} references token of type ${String(
-        target.$type,
-      )}; expected ${expected}`,
-    );
-  }
-}
+import type { FlattenedToken } from '../types.js';
+import { resolveAliases } from './alias.js';
 
 export function normalizeTokens(tokens: FlattenedToken[]): FlattenedToken[] {
   const tokenMap = new Map(tokens.map((t) => [t.path, t.token]));
   for (const { path, token } of tokens) {
-    if (typeof token.$value === 'string') {
-      const match = ALIAS_PATTERN.exec(token.$value);
-      if (match) {
-        const target = resolveAlias(match[1], tokenMap, [path]);
-        const aliasType = target.$type;
-        if (!aliasType) {
-          throw new Error(
-            `Token ${path} references token without $type: ${match[1]}`,
-          );
-        }
-        if (!token.$type) {
-          token.$type = aliasType;
-        } else if (token.$type !== aliasType) {
-          throw new Error(
-            `Token ${path} has mismatched $type ${token.$type}; expected ${aliasType}`,
-          );
-        }
-        token.$value = target.$value;
-      }
+    const { value, refs } = resolveAliases(token.$value, path, token, tokenMap);
+    token.$value = value;
+    if (refs.length) {
+      token.aliasOf = Array.from(new Set(refs));
     }
   }
   return tokens;

--- a/src/core/token-validators/color.ts
+++ b/src/core/token-validators/color.ts
@@ -1,17 +1,7 @@
-import type { Token } from '../types.js';
-import { expectAlias, isAlias } from '../parser/normalize.js';
 import { parse } from 'culori';
 
-export function validateColor(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateColor(value: unknown, path: string): void {
   if (typeof value === 'string') {
-    if (isAlias(value)) {
-      expectAlias(value, path, 'color', tokenMap);
-      return;
-    }
     const parsed = parse(value);
     if (parsed && (parsed.mode === 'rgb' || parsed.mode === 'hsl')) return;
   }

--- a/src/core/token-validators/cubicBezier.ts
+++ b/src/core/token-validators/cubicBezier.ts
@@ -1,28 +1,11 @@
-import type { Token } from '../types.js';
-import { expectAlias } from '../parser/normalize.js';
-
-export function validateCubicBezier(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateCubicBezier(value: unknown, path: string): void {
   if (Array.isArray(value) && value.length === 4) {
     for (let i = 0; i < 4; i++) {
       const v: unknown = value[i];
-      if (typeof v === 'number') {
-        if (v < 0 || v > 1) {
-          throw new Error(`Token ${path} has invalid cubicBezier value`);
-        }
-      } else if (typeof v === 'string') {
-        expectAlias(v, `${path}[${String(i)}]`, 'number', tokenMap);
-      } else {
+      if (typeof v !== 'number' || v < 0 || v > 1) {
         throw new Error(`Token ${path} has invalid cubicBezier value`);
       }
     }
-    return;
-  }
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'cubicBezier', tokenMap);
     return;
   }
   throw new Error(`Token ${path} has invalid cubicBezier value`);

--- a/src/core/token-validators/dimension.ts
+++ b/src/core/token-validators/dimension.ts
@@ -1,24 +1,14 @@
-import type { Token } from '../types.js';
-import { expectAlias } from '../parser/normalize.js';
 import { isRecord } from './utils.js';
 
 const DIMENSION_UNITS = new Set(['px', 'rem']);
 
-export function validateDimension(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateDimension(value: unknown, path: string): void {
   if (
     isRecord(value) &&
     typeof value.value === 'number' &&
     typeof value.unit === 'string' &&
     DIMENSION_UNITS.has(value.unit)
   ) {
-    return;
-  }
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'dimension', tokenMap);
     return;
   }
   throw new Error(`Token ${path} has invalid dimension value`);

--- a/src/core/token-validators/duration.ts
+++ b/src/core/token-validators/duration.ts
@@ -1,24 +1,14 @@
-import type { Token } from '../types.js';
-import { expectAlias } from '../parser/normalize.js';
 import { isRecord } from './utils.js';
 
 const DURATION_UNITS = new Set(['ms', 's']);
 
-export function validateDuration(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateDuration(value: unknown, path: string): void {
   if (
     isRecord(value) &&
     typeof value.value === 'number' &&
     typeof value.unit === 'string' &&
     DURATION_UNITS.has(value.unit)
   ) {
-    return;
-  }
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'duration', tokenMap);
     return;
   }
   throw new Error(`Token ${path} has invalid duration value`);

--- a/src/core/token-validators/fontFamily.ts
+++ b/src/core/token-validators/fontFamily.ts
@@ -1,15 +1,5 @@
-import type { Token } from '../types.js';
-import { expectAlias, isAlias } from '../parser/normalize.js';
-
-export function validateFontFamily(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
-  if (typeof value === 'string') {
-    if (isAlias(value)) expectAlias(value, path, 'fontFamily', tokenMap);
-    return;
-  }
+export function validateFontFamily(value: unknown, path: string): void {
+  if (typeof value === 'string') return;
   if (Array.isArray(value) && value.every((v) => typeof v === 'string')) return;
   throw new Error(`Token ${path} has invalid fontFamily value`);
 }

--- a/src/core/token-validators/fontWeight.ts
+++ b/src/core/token-validators/fontWeight.ts
@@ -1,6 +1,3 @@
-import type { Token } from '../types.js';
-import { expectAlias, isAlias } from '../parser/normalize.js';
-
 const FONT_WEIGHT_KEYWORDS = new Set([
   'thin',
   'hairline',
@@ -22,23 +19,13 @@ const FONT_WEIGHT_KEYWORDS = new Set([
   'ultra-black',
 ]);
 
-export function validateFontWeight(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateFontWeight(value: unknown, path: string): void {
   if (typeof value === 'number') {
     if (value < 1 || value > 1000) {
       throw new Error(`Token ${path} has invalid fontWeight value`);
     }
     return;
   }
-  if (typeof value === 'string') {
-    if (isAlias(value)) {
-      expectAlias(value, path, 'fontWeight', tokenMap);
-      return;
-    }
-    if (FONT_WEIGHT_KEYWORDS.has(value)) return;
-  }
+  if (typeof value === 'string' && FONT_WEIGHT_KEYWORDS.has(value)) return;
   throw new Error(`Token ${path} has invalid fontWeight value`);
 }

--- a/src/core/token-validators/gradient.ts
+++ b/src/core/token-validators/gradient.ts
@@ -1,13 +1,7 @@
-import type { Token } from '../types.js';
-import { expectAlias } from '../parser/normalize.js';
 import { isArray, isRecord } from './utils.js';
 import { validateColor } from './color.js';
 
-export function validateGradient(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateGradient(value: unknown, path: string): void {
   if (!isArray(value) || value.length === 0) {
     throw new Error(`Token ${path} has invalid gradient value`);
   }
@@ -22,13 +16,9 @@ export function validateGradient(
         throw new Error(`Token ${path} has invalid gradient value`);
       }
     }
-    validateColor(stop.color, `${path}[${String(i)}].color`, tokenMap);
+    validateColor(stop.color, `${path}[${String(i)}].color`);
     const pos = stop.position;
-    if (typeof pos === 'number') {
-      // allow any number; clamping is handled by consumers
-    } else if (typeof pos === 'string') {
-      expectAlias(pos, `${path}[${String(i)}].position`, 'number', tokenMap);
-    } else {
+    if (typeof pos !== 'number') {
       throw new Error(`Token ${path} has invalid gradient value`);
     }
   }

--- a/src/core/token-validators/number.ts
+++ b/src/core/token-validators/number.ts
@@ -1,15 +1,4 @@
-import type { Token } from '../types.js';
-import { expectAlias } from '../parser/normalize.js';
-
-export function validateNumber(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateNumber(value: unknown, path: string): void {
   if (typeof value === 'number') return;
-  if (typeof value === 'string') {
-    expectAlias(value, path, 'number', tokenMap);
-    return;
-  }
   throw new Error(`Token ${path} has invalid number value`);
 }

--- a/src/core/token-validators/shadow.ts
+++ b/src/core/token-validators/shadow.ts
@@ -1,13 +1,8 @@
-import type { Token } from '../types.js';
 import { isRecord, toArray } from './utils.js';
 import { validateColor } from './color.js';
 import { validateDimension } from './dimension.js';
 
-export function validateShadow(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateShadow(value: unknown, path: string): void {
   const items = toArray(value);
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
@@ -28,12 +23,12 @@ export function validateShadow(
       }
     }
     const base = `${path}[${String(i)}]`;
-    validateColor(item.color, `${base}.color`, tokenMap);
-    validateDimension(item.offsetX, `${base}.offsetX`, tokenMap);
-    validateDimension(item.offsetY, `${base}.offsetY`, tokenMap);
-    validateDimension(item.blur, `${base}.blur`, tokenMap);
+    validateColor(item.color, `${base}.color`);
+    validateDimension(item.offsetX, `${base}.offsetX`);
+    validateDimension(item.offsetY, `${base}.offsetY`);
+    validateDimension(item.blur, `${base}.blur`);
     if (item.spread !== undefined) {
-      validateDimension(item.spread, `${base}.spread`, tokenMap);
+      validateDimension(item.spread, `${base}.spread`);
     }
     if ('inset' in item && typeof item.inset !== 'boolean') {
       throw new Error(`Token ${path} has invalid shadow value`);

--- a/src/core/token-validators/strokeStyle.ts
+++ b/src/core/token-validators/strokeStyle.ts
@@ -1,4 +1,3 @@
-import type { Token } from '../types.js';
 import { isRecord } from './utils.js';
 import { validateDimension } from './dimension.js';
 
@@ -14,11 +13,7 @@ const STROKE_STYLE_KEYWORDS = new Set([
 ]);
 const STROKE_LINECAPS = new Set(['round', 'butt', 'square']);
 
-export function validateStrokeStyle(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateStrokeStyle(value: unknown, path: string): void {
   if (typeof value === 'string') {
     if (!STROKE_STYLE_KEYWORDS.has(value)) {
       throw new Error(`Token ${path} has invalid strokeStyle value`);
@@ -39,7 +34,6 @@ export function validateStrokeStyle(
       validateDimension(
         value.dashArray[i],
         `${path}.dashArray[${String(i)}]`,
-        tokenMap,
       );
     }
     if (

--- a/src/core/token-validators/typography.ts
+++ b/src/core/token-validators/typography.ts
@@ -1,15 +1,10 @@
-import type { Token } from '../types.js';
 import { isRecord } from './utils.js';
 import { validateFontFamily } from './fontFamily.js';
 import { validateDimension } from './dimension.js';
 import { validateFontWeight } from './fontWeight.js';
 import { validateNumber } from './number.js';
 
-export function validateTypography(
-  value: unknown,
-  path: string,
-  tokenMap: Map<string, Token>,
-): void {
+export function validateTypography(value: unknown, path: string): void {
   if (!isRecord(value)) {
     throw new Error(`Token ${path} has invalid typography value`);
   }
@@ -33,8 +28,8 @@ export function validateTypography(
   ) {
     throw new Error(`Token ${path} has invalid typography value`);
   }
-  validateFontFamily(fontFamily, `${path}.fontFamily`, tokenMap);
-  validateDimension(fontSize, `${path}.fontSize`, tokenMap);
-  validateFontWeight(fontWeight, `${path}.fontWeight`, tokenMap);
-  validateNumber(lineHeight, `${path}.lineHeight`, tokenMap);
+  validateFontFamily(fontFamily, `${path}.fontFamily`);
+  validateDimension(fontSize, `${path}.fontSize`);
+  validateFontWeight(fontWeight, `${path}.fontWeight`);
+  validateNumber(lineHeight, `${path}.lineHeight`);
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,6 +15,7 @@ export interface Token {
   $description?: string;
   $extensions?: Record<string, unknown>;
   $deprecated?: boolean | string;
+  aliasOf?: string[];
 }
 
 /**

--- a/tests/core/flatten-design-tokens.test.ts
+++ b/tests/core/flatten-design-tokens.test.ts
@@ -89,7 +89,7 @@ void test('flattenDesignTokens resolves alias references', () => {
     },
     {
       path: 'color.primary',
-      token: { $value: '#fff', $type: 'color' },
+      token: { $value: '#fff', $type: 'color', aliasOf: ['color.base'] },
       loc: { line: 1, column: 1 },
     },
   ]);

--- a/tests/core/get-flattened-tokens.test.ts
+++ b/tests/core/get-flattened-tokens.test.ts
@@ -77,7 +77,7 @@ void test('getFlattenedTokens resolves aliases', () => {
     },
     {
       path: 'palette.primary',
-      token: { $value: '#f00', $type: 'color' },
+      token: { $value: '#f00', $type: 'color', aliasOf: ['palette.base'] },
       loc: { line: 1, column: 1 },
     },
   ]);


### PR DESCRIPTION
## Summary
- add alias resolver to parse nested `{alias}` segments and collect references
- normalize tokens using resolver and record `aliasOf`
- update validators and tests for gradients and shadows with aliases

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c208779c84832886bbdf2be5b6ae28