### PR TITLE
refactor(rules): centralize token retrieval logic

### DIFF
--- a/.changeset/token-rule-util.md
+++ b/.changeset/token-rule-util.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor token rules to share common retrieval logic

--- a/src/rules/token-border-color.ts
+++ b/src/rules/token-border-color.ts
@@ -1,7 +1,7 @@
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
 import colorName from 'color-name';
-import type { RuleModule } from '../core/types.js';
+import { tokenRule } from './utils/token-rule.js';
 
 type ColorFormat =
   | 'hex'
@@ -32,25 +32,18 @@ function detectFormat(value: string): ColorFormat | null {
   return null;
 }
 
-export const borderColorRule: RuleModule = {
+export const borderColorRule = tokenRule({
   name: 'design-token/border-color',
   meta: {
     description: 'enforce border-color tokens',
     category: 'design-token',
   },
-  create(context) {
-    const borderColorTokens = context.getFlattenedTokens('color');
-    if (borderColorTokens.length === 0) {
-      context.report({
-        message:
-          'design-token/border-color requires color tokens; configure tokens with $type "color" to enable this rule.',
-        line: 1,
-        column: 1,
-      });
-      return {};
-    }
-    const allowed = new Set(
-      borderColorTokens
+  tokens: 'color',
+  message:
+    'design-token/border-color requires color tokens; configure tokens with $type "color" to enable this rule.',
+  getAllowed(tokens) {
+    return new Set(
+      tokens
         .map(({ token }) => {
           const v = token.$value;
           return typeof v === 'string' && !v.startsWith('{')
@@ -59,6 +52,8 @@ export const borderColorRule: RuleModule = {
         })
         .filter((v): v is string => v !== null),
     );
+  },
+  create(context, allowed) {
     return {
       onCSSDeclaration(decl) {
         if (/^border(-(top|right|bottom|left))?-color$/.test(decl.prop)) {
@@ -80,4 +75,4 @@ export const borderColorRule: RuleModule = {
       },
     };
   },
-};
+});

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -1,22 +1,24 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
-import type { RuleModule } from '../core/types.js';
+import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
 
 interface BorderRadiusOptions {
   units?: string[];
 }
 
-export const borderRadiusRule: RuleModule<BorderRadiusOptions> = {
+export const borderRadiusRule = tokenRule<BorderRadiusOptions>({
   name: 'design-token/border-radius',
   meta: {
     description: 'enforce border-radius tokens',
     category: 'design-token',
   },
-  create(context) {
-    const radiusTokens = context.getFlattenedTokens('dimension');
+  tokens: 'dimension',
+  message:
+    'design-token/border-radius requires radius tokens; configure tokens with $type "dimension" under a "radius" group to enable this rule.',
+  getAllowed(tokens) {
     const allowed = new Set<number>();
-    for (const { path, token } of radiusTokens) {
+    for (const { path, token } of tokens) {
       if (!path.startsWith('radius.')) continue;
       const val = token.$value;
       if (val && typeof val === 'object') {
@@ -26,15 +28,9 @@ export const borderRadiusRule: RuleModule<BorderRadiusOptions> = {
         }
       }
     }
-    if (allowed.size === 0) {
-      context.report({
-        message:
-          'design-token/border-radius requires radius tokens; configure tokens with $type "dimension" under a "radius" group to enable this rule.',
-        line: 1,
-        column: 1,
-      });
-      return {};
-    }
+    return allowed;
+  },
+  create(context, allowed) {
     const allowedUnits = new Set(
       (context.options?.units ?? ['px', 'rem', 'em']).map((u) =>
         u.toLowerCase(),
@@ -81,4 +77,4 @@ export const borderRadiusRule: RuleModule<BorderRadiusOptions> = {
       },
     };
   },
-};
+});

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
 import colorName from 'color-name';
-import type { RuleModule } from '../core/types.js';
+import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
 
 type ColorFormat =
@@ -38,22 +38,15 @@ interface ColorRuleOptions {
   allow?: ColorFormat[];
 }
 
-export const colorsRule: RuleModule<ColorRuleOptions> = {
+export const colorsRule = tokenRule<ColorRuleOptions>({
   name: 'design-token/colors',
   meta: { description: 'disallow raw colors', category: 'design-token' },
-  create(context) {
-    const colorTokens = context.getFlattenedTokens('color');
-    if (colorTokens.length === 0) {
-      context.report({
-        message:
-          'design-token/colors requires color tokens; configure tokens with $type "color" to enable this rule.',
-        line: 1,
-        column: 1,
-      });
-      return {};
-    }
-    const allowed = new Set(
-      colorTokens
+  tokens: 'color',
+  message:
+    'design-token/colors requires color tokens; configure tokens with $type "color" to enable this rule.',
+  getAllowed(tokens) {
+    return new Set(
+      tokens
         .map(({ token }) => {
           const v = token.$value;
           return typeof v === 'string' && !v.startsWith('{')
@@ -62,6 +55,8 @@ export const colorsRule: RuleModule<ColorRuleOptions> = {
         })
         .filter((v): v is string => v !== null),
     );
+  },
+  create(context, allowed) {
     const opts = context.options ?? {};
     const allowFormats = new Set(opts.allow ?? []);
     const parserFormats = new Set<ColorFormat>([
@@ -117,4 +112,4 @@ export const colorsRule: RuleModule<ColorRuleOptions> = {
       },
     };
   },
-};
+});

--- a/src/rules/token-font-family.ts
+++ b/src/rules/token-font-family.ts
@@ -1,25 +1,21 @@
-import type { RuleModule } from '../core/types.js';
+import { tokenRule } from './utils/token-rule.js';
 
-export const fontFamilyRule: RuleModule = {
+export const fontFamilyRule = tokenRule({
   name: 'design-token/font-family',
   meta: { description: 'enforce font-family tokens', category: 'design-token' },
-  create(context) {
-    const fontFamilies = context.getFlattenedTokens('fontFamily');
+  tokens: 'fontFamily',
+  message:
+    'design-token/font-family requires font tokens; configure tokens with $type "fontFamily" under a "fonts" group to enable this rule.',
+  getAllowed(tokens) {
     const fonts = new Set<string>();
-    for (const { path, token } of fontFamilies) {
+    for (const { path, token } of tokens) {
       if (!path.startsWith('fonts.')) continue;
       const val = token.$value;
       if (typeof val === 'string') fonts.add(val);
     }
-    if (fonts.size === 0) {
-      context.report({
-        message:
-          'design-token/font-family requires font tokens; configure tokens with $type "fontFamily" under a "fonts" group to enable this rule.',
-        line: 1,
-        column: 1,
-      });
-      return {};
-    }
+    return fonts;
+  },
+  create(context, fonts) {
     return {
       onCSSDeclaration(decl) {
         if (decl.prop === 'font-family') {
@@ -40,4 +36,4 @@ export const fontFamilyRule: RuleModule = {
       },
     };
   },
-};
+});

--- a/src/rules/token-font-size.ts
+++ b/src/rules/token-font-size.ts
@@ -1,46 +1,43 @@
-import type { RuleModule } from '../core/types.js';
+import { tokenRule } from './utils/token-rule.js';
 import { isRecord } from '../utils/type-guards.js';
 
-export const fontSizeRule: RuleModule = {
+const parseSize = (val: unknown): number | null => {
+  if (
+    isRecord(val) &&
+    typeof val.value === 'number' &&
+    typeof val.unit === 'string'
+  ) {
+    const factor = val.unit === 'px' ? 1 : 16;
+    return val.value * factor;
+  }
+  if (typeof val === 'string') {
+    const match = /^(\d*\.?\d+)(px|rem|em)$/.exec(val.trim());
+    if (match) {
+      const [, num, unit] = match;
+      const n = parseFloat(num);
+      const factor = unit === 'px' ? 1 : 16;
+      return n * factor;
+    }
+  }
+  return null;
+};
+
+export const fontSizeRule = tokenRule({
   name: 'design-token/font-size',
   meta: { description: 'enforce font-size tokens', category: 'design-token' },
-  create(context) {
-    const fontSizes = context.getFlattenedTokens('dimension');
-    const parseSize = (val: unknown): number | null => {
-      if (
-        isRecord(val) &&
-        typeof val.value === 'number' &&
-        typeof val.unit === 'string'
-      ) {
-        const factor = val.unit === 'px' ? 1 : 16;
-        return val.value * factor;
-      }
-      if (typeof val === 'string') {
-        const match = /^(\d*\.?\d+)(px|rem|em)$/.exec(val.trim());
-        if (match) {
-          const [, num, unit] = match;
-          const n = parseFloat(num);
-          const factor = unit === 'px' ? 1 : 16;
-          return n * factor;
-        }
-      }
-      return null;
-    };
+  tokens: 'dimension',
+  message:
+    'design-token/font-size requires font size tokens; configure tokens with $type "dimension" under a "fontSizes" group to enable this rule.',
+  getAllowed(tokens) {
     const sizes = new Set<number>();
-    for (const { path, token } of fontSizes) {
+    for (const { path, token } of tokens) {
       if (!path.startsWith('fontSizes.')) continue;
       const num = parseSize(token.$value);
       if (num !== null) sizes.add(num);
     }
-    if (sizes.size === 0) {
-      context.report({
-        message:
-          'design-token/font-size requires font size tokens; configure tokens with $type "dimension" under a "fontSizes" group to enable this rule.',
-        line: 1,
-        column: 1,
-      });
-      return {};
-    }
+    return sizes;
+  },
+  create(context, sizes) {
     return {
       onCSSDeclaration(decl) {
         if (decl.prop === 'font-size') {
@@ -56,4 +53,4 @@ export const fontSizeRule: RuleModule = {
       },
     };
   },
-};
+});

--- a/src/rules/token-outline.ts
+++ b/src/rules/token-outline.ts
@@ -1,28 +1,25 @@
 import valueParser from 'postcss-value-parser';
-import type { RuleModule } from '../core/types.js';
+import { tokenRule } from './utils/token-rule.js';
 
-export const outlineRule: RuleModule = {
+const normalize = (val: string): string =>
+  valueParser.stringify(valueParser(val).nodes).trim();
+
+export const outlineRule = tokenRule({
   name: 'design-token/outline',
   meta: { description: 'enforce outline tokens', category: 'design-token' },
-  create(context) {
-    const outlineTokens = context.getFlattenedTokens('string');
-    const normalize = (val: string): string =>
-      valueParser.stringify(valueParser(val).nodes).trim();
+  tokens: 'string',
+  message:
+    'design-token/outline requires outline tokens; configure tokens with $type "string" under an "outlines" group to enable this rule.',
+  getAllowed(tokens) {
     const allowed = new Set<string>();
-    for (const { path, token } of outlineTokens) {
+    for (const { path, token } of tokens) {
       if (!path.startsWith('outlines.')) continue;
       const val = token.$value;
       if (typeof val === 'string') allowed.add(normalize(val));
     }
-    if (allowed.size === 0) {
-      context.report({
-        message:
-          'design-token/outline requires outline tokens; configure tokens with $type "string" under an "outlines" group to enable this rule.',
-        line: 1,
-        column: 1,
-      });
-      return {};
-    }
+    return allowed;
+  },
+  create(context, allowed) {
     return {
       onCSSDeclaration(decl) {
         if (decl.prop === 'outline') {
@@ -38,4 +35,4 @@ export const outlineRule: RuleModule = {
       },
     };
   },
-};
+});

--- a/src/rules/token-z-index.ts
+++ b/src/rules/token-z-index.ts
@@ -1,26 +1,23 @@
 import ts from 'typescript';
-import type { RuleModule } from '../core/types.js';
+import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
-export const zIndexRule: RuleModule = {
+
+export const zIndexRule = tokenRule({
   name: 'design-token/z-index',
   meta: { description: 'enforce z-index tokens', category: 'design-token' },
-  create(context) {
-    const zTokens = context.getFlattenedTokens('number');
+  tokens: 'number',
+  message:
+    'design-token/z-index requires z-index tokens; configure tokens with $type "number" under a "zIndex" group to enable this rule.',
+  getAllowed(tokens) {
     const allowed = new Set<number>();
-    for (const { path, token } of zTokens) {
+    for (const { path, token } of tokens) {
       if (!path.startsWith('zIndex.')) continue;
       const val = token.$value;
       if (typeof val === 'number') allowed.add(val);
     }
-    if (allowed.size === 0) {
-      context.report({
-        message:
-          'design-token/z-index requires z-index tokens; configure tokens with $type "number" under a "zIndex" group to enable this rule.',
-        line: 1,
-        column: 1,
-      });
-      return {};
-    }
+    return allowed;
+  },
+  create(context, allowed) {
     return {
       onNode(node) {
         if (!isStyleValue(node)) return;
@@ -52,4 +49,4 @@ export const zIndexRule: RuleModule = {
       },
     };
   },
-};
+});

--- a/src/rules/utils/token-rule.ts
+++ b/src/rules/utils/token-rule.ts
@@ -1,0 +1,60 @@
+import type {
+  FlattenedToken,
+  RuleContext,
+  RuleListener,
+  RuleModule,
+} from '../../core/types.js';
+
+interface TokenRuleConfig<TOptions, TAllowed> {
+  name: string;
+  meta: {
+    description: string;
+    category?: string;
+  };
+  tokens: string | string[];
+  message: string;
+  getAllowed: (
+    tokens: FlattenedToken[],
+    context: RuleContext<TOptions>,
+  ) => TAllowed;
+  create: (context: RuleContext<TOptions>, allowed: TAllowed) => RuleListener;
+  isEmpty?: (allowed: TAllowed) => boolean;
+}
+
+function hasSize(value: unknown): value is { size: number } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof Reflect.get(value, 'size') === 'number'
+  );
+}
+
+export function tokenRule<TOptions = unknown, TAllowed = Set<unknown>>(
+  config: TokenRuleConfig<TOptions, TAllowed>,
+): RuleModule<TOptions> {
+  return {
+    name: config.name,
+    meta: config.meta,
+    create(context) {
+      const types = Array.isArray(config.tokens)
+        ? config.tokens
+        : [config.tokens];
+      const tokens = types.flatMap((t) => context.getFlattenedTokens(t));
+      const allowed = config.getAllowed(tokens, context);
+      const empty = config.isEmpty
+        ? config.isEmpty(allowed)
+        : hasSize(allowed) && allowed.size === 0;
+      if (empty) {
+        context.report({
+          message: config.message,
+          line: 1,
+          column: 1,
+        });
+        return {};
+      }
+      return config.create(context, allowed);
+    },
+  };
+}
+
+export type { TokenRuleConfig };

--- a/tests/rules/token-rule.test.ts
+++ b/tests/rules/token-rule.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { tokenRule } from '../../src/rules/utils/token-rule.ts';
+import type { RuleContext } from '../../src/core/types.ts';
+
+void test('tokenRule reports when tokens are missing', () => {
+  const rule = tokenRule({
+    name: 'design-token/example',
+    meta: { description: 'example', category: 'design-token' },
+    tokens: 'number',
+    message: 'no tokens',
+    getAllowed: () => new Set<number>(),
+    create: () => ({}),
+  });
+  const reports: unknown[] = [];
+  const ctx: RuleContext = {
+    report: (m) => reports.push(m),
+    getFlattenedTokens: () => [],
+    sourceId: 'x',
+  };
+  const listener = rule.create(ctx);
+  assert.equal(reports.length, 1);
+  assert.deepEqual(listener, {});
+});
+
+void test('tokenRule passes allowed values to create', () => {
+  let received: Set<number> | undefined;
+  const rule = tokenRule({
+    name: 'design-token/example',
+    meta: { description: 'example', category: 'design-token' },
+    tokens: 'number',
+    message: 'no tokens',
+    getAllowed(tokens) {
+      const s = new Set<number>();
+      for (const { token } of tokens) {
+        if (typeof token.$value === 'number') s.add(token.$value);
+      }
+      return s;
+    },
+    create(_ctx, allowed) {
+      received = allowed;
+      return {};
+    },
+  });
+  const reports: unknown[] = [];
+  const ctx: RuleContext = {
+    report: (m) => reports.push(m),
+    getFlattenedTokens: () => [{ path: 'a', token: { $value: 2 } }],
+    sourceId: 'x',
+  };
+  rule.create(ctx);
+  assert.ok(received?.has(2));
+});


### PR DESCRIPTION
## Summary
- add tokenRule helper for shared token lookup and missing-token reporting
- refactor token rules to use new helper
- cover tokenRule with unit tests

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c28645036c8328a14b26c3603a14bf