### PR TITLE
feat(core): expose design tokens per theme

### DIFF
--- a/.changeset/root-token-themes.md
+++ b/.changeset/root-token-themes.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix theme detection to recognize per-theme tokens defined at the root and export them via the CLI

--- a/src/cli/tokens.ts
+++ b/src/cli/tokens.ts
@@ -53,5 +53,29 @@ function isDesignTokens(value: unknown): value is DesignTokens {
 
 function isThemeRecord(val: unknown): val is Record<string, DesignTokens> {
   if (!isRecord(val)) return false;
-  return Object.values(val).every((v) => isDesignTokens(v) && !('$value' in v));
+  const entries = Object.entries(val).filter(([k]) => !k.startsWith('$'));
+  if (entries.length === 0) return false;
+  if (entries.length === 1) {
+    const [, theme] = entries[0];
+    if (!isRecord(theme)) return false;
+    const children = Object.entries(theme)
+      .filter(([k]) => !k.startsWith('$'))
+      .map(([, v]) => v);
+    const allTokens = children.every(
+      (child) => isRecord(child) && ('$value' in child || 'value' in child),
+    );
+    return !allTokens;
+  }
+  let shared: string[] | null = null;
+  for (const [, theme] of entries) {
+    if (!isRecord(theme)) return false;
+    const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
+    if (shared === null) {
+      shared = keys;
+    } else {
+      shared = shared.filter((k) => keys.includes(k));
+      if (shared.length === 0) return false;
+    }
+  }
+  return true;
 }

--- a/src/config/config-token-provider.ts
+++ b/src/config/config-token-provider.ts
@@ -38,7 +38,29 @@ function isDesignTokens(value: unknown): value is DesignTokens {
 
 function isThemeRecord(val: unknown): val is Record<string, DesignTokens> {
   if (!isRecord(val)) return false;
-  return Object.values(val).every(
-    (v) => isDesignTokens(v) && !('$value' in v) && !('value' in v),
-  );
+  const entries = Object.entries(val).filter(([k]) => !k.startsWith('$'));
+  if (entries.length === 0) return false;
+  if (entries.length === 1) {
+    const [, theme] = entries[0];
+    if (!isRecord(theme)) return false;
+    const children = Object.entries(theme)
+      .filter(([k]) => !k.startsWith('$'))
+      .map(([, v]) => v);
+    const allTokens = children.every(
+      (child) => isRecord(child) && ('$value' in child || 'value' in child),
+    );
+    return !allTokens;
+  }
+  let shared: string[] | null = null;
+  for (const [, theme] of entries) {
+    if (!isRecord(theme)) return false;
+    const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
+    if (shared === null) {
+      shared = keys;
+    } else {
+      shared = shared.filter((k) => keys.includes(k));
+      if (shared.length === 0) return false;
+    }
+  }
+  return true;
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -139,7 +139,29 @@ function isDesignTokens(value: unknown): value is DesignTokens {
 
 function isThemeRecord(val: unknown): val is Record<string, DesignTokens> {
   if (!isRecord(val)) return false;
-  return Object.values(val).every(
-    (v) => isDesignTokens(v) && !('$value' in v) && !('value' in v),
-  );
+  const entries = Object.entries(val).filter(([k]) => !k.startsWith('$'));
+  if (entries.length === 0) return false;
+  if (entries.length === 1) {
+    const [, theme] = entries[0];
+    if (!isRecord(theme)) return false;
+    const children = Object.entries(theme)
+      .filter(([k]) => !k.startsWith('$'))
+      .map(([, v]) => v);
+    const allTokens = children.every(
+      (child) => isRecord(child) && ('$value' in child || 'value' in child),
+    );
+    return !allTokens;
+  }
+  let shared: string[] | null = null;
+  for (const [, theme] of entries) {
+    if (!isRecord(theme)) return false;
+    const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
+    if (shared === null) {
+      shared = keys;
+    } else {
+      shared = shared.filter((k) => keys.includes(k));
+      if (shared.length === 0) return false;
+    }
+  }
+  return true;
 }

--- a/tests/cli/tokens.test.ts
+++ b/tests/cli/tokens.test.ts
@@ -93,3 +93,33 @@ void test('tokens command reads config from outside cwd', () => {
   >;
   assert.equal(out.default['color.red'].$value, '#ff0000');
 });
+
+void test('tokens command exports themes with root tokens', () => {
+  const dir = makeTmpDir();
+  const configPath = path.join(dir, 'designlint.config.json');
+  const tokens = {
+    light: { primary: { $type: 'color', $value: '#fff' } },
+    dark: { primary: { $type: 'color', $value: '#000' } },
+  };
+  fs.writeFileSync(configPath, JSON.stringify({ tokens, rules: {} }));
+  const cli = path.join(__dirname, '..', '..', 'src', 'cli', 'index.ts');
+  const res = spawnSync(
+    process.execPath,
+    [
+      '--import',
+      tsxLoader,
+      cli,
+      'tokens',
+      '--config',
+      'designlint.config.json',
+    ],
+    { cwd: dir, encoding: 'utf8' },
+  );
+  assert.equal(res.status, 0);
+  const out = JSON.parse(res.stdout) as Record<
+    string,
+    Record<string, { $value: unknown }>
+  >;
+  assert.equal(out.light.primary.$value, '#fff');
+  assert.equal(out.dark.primary.$value, '#000');
+});

--- a/tests/node-token-provider.test.ts
+++ b/tests/node-token-provider.test.ts
@@ -35,6 +35,16 @@ void test('accepts explicit theme records without modification', async () => {
   assert.deepEqual(result, themes);
 });
 
+void test('accepts theme records with tokens at the root', async () => {
+  const themes = {
+    light: { primary: { $type: 'color', $value: '#fff' } },
+    dark: { primary: { $type: 'color', $value: '#000' } },
+  };
+  const provider = new NodeTokenProvider(themes);
+  const result = await provider.load();
+  assert.deepEqual(result, themes);
+});
+
 void test('accepts theme records with primitive metadata fields', async () => {
   const themesWithMetadata = {
     light: tokens,


### PR DESCRIPTION
## Summary
- recognize theme records with root tokens across token providers and CLI
- add regression tests ensuring root-level tokens are exported per theme
- record the bug fix in a patch changeset

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c217ded1f483288d371008cd3c1fc7