### PR TITLE
refactor: share unit guard in token tracker

### DIFF
--- a/.changeset/shared-unit-helper.md
+++ b/.changeset/shared-unit-helper.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor token tracker to use shared unit helper

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -130,14 +130,10 @@ function collectTokenValues(
         if (!values.has(key)) values.set(key, flat);
         continue;
       }
-      if (isDimension(val)) {
+      if (isValueWithUnit(val)) {
         const key = `${String(val.value)}${val.unit}`;
         if (!values.has(key)) values.set(key, flat);
         continue;
-      }
-      if (isDuration(val)) {
-        const key = `${String(val.value)}${val.unit}`;
-        if (!values.has(key)) values.set(key, flat);
       }
     }
   }
@@ -162,15 +158,9 @@ function isUnusedTokenRule(e: {
   );
 }
 
-function isDimension(value: unknown): value is { value: number; unit: string } {
-  return (
-    isRecord(value) &&
-    typeof Reflect.get(value, 'value') === 'number' &&
-    typeof Reflect.get(value, 'unit') === 'string'
-  );
-}
-
-function isDuration(value: unknown): value is { value: number; unit: string } {
+function isValueWithUnit(
+  value: unknown,
+): value is { value: number; unit: string } {
   return (
     isRecord(value) &&
     typeof Reflect.get(value, 'value') === 'number' &&


### PR DESCRIPTION
## Summary
- replace dimension and duration guards with shared isValueWithUnit helper in token tracker
- add changeset entry

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2abd0a6508328a3255edd3e546795