### PR TITLE
docs: update architecture and API references

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -61,6 +61,10 @@ Key methods:
 - `applyFixes(text, messages)` – apply non-overlapping fixes.
 - `registerTokenTransform(transform)` – convert design tokens before validation;
   returns an unregister function.
+- `parseDesignTokens(tokens, getLoc?, options?)` – validate and flatten design tokens.
+- `readDesignTokensFile(path)` – load and validate a `.tokens` or `.tokens.json` file.
+- `parseDesignTokensFile(path)` – read and parse a design tokens file, returning flattened tokens.
+- `TokenParseError` – error type exposing file location details for token parsing failures.
 
 ### Token transforms
 Design token objects may originate from sources like Figma or Tokens Studio.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,11 +44,18 @@ Transforms collected results into human- or machine-readable output. Implementat
 ### Plugin loader
 Resolves configuration packages, rules, and formatters. The Node implementation is [`src/adapters/node/plugin-loader.ts`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/plugin-loader.ts).
 
+### Plugin manager
+Coordinates plugin loading and registers rules. It validates rule shape, prevents name collisions, and exposes the final set of
+plugins to the linter. See [`src/core/plugin-manager.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/plugin-manager.ts).
+
 ### Cache provider
 Stores metadata and parsed documents across runs. [`src/adapters/node/node-cache-provider.ts`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/node-cache-provider.ts) caches to disk.
 
 ### Token provider
 Supplies design tokens to rules. [`src/adapters/node/token-provider.ts`](https://github.com/bylapidist/design-lint/blob/main/src/adapters/node/token-provider.ts) normalises tokens from configuration.
+
+### Token tracker
+Keeps track of token usage across linted files and reports unused values for the [`design-system/no-unused-tokens`](./rules/design-system/no-unused-tokens.md) rule. Implementation: [`src/core/token-tracker.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/token-tracker.ts).
 
 ## Performance and caching
 design-lint processes files concurrently across CPU cores. Parsed documents and rule results are cached between runs in `.designlintcache` to reduce work.


### PR DESCRIPTION
## Summary
- document plugin manager and token tracker in architecture overview
- expose token parsing helpers in API reference

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c273ba92d4832894d487635bead97e