### PR TITLE
refactor: auto collect rule modules

### DIFF
--- a/.changeset/auto-rule-aggregation.md
+++ b/.changeset/auto-rule-aggregation.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+auto-generate built-in rule list from rule modules

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,54 +1,34 @@
-import { colorsRule } from './token-colors.js';
-import { spacingRule } from './token-spacing.js';
-import { fontSizeRule } from './token-font-size.js';
-import { fontFamilyRule } from './token-font-family.js';
-import { lineHeightRule } from './token-line-height.js';
-import { fontWeightRule } from './token-font-weight.js';
-import { letterSpacingRule } from './token-letter-spacing.js';
-import { borderRadiusRule } from './token-border-radius.js';
-import { borderWidthRule } from './token-border-width.js';
-import { zIndexRule } from './token-z-index.js';
-import { boxShadowRule } from './token-box-shadow.js';
-import { durationRule } from './token-duration.js';
-import { animationRule } from './token-animation.js';
-import { blurRule } from './token-blur.js';
-import { borderColorRule } from './token-border-color.js';
-import { opacityRule } from './token-opacity.js';
-import { outlineRule } from './token-outline.js';
-import { componentUsageRule } from './component-usage.js';
-import { deprecationRule } from './deprecation.js';
-import { variantPropRule } from './variant-prop.js';
-import { componentPrefixRule } from './component-prefix.js';
-import { noInlineStylesRule } from './no-inline-styles.js';
-import { iconUsageRule } from './icon-usage.js';
-import { importPathRule } from './import-path.js';
-import { noUnusedTokensRule } from './no-unused-tokens.js';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { globby } from 'globby';
 import type { RuleModule } from '../core/types.js';
 
-export const builtInRules: RuleModule[] = [
-  animationRule,
-  blurRule,
-  borderColorRule,
-  colorsRule,
-  spacingRule,
-  fontSizeRule,
-  fontFamilyRule,
-  lineHeightRule,
-  fontWeightRule,
-  letterSpacingRule,
-  borderRadiusRule,
-  borderWidthRule,
-  boxShadowRule,
-  durationRule,
-  opacityRule,
-  outlineRule,
-  zIndexRule,
-  componentUsageRule,
-  deprecationRule,
-  variantPropRule,
-  componentPrefixRule,
-  noInlineStylesRule,
-  iconUsageRule,
-  importPathRule,
-  noUnusedTokensRule,
-];
+function isRuleModule(value: unknown): value is RuleModule {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const name: unknown = Reflect.get(value, 'name');
+  const create: unknown = Reflect.get(value, 'create');
+  return typeof name === 'string' && typeof create === 'function';
+}
+
+const ruleDir = path.dirname(fileURLToPath(import.meta.url));
+const ruleFiles = await globby('*.{ts,js}', {
+  cwd: ruleDir,
+  ignore: ['index.ts', 'index.js', 'utils/**', '*.d.ts'],
+});
+
+const modules = await Promise.all(
+  ruleFiles.map(async (file) => {
+    const mod: unknown = await import(`./${file.replace(/\.ts$/, '.js')}`);
+    let values: unknown[] = [];
+    if (typeof mod === 'object' && mod !== null) {
+      values = Object.values(mod);
+    }
+    return values.filter(isRuleModule);
+  }),
+);
+
+export const builtInRules: RuleModule[] = modules
+  .flat()
+  .sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- automatically aggregate rule modules using globby
- build built-in rules list from gathered modules

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2aa3bd9cc8328be160cfd299462a0