### PR TITLE
refactor(core): extract FILE_TYPE_MAP constant

### DIFF
--- a/.changeset/file-type-map-export.md
+++ b/.changeset/file-type-map-export.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor file type mapping into exportable constant

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,9 @@ Supplies raw text to the linter. The Node adapter [`FileSource`](https://github.
 ### Parser adapters
 Convert documents into ASTs. CSS uses PostCSS, JavaScript and TypeScript rely on the TypeScript compiler, and Vue/Svelte files compile before analysis. See [`src/core/framework-parsers`](https://github.com/bylapidist/design-lint/tree/main/src/core/framework-parsers).
 
+### File type mapping
+File extensions are normalised via [`FILE_TYPE_MAP`](https://github.com/bylapidist/design-lint/blob/main/src/core/linter.ts). This mapping tells the linter which parser to apply. To support a new extension, add it to `FILE_TYPE_MAP` and implement or reference the appropriate parser.
+
 ### Rule engine
 Registers rules and coordinates execution. See [`src/core/linter.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/linter.ts) and [`src/core/rule-registry.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/rule-registry.ts).
 

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -17,6 +17,23 @@ import type {
 } from './environment.js';
 import { parserRegistry } from './parser-registry.js';
 
+export const FILE_TYPE_MAP: Record<string, string> = {
+  ts: 'ts',
+  tsx: 'ts',
+  mts: 'ts',
+  cts: 'ts',
+  js: 'ts',
+  jsx: 'ts',
+  mjs: 'ts',
+  cjs: 'ts',
+  css: 'css',
+  scss: 'css',
+  sass: 'css',
+  less: 'css',
+  vue: 'vue',
+  svelte: 'svelte',
+};
+
 function isDesignTokens(val: unknown): val is DesignTokens {
   return typeof val === 'object' && val !== null;
 }
@@ -254,23 +271,7 @@ function getDisabledLines(text: string): Set<number> {
   return disabled;
 }
 
-function inferFileType(sourceId: string): string {
+export function inferFileType(sourceId: string): string {
   const ext = sourceId.split('.').pop()?.toLowerCase() ?? '';
-  const map: Record<string, string> = {
-    ts: 'ts',
-    tsx: 'ts',
-    mts: 'ts',
-    cts: 'ts',
-    js: 'ts',
-    jsx: 'ts',
-    mjs: 'ts',
-    cjs: 'ts',
-    css: 'css',
-    scss: 'css',
-    sass: 'css',
-    less: 'css',
-    vue: 'vue',
-    svelte: 'svelte',
-  };
-  return map[ext] ?? ext;
+  return FILE_TYPE_MAP[ext] ?? ext;
 }


### PR DESCRIPTION
## Summary
- extract FILE_TYPE_MAP for extension inference and export inferFileType
- document file type mapping for contributors

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md docs/architecture.md`


------
https://chatgpt.com/codex/tasks/task_e_68c28be12ba88328b4b71f0cd455ee1c