### PR TITLE
refactor: centralize isRecord type guard

### DIFF
--- a/.changeset/centralize-is-record.md
+++ b/.changeset/centralize-is-record.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": patch
+---
+
+refactor: centralize isRecord type guard

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import { Command } from 'commander';
 import chalk, { supportsColor } from 'chalk';
 import { TokenParseError } from '../adapters/node/token-parser.js';
+import { isRecord } from '../utils/type-guards.js';
 import { prepareEnvironment, type PrepareEnvironmentOptions } from './env.js';
 import { executeLint, type ExecuteOptions } from './execute.js';
 import { watchMode } from './watch.js';
@@ -15,10 +16,6 @@ type CliOptions = ExecuteOptions &
     color?: boolean;
     watch?: boolean;
   };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 function hasVersion(value: unknown): value is { version: string } {
   return isRecord(value) && typeof value.version === 'string';

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import type { Config } from '../core/linter.js';
 import type { DesignTokens } from '../core/types.js';
+import { isRecord } from '../utils/type-guards.js';
 
 const severitySchema = z.union([
   z.literal('error'),
@@ -16,10 +17,6 @@ const ruleSettingSchema = z.union([
   severitySchema,
   z.tuple([severitySchema, z.unknown()]),
 ]);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function isToken(value: unknown): boolean {
   return isRecord(value) && '$value' in value;

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -2,6 +2,7 @@ import type { Config } from './linter.js';
 import type { RuleModule } from './types.js';
 import type { PluginLoader } from './plugin-loader.js';
 import { PluginError } from './errors.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export class PluginManager {
   private pluginPaths: string[] = [];
@@ -71,8 +72,4 @@ function isRuleModule(value: unknown): value is RuleModule {
     value.meta.description.trim() !== '' &&
     typeof value.create === 'function'
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -1,5 +1,6 @@
 import type { LintResult, DesignTokens, FlattenedToken } from './types.js';
 import type { TokenProvider } from './environment.js';
+import { isRecord } from '../utils/type-guards.js';
 import { getFlattenedTokens, extractVarName } from './token-utils.js';
 
 type TokenType = 'cssVar' | 'hexColor' | 'numeric' | 'string';
@@ -159,10 +160,6 @@ function isUnusedTokenRule(e: {
     (Array.isArray(e.options.ignore) &&
       e.options.ignore.every((t): t is string => typeof t === 'string'))
   );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 function isDimension(value: unknown): value is { value: number; unit: string } {

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -1,7 +1,7 @@
 import type { DesignTokens } from '../core/types.js';
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export function isDesignTokens(value: unknown): value is DesignTokens {


### PR DESCRIPTION
## Summary
- deduplicate isRecord by consolidating implementation in type-guards
- reuse shared isRecord in CLI, plugin manager, token tracker, and schema

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2aa29a610832885d0a3978d60de20