### PR TITLE
fix(core): merge tokens from all themes when theme omitted

### DIFF
--- a/.changeset/merge-all-theme-tokens.md
+++ b/.changeset/merge-all-theme-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+merge tokens from all themes when no theme is specified

--- a/src/adapters/node/token-parser.ts
+++ b/src/adapters/node/token-parser.ts
@@ -62,7 +62,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function hasBody(value: unknown): value is { body: unknown } {
+function hasBody(value: unknown): value is DocumentNode {
   return isObject(value) && 'body' in value;
 }
 
@@ -75,15 +75,17 @@ function parseTokensContent(
 } {
   const ext = path.extname(filePath).toLowerCase();
   try {
-    const doc: DocumentNode =
+    const rawDoc: unknown =
       ext === '.yaml' || ext === '.yml'
         ? yamlToMomoa(content)
         : parseJson(content, { mode: 'json', ranges: true });
-    if (!hasBody(doc)) {
+    if (!hasBody(rawDoc)) {
       throw new Error(
         `Error parsing ${filePath}: root value must be an object`,
       );
     }
+
+    const doc = rawDoc;
 
     const locations = new Map<string, { line: number; column: number }>();
 

--- a/src/core/token-utils.ts
+++ b/src/core/token-utils.ts
@@ -43,12 +43,24 @@ export function flattenDesignTokens(tokens: DesignTokens): FlattenedToken[] {
 
 export function getFlattenedTokens(
   tokensByTheme: Record<string, DesignTokens>,
-  theme = 'default',
+  theme?: string,
 ): FlattenedToken[] {
-  if (Object.prototype.hasOwnProperty.call(tokensByTheme, theme)) {
-    return parseDesignTokens(tokensByTheme[theme]);
+  if (theme) {
+    if (Object.prototype.hasOwnProperty.call(tokensByTheme, theme)) {
+      return parseDesignTokens(tokensByTheme[theme]);
+    }
+    return [];
   }
-  return [];
+  // dedupe tokens by their path across themes
+  const seen = new Map<string, FlattenedToken>();
+  for (const tokens of Object.values(tokensByTheme)) {
+    for (const flat of parseDesignTokens(tokens)) {
+      if (!seen.has(flat.path)) {
+        seen.set(flat.path, flat);
+      }
+    }
+  }
+  return [...seen.values()];
 }
 
 export function extractVarName(value: string): string | null {

--- a/tests/core/get-flattened-tokens.test.ts
+++ b/tests/core/get-flattened-tokens.test.ts
@@ -44,15 +44,21 @@ void test('getFlattenedTokens flattens tokens for specified theme and preserves 
   ]);
 });
 
-void test('getFlattenedTokens defaults to the "default" theme', () => {
-  const tokens: DesignTokens = {
-    palette: { $type: 'color', primary: { $value: '#fff' } },
+void test('getFlattenedTokens merges tokens from all themes when none is specified', () => {
+  const tokens: Record<string, DesignTokens> = {
+    light: { palette: { $type: 'color', primary: { $value: '#fff' } } },
+    dark: { palette: { $type: 'color', secondary: { $value: '#000' } } },
   };
-  const flat = getFlattenedTokens({ default: tokens });
+  const flat = getFlattenedTokens(tokens);
   assert.deepEqual(flat, [
     {
       path: 'palette.primary',
       token: { $value: '#fff', $type: 'color' },
+      loc: { line: 1, column: 1 },
+    },
+    {
+      path: 'palette.secondary',
+      token: { $value: '#000', $type: 'color' },
       loc: { line: 1, column: 1 },
     },
   ]);


### PR DESCRIPTION
## Summary
- merge tokens across themes when `getFlattenedTokens` is called without a theme
- add regression test verifying token merging
- drop manual type shims and rely on upstream types

## Testing
- `npm run lint`
- `npm run build`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2799089308328915318483ceef90a