### PR TITLE
refactor: centralize type guards

### DIFF
--- a/.changeset/shared-type-guards.md
+++ b/.changeset/shared-type-guards.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor: centralize type guards
+

--- a/src/adapters/node/token-provider.ts
+++ b/src/adapters/node/token-provider.ts
@@ -1,6 +1,7 @@
 import type { VariableProvider } from '../../core/environment.js';
 import type { DesignTokens } from '../../core/types.js';
 import type { Config } from '../../core/linter.js';
+import { isDesignTokens, isThemeRecord } from '../../utils/type-guards.js';
 
 export class NodeTokenProvider implements VariableProvider {
   private tokens: Record<string, DesignTokens>;
@@ -26,43 +27,4 @@ export class NodeTokenProvider implements VariableProvider {
   subscribe(): () => void {
     return () => undefined;
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function isDesignTokens(value: unknown): value is DesignTokens {
-  return isRecord(value);
-}
-
-function isThemeRecord(val: unknown): val is Record<string, DesignTokens> {
-  if (!isRecord(val)) return false;
-  const entries = Object.entries(val).filter(([k]) => !k.startsWith('$'));
-  if (entries.length === 0) return false;
-  if (entries.length === 1) {
-    const [, theme] = entries[0];
-    if (!isRecord(theme)) return false;
-    const children = Object.entries(theme)
-      .filter(([k]) => !k.startsWith('$'))
-      .map(([, v]) => v);
-    const allTokens = children.every(
-      (child) => isRecord(child) && ('$value' in child || 'value' in child),
-    );
-    return !allTokens;
-  }
-
-  let shared: string[] | null = null;
-  for (const [, theme] of entries) {
-    if (!isRecord(theme)) return false;
-    const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
-    if (shared === null) {
-      shared = keys;
-    } else {
-      shared = shared.filter((k) => keys.includes(k));
-      if (shared.length === 0) return false;
-    }
-  }
-
-  return true;
 }

--- a/src/config/config-token-provider.ts
+++ b/src/config/config-token-provider.ts
@@ -1,6 +1,6 @@
 import type { Config } from '../core/linter.js';
-import type { DesignTokens } from '../core/types.js';
 import { parseDesignTokens } from '../core/parser/index.js';
+import { isDesignTokens, isThemeRecord } from '../utils/type-guards.js';
 
 export class ConfigTokenProvider {
   private config: Config;
@@ -26,41 +26,4 @@ export class ConfigTokenProvider {
     }
     return Promise.resolve({});
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function isDesignTokens(value: unknown): value is DesignTokens {
-  return isRecord(value);
-}
-
-function isThemeRecord(val: unknown): val is Record<string, DesignTokens> {
-  if (!isRecord(val)) return false;
-  const entries = Object.entries(val).filter(([k]) => !k.startsWith('$'));
-  if (entries.length === 0) return false;
-  if (entries.length === 1) {
-    const [, theme] = entries[0];
-    if (!isRecord(theme)) return false;
-    const children = Object.entries(theme)
-      .filter(([k]) => !k.startsWith('$'))
-      .map(([, v]) => v);
-    const allTokens = children.every(
-      (child) => isRecord(child) && ('$value' in child || 'value' in child),
-    );
-    return !allTokens;
-  }
-  let shared: string[] | null = null;
-  for (const [, theme] of entries) {
-    if (!isRecord(theme)) return false;
-    const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
-    if (shared === null) {
-      shared = keys;
-    } else {
-      shared = shared.filter((k) => keys.includes(k));
-      if (shared.length === 0) return false;
-    }
-  }
-  return true;
 }

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -4,6 +4,7 @@ import type { LintResult } from '../core/types.js';
 import { stylish } from './stylish.js';
 import { jsonFormatter } from './json.js';
 import { sarifFormatter } from './sarif.js';
+import { isRecord } from '../utils/type-guards.js';
 
 type Formatter = (results: LintResult[], useColor?: boolean) => string;
 
@@ -61,8 +62,4 @@ function resolveFormatter(mod: unknown): Formatter | undefined {
 
 function isFormatter(value: unknown): value is Formatter {
   return typeof value === 'function';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 import type { RuleModule } from '../core/types.js';
+import { isRecord } from '../utils/type-guards.js';
 
 interface BlurRuleOptions {
   units?: string[];
@@ -62,7 +63,3 @@ export const blurRule: RuleModule<BlurRuleOptions> = {
     };
   },
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -2,6 +2,7 @@ import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import type { RuleModule } from '../core/types.js';
 import { isStyleValue } from '../utils/style.js';
+import { isRecord } from '../utils/type-guards.js';
 
 interface BorderWidthOptions {
   units?: string[];
@@ -127,7 +128,3 @@ export const borderWidthRule: RuleModule<BorderWidthOptions> = {
 };
 
 export default borderWidthRule;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/src/rules/token-box-shadow.ts
+++ b/src/rules/token-box-shadow.ts
@@ -1,5 +1,6 @@
 import valueParser from 'postcss-value-parser';
 import type { RuleModule } from '../core/types.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export const boxShadowRule: RuleModule = {
   name: 'design-token/box-shadow',
@@ -89,7 +90,3 @@ export const boxShadowRule: RuleModule = {
     };
   },
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/src/rules/token-font-size.ts
+++ b/src/rules/token-font-size.ts
@@ -1,4 +1,5 @@
 import type { RuleModule } from '../core/types.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export const fontSizeRule: RuleModule = {
   name: 'design-token/font-size',
@@ -56,7 +57,3 @@ export const fontSizeRule: RuleModule = {
     };
   },
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/src/rules/token-letter-spacing.ts
+++ b/src/rules/token-letter-spacing.ts
@@ -1,6 +1,7 @@
 import ts from 'typescript';
 import type { RuleModule } from '../core/types.js';
 import { isStyleValue } from '../utils/style.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export const letterSpacingRule: RuleModule = {
   name: 'design-token/letter-spacing',
@@ -97,7 +98,3 @@ export const letterSpacingRule: RuleModule = {
     };
   },
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -1,0 +1,40 @@
+import type { DesignTokens } from '../core/types.js';
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isDesignTokens(value: unknown): value is DesignTokens {
+  return isRecord(value);
+}
+
+export function isThemeRecord(
+  val: unknown,
+): val is Record<string, DesignTokens> {
+  if (!isRecord(val)) return false;
+  const entries = Object.entries(val).filter(([k]) => !k.startsWith('$'));
+  if (entries.length === 0) return false;
+  if (entries.length === 1) {
+    const [, theme] = entries[0];
+    if (!isRecord(theme)) return false;
+    const children = Object.entries(theme)
+      .filter(([k]) => !k.startsWith('$'))
+      .map(([, v]) => v);
+    const allTokens = children.every(
+      (child) => isRecord(child) && ('$value' in child || 'value' in child),
+    );
+    return !allTokens;
+  }
+  let shared: string[] | null = null;
+  for (const [, theme] of entries) {
+    if (!isRecord(theme)) return false;
+    const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
+    if (shared === null) {
+      shared = keys;
+    } else {
+      shared = shared.filter((k) => keys.includes(k));
+      if (shared.length === 0) return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add shared `isRecord`, `isDesignTokens`, and `isThemeRecord` helpers
- refactor config, token providers, CLI, and rules to reuse shared type guards
- document the change with a changeset

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c283f54c4483289768afc8797de5d1