### PR TITLE
refactor(cli): reuse shared path utilities

### DIFF
--- a/.changeset/cli-use-shared-path-utils.md
+++ b/.changeset/cli-use-shared-path-utils.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor: reuse shared path utilities in CLI environment
+

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -6,16 +6,7 @@ import type { CacheProvider } from '../core/cache-provider.js';
 import type { Config, Linter } from '../core/linter.js';
 import type { LintResult } from '../core/types.js';
 import { createNodeEnvironment } from '../adapters/node/environment.js';
-
-const relFromCwd = (p: string) =>
-  path.relative(process.cwd(), p).split(path.sep).join('/');
-const realpathIfExists = (p: string) => {
-  try {
-    return fs.realpathSync.native(p);
-  } catch {
-    return p;
-  }
-};
+import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths.js';
 
 export interface Environment {
   formatter: (results: LintResult[], useColor?: boolean) => string;


### PR DESCRIPTION
## Summary
- refactor CLI environment to import `relFromCwd` and `realpathIfExists` from shared path utilities
- add changeset for refactor

## Testing
- `npm run lint` *(fails: Unsafe assignment / missing type declarations)*
- `npm run format:check`
- `npm run lint:md`
- `npm run build` *(fails: Cannot find modules / implicit any types)*
- `npm test` *(fails: 41 failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c28634680483289330114defda3b14