### PR TITLE
docs: remove unsupported dry-run reference

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,7 +76,7 @@ Many rules support auto-fix. Use the `--fix` flag to update files in place:
 npx design-lint "src/**/*" --fix
 ```
 
-Run `--fix` locally before committing to keep diffs small and intentional. In CI environments, avoid `--fix`; instead run design-lint in read-only mode and fail the build if fixes are required. To preview changes without writing to disk, combine `--fix` with `--dry-run`.
+Run `--fix` locally before committing to keep diffs small and intentional. In CI environments, avoid `--fix`; instead run design-lint in read-only mode and fail the build if fixes are required. There is currently no dry-run mode for previewing changes.
 
 ## Export resolved tokens
 Use the `tokens` subcommand to write flattened tokens to a file or stdout. Alias references are resolved and metadata like `$extensions` is preserved:


### PR DESCRIPTION
## Summary
- clarify that design-lint does not support `--dry-run`

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c27f8fb95c83289e9227a4105a75ac