### PR TITLE
refactor(config): split config loading into helpers

### DIFF
--- a/.changeset/refactor-config-helpers.md
+++ b/.changeset/refactor-config-helpers.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor config loading into separate helpers

--- a/src/config/file-resolution.ts
+++ b/src/config/file-resolution.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { cosmiconfig } from 'cosmiconfig';
+import { TypeScriptLoader } from 'cosmiconfig-typescript-loader';
+
+export async function resolveConfigFile(
+  cwd: string,
+  configPath?: string,
+): Promise<{ config: unknown; filepath: string } | null> {
+  const explorer = cosmiconfig('designlint', {
+    searchPlaces: [
+      'package.json',
+      'designlint.config.ts',
+      'designlint.config.mts',
+      'designlint.config.js',
+      'designlint.config.mjs',
+      'designlint.config.cjs',
+      'designlint.config.json',
+      '.designlintrc',
+      '.designlintrc.json',
+      '.designlintrc.yaml',
+      '.designlintrc.yml',
+      '.designlintrc.js',
+      '.designlintrc.cjs',
+      '.designlintrc.mjs',
+      '.designlintrc.ts',
+      '.designlintrc.mts',
+    ],
+    loaders: {
+      '.ts': TypeScriptLoader(),
+      '.mts': TypeScriptLoader(),
+    },
+    searchStrategy: 'global',
+  });
+
+  if (configPath) {
+    const abs = path.resolve(cwd, configPath);
+    try {
+      await fs.promises.access(abs);
+    } catch {
+      throw new Error(
+        `Config file not found at ${abs}. Run \`npx design-lint init\` to create a config.`,
+      );
+    }
+    return explorer.load(abs);
+  }
+
+  return explorer.search(cwd);
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,20 +1,10 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import { cosmiconfig } from 'cosmiconfig';
-import { TypeScriptLoader } from 'cosmiconfig-typescript-loader';
 import type { Config } from '../core/linter.js';
 import { configSchema } from './schema.js';
 import { realpathIfExists } from '../adapters/node/utils/paths.js';
-import {
-  readDesignTokensFile,
-  TokenParseError,
-} from '../adapters/node/token-parser.js';
-import { parseDesignTokens } from '../core/parser/index.js';
-import {
-  isRecord,
-  isDesignTokens,
-  isThemeRecord,
-} from '../utils/type-guards.js';
+import { resolveConfigFile } from './file-resolution.js';
+import { loadTokens } from './token-loader.js';
+import { isRecord } from '../utils/type-guards.js';
 
 /**
  * Resolve and load configuration for the linter.
@@ -26,46 +16,7 @@ export async function loadConfig(
   cwd: string,
   configPath?: string,
 ): Promise<Config> {
-  const explorer = cosmiconfig('designlint', {
-    searchPlaces: [
-      'package.json',
-      'designlint.config.ts',
-      'designlint.config.mts',
-      'designlint.config.js',
-      'designlint.config.mjs',
-      'designlint.config.cjs',
-      'designlint.config.json',
-      '.designlintrc',
-      '.designlintrc.json',
-      '.designlintrc.yaml',
-      '.designlintrc.yml',
-      '.designlintrc.js',
-      '.designlintrc.cjs',
-      '.designlintrc.mjs',
-      '.designlintrc.ts',
-      '.designlintrc.mts',
-    ],
-    loaders: {
-      '.ts': TypeScriptLoader(),
-      '.mts': TypeScriptLoader(),
-    },
-    searchStrategy: 'global',
-  });
-
-  let result: { config: unknown; filepath: string } | null;
-  if (configPath) {
-    const abs = path.resolve(cwd, configPath);
-    try {
-      await fs.promises.access(abs);
-    } catch {
-      throw new Error(
-        `Config file not found at ${abs}. Run \`npx design-lint init\` to create a config.`,
-      );
-    }
-    result = await explorer.load(abs);
-  } else {
-    result = await explorer.search(cwd);
-  }
+  const result = await resolveConfigFile(cwd, configPath);
 
   const base: Config = {
     tokens: {},
@@ -88,45 +39,7 @@ export async function loadConfig(
   const config = parsed.data;
   if (config.tokens && typeof config.tokens === 'object') {
     const baseDir = config.configPath ? path.dirname(config.configPath) : cwd;
-    const themes: Record<string, unknown> = {};
-    for (const [theme, val] of Object.entries(config.tokens)) {
-      if (typeof val === 'string') {
-        const filePath = path.resolve(baseDir, val);
-        try {
-          themes[theme] = await readDesignTokensFile(filePath);
-        } catch (err) {
-          if (err instanceof TokenParseError) throw err;
-          const message = err instanceof Error ? err.message : String(err);
-          throw new Error(
-            `Failed to read tokens for theme "${theme}": ${message}`,
-          );
-        }
-      } else {
-        themes[theme] = val;
-      }
-    }
-    if (isThemeRecord(themes)) {
-      for (const [theme, t] of Object.entries(themes)) {
-        try {
-          parseDesignTokens(t);
-        } catch (err) {
-          if (err instanceof TokenParseError) throw err;
-          const message = err instanceof Error ? err.message : String(err);
-          throw new Error(
-            `Failed to parse tokens for theme "${theme}": ${message}`,
-          );
-        }
-      }
-      config.tokens = themes;
-    } else if (isDesignTokens(themes)) {
-      try {
-        parseDesignTokens(themes);
-      } catch (err) {
-        if (err instanceof TokenParseError) throw err;
-        throw err instanceof Error ? err : new Error(String(err));
-      }
-      config.tokens = themes;
-    }
+    config.tokens = await loadTokens(config.tokens, baseDir);
   }
   return config;
 }

--- a/src/config/token-loader.ts
+++ b/src/config/token-loader.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+import {
+  readDesignTokensFile,
+  TokenParseError,
+} from '../adapters/node/token-parser.js';
+import { parseDesignTokens } from '../core/parser/index.js';
+import {
+  isDesignTokens,
+  isThemeRecord,
+  isRecord,
+} from '../utils/type-guards.js';
+
+export async function loadTokens(
+  tokens: unknown,
+  baseDir: string,
+): Promise<Record<string, unknown>> {
+  if (!isRecord(tokens)) return {};
+  const themes: Record<string, unknown> = {};
+  for (const [theme, val] of Object.entries(tokens)) {
+    if (typeof val === 'string') {
+      const filePath = path.resolve(baseDir, val);
+      try {
+        themes[theme] = await readDesignTokensFile(filePath);
+      } catch (err) {
+        if (err instanceof TokenParseError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Failed to read tokens for theme "${theme}": ${message}`,
+        );
+      }
+    } else {
+      themes[theme] = val;
+    }
+  }
+
+  if (isThemeRecord(themes)) {
+    for (const [theme, t] of Object.entries(themes)) {
+      try {
+        parseDesignTokens(t);
+      } catch (err) {
+        if (err instanceof TokenParseError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Failed to parse tokens for theme "${theme}": ${message}`,
+        );
+      }
+    }
+    return themes;
+  }
+
+  if (isDesignTokens(themes)) {
+    try {
+      parseDesignTokens(themes);
+    } catch (err) {
+      if (err instanceof TokenParseError) throw err;
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+    return themes;
+  }
+
+  return tokens;
+}


### PR DESCRIPTION
## Summary
- extract config file resolution into dedicated helper
- move token parsing and validation into token-loader
- update config loading and tests to use new helpers

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2875e071c83288b9dc93d0f9612d6