### PR TITLE
refactor(token-tracker): use shared value-with-unit helper

### DIFF
--- a/.changeset/shared-value-unit-helper.md
+++ b/.changeset/shared-value-unit-helper.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor token tracker to use shared value-with-unit helper

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -129,12 +129,7 @@ function collectTokenValues(
         if (!values.has(key)) values.set(key, flat);
         continue;
       }
-      if (isDimension(val)) {
-        const key = `${String(val.value)}${val.unit}`;
-        if (!values.has(key)) values.set(key, flat);
-        continue;
-      }
-      if (isDuration(val)) {
+      if (isValueWithUnit(val)) {
         const key = `${String(val.value)}${val.unit}`;
         if (!values.has(key)) values.set(key, flat);
       }
@@ -165,15 +160,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function isDimension(value: unknown): value is { value: number; unit: string } {
-  return (
-    isRecord(value) &&
-    typeof Reflect.get(value, 'value') === 'number' &&
-    typeof Reflect.get(value, 'unit') === 'string'
-  );
-}
-
-function isDuration(value: unknown): value is { value: number; unit: string } {
+function isValueWithUnit(
+  value: unknown,
+): value is { value: number; unit: string } {
   return (
     isRecord(value) &&
     typeof Reflect.get(value, 'value') === 'number' &&


### PR DESCRIPTION
## Summary
- replace `isDimension` and `isDuration` with shared `isValueWithUnit` helper
- update token value collection to use new helper
- add changeset entry

## Testing
- `npm run format`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2aa3609d48328aec9dde05f2e29eb