### PR TITLE
chore: format strokeStyle validator

### DIFF
--- a/src/core/token-validators/strokeStyle.ts
+++ b/src/core/token-validators/strokeStyle.ts
@@ -31,10 +31,7 @@ export function validateStrokeStyle(value: unknown, path: string): void {
       throw new Error(`Token ${path} has invalid strokeStyle value`);
     }
     for (let i = 0; i < value.dashArray.length; i++) {
-      validateDimension(
-        value.dashArray[i],
-        `${path}.dashArray[${String(i)}]`,
-      );
+      validateDimension(value.dashArray[i], `${path}.dashArray[${String(i)}]`);
     }
     if (
       typeof value.lineCap !== 'string' ||


### PR DESCRIPTION
## Summary
- run formatter on strokeStyle validator

## Testing
- `npm run format:check`
- `npm run lint` (fails: unsafe typings)
- `npm test` (fails: 40 failing tests)
- `npm run build` (fails: missing modules)


------
https://chatgpt.com/codex/tasks/task_e_68c20e9a44e0832890ca29788cd1214d