### PR TITLE
refactor(parser): remove legacy props check

### DIFF
--- a/.changeset/remove-legacy-props-check.md
+++ b/.changeset/remove-legacy-props-check.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+remove legacy token property checks

--- a/src/core/parser/parse-tree.ts
+++ b/src/core/parser/parse-tree.ts
@@ -21,13 +21,6 @@ const GROUP_PROPS = new Set([
   '$schema',
   '$metadata',
 ]);
-const LEGACY_PROPS = new Set([
-  'type',
-  'value',
-  'description',
-  'extensions',
-  'deprecated',
-]);
 const INVALID_NAME_CHARS = /[{}\.]/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -147,13 +140,6 @@ export function buildParseTree(
           tokenLocations.set(pathId, loc);
           result.push({ path: pathId, token, loc });
         } else if (isTokenGroup(node)) {
-          for (const key of Object.keys(node)) {
-            if (LEGACY_PROPS.has(key)) {
-              throw new Error(
-                `Token ${pathId} uses legacy property ${key}; expected $${key}`,
-              );
-            }
-          }
           const childKeys = Object.keys(node).filter(
             (k) => !GROUP_PROPS.has(k),
           );

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -176,13 +176,6 @@ void test('parseDesignTokens rejects legacy shorthand token values', () => {
   );
 });
 
-void test('parseDesignTokens rejects legacy token properties', () => {
-  const tokens = {
-    color: { blue: { value: '#00f', type: 'color' } },
-  } as unknown as DesignTokens;
-  assert.throws(() => parseDesignTokens(tokens), /legacy property/i);
-});
-
 void test('parseDesignTokens rejects tokens with mismatched $type and value', () => {
   const tokens = {
     color: { $type: 'color', bad: { $value: 123 as unknown as string } },


### PR DESCRIPTION
## Summary
- drop obsolete legacy token property validation
- tidy token parser tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c276bec0e883288eedead4e5945056