### PR TITLE
feat(core): introduce PluginError and ConfigError classes

### DIFF
--- a/.changeset/plugin-config-error-classes.md
+++ b/.changeset/plugin-config-error-classes.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add dedicated PluginError and ConfigError classes and use them for plugin loading and configuration

--- a/src/adapters/node/plugin-loader.ts
+++ b/src/adapters/node/plugin-loader.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from 'url';
 import { realpathIfExists, relFromCwd } from './utils/paths.js';
 import type { PluginModule } from '../../core/types.js';
 import type { PluginLoader, LoadedPlugin } from '../../core/plugin-loader.js';
-import { createEngineError } from '../../core/plugin-manager.js';
+import { PluginError } from '../../core/errors.js';
 
 export class NodePluginLoader implements PluginLoader {
   async load(p: string, configPath?: string): Promise<LoadedPlugin> {
@@ -19,7 +19,7 @@ export class NodePluginLoader implements PluginLoader {
       resolved = realpathIfExists(path.resolve(p));
     }
     if (!fs.existsSync(resolved)) {
-      throw createEngineError({
+      throw new PluginError({
         message: `Plugin not found: "${relFromCwd(resolved)}"`,
         context: `Plugin "${p}"`,
         remediation: 'Ensure the plugin is installed and resolvable.',
@@ -40,7 +40,7 @@ export class NodePluginLoader implements PluginLoader {
           `${pathToFileURL(resolved).href}?t=${String(Date.now())}`
         );
       } else {
-        throw createEngineError({
+        throw new PluginError({
           message: `Failed to load plugin "${p}": ${
             e instanceof Error ? e.message : String(e)
           }`,
@@ -61,7 +61,7 @@ function resolvePlugin(mod: unknown): PluginModule {
       return candidate;
     }
   }
-  throw createEngineError({
+  throw new PluginError({
     message: 'Invalid plugin module',
     context: 'Plugin',
     remediation: 'Ensure the plugin exports a rules array.',

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -5,6 +5,7 @@ import { realpathIfExists } from '../adapters/node/utils/paths.js';
 import { resolveConfigFile } from './file-resolution.js';
 import { loadTokens } from './token-loader.js';
 import { isRecord } from '../utils/type-guards.js';
+import { ConfigError } from '../core/errors.js';
 
 /**
  * Resolve and load configuration for the linter.
@@ -34,7 +35,11 @@ export async function loadConfig(
   const parsed = configSchema.safeParse(merged);
   if (!parsed.success) {
     const location = result?.filepath ? ` at ${result.filepath}` : '';
-    throw new Error(`Invalid config${location}: ${parsed.error.message}`);
+    throw new ConfigError({
+      message: `Invalid config${location}: ${parsed.error.message}`,
+      context: result?.filepath ? `Config file "${result.filepath}"` : 'Config',
+      remediation: 'Review and fix the configuration file.',
+    });
   }
   const config = parsed.data;
   if (config.tokens && typeof config.tokens === 'object') {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,21 @@
+export interface EngineErrorOptions {
+  message: string;
+  context: string;
+  remediation: string;
+}
+
+export class EngineError extends Error {
+  context: string;
+  remediation: string;
+
+  constructor(opts: EngineErrorOptions) {
+    super(
+      `${opts.message}\nContext: ${opts.context}\nRemediation: ${opts.remediation}`,
+    );
+    this.context = opts.context;
+    this.remediation = opts.remediation;
+  }
+}
+
+export class PluginError extends EngineError {}
+export class ConfigError extends EngineError {}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,7 @@
 export { Linter, type Config } from './linter.js';
 export { applyFixes } from './apply-fixes.js';
 export { Runner } from './runner.js';
+export { PluginError, ConfigError } from './errors.js';
 export type {
   Environment,
   TokenProvider,

--- a/src/core/rule-registry.ts
+++ b/src/core/rule-registry.ts
@@ -2,7 +2,8 @@ import type { Config } from './linter.js';
 import type { RuleModule } from './types.js';
 import type { PluginLoader } from './plugin-loader.js';
 import { builtInRules } from '../rules/index.js';
-import { PluginManager, createEngineError } from './plugin-manager.js';
+import { PluginManager } from './plugin-manager.js';
+import { ConfigError } from './errors.js';
 
 export class RuleRegistry {
   private ruleMap = new Map<string, { rule: RuleModule; source: string }>();
@@ -62,7 +63,7 @@ export class RuleRegistry {
       }
     }
     if (unknown.length > 0) {
-      throw createEngineError({
+      throw new ConfigError({
         message: `Unknown rule(s): ${unknown.join(', ')}`,
         context: 'Config.rules',
         remediation: 'Remove or correct these rule names.',


### PR DESCRIPTION
## Summary
- add EngineError base with PluginError and ConfigError
- use new errors in plugin loading and config handling
- assert new error types and fields in tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c28bf83aa08328aa53fdd229ca34e6