### PR TITLE
refactor: extract lint setup and scanning service

### DIFF
--- a/.changeset/factory-lint-service.md
+++ b/.changeset/factory-lint-service.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+extract token setup and scanning into dedicated factory and service

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,7 +45,7 @@ main().catch(console.error);
 
 ```ts
 import { Linter, FileSource } from '@lapidist/design-lint';
-const linter = new Linter(config, new FileSource());
+const linter = initLinter(config, new FileSource());
 const { results } = await linter.lintTargets(['src/**/*.ts']);
 ```
 

--- a/docs/examples/plugin/README.md
+++ b/docs/examples/plugin/README.md
@@ -23,7 +23,7 @@ Start a new plugin that exposes one rule.
    ```ts
    import { Linter, FileSource } from '@lapidist/design-lint';
    import plugin from './index.js';
-   const linter = new Linter({ plugins: [plugin], rules: { 'demo/no-raw-colors': 'error' } }, new FileSource());
+   const linter = initLinter({ plugins: [plugin], rules: { 'demo/no-raw-colors': 'error' } }, new FileSource());
    ```
 
 ## Next steps

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -95,7 +95,7 @@ import { Linter, FileSource } from '@lapidist/design-lint';
 import plugin from '../index.js';
 
 void test('reports raw colors', async () => {
-  const linter = new Linter({ plugins: [plugin], rules: { 'acme/no-raw-colors': 'error' } }, new FileSource());
+  const linter = initLinter({ plugins: [plugin], rules: { 'acme/no-raw-colors': 'error' } }, new FileSource());
   const res = await linter.lintText('h1 { color: #fff; }', 'file.css');
   assert.equal(res.messages.length, 1);
 });

--- a/scripts/bench/fs.js
+++ b/scripts/bench/fs.js
@@ -9,7 +9,7 @@ const targets = process.argv.slice(2);
 (async () => {
   const config = await loadConfig(process.cwd());
   const env = createNodeEnvironment(config);
-  const linter = new Linter(config, env);
+  const linter = initLinter(config, env);
   const start = performance.now();
   await linter.lintTargets(targets.length ? targets : ['.']);
   const end = performance.now();

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -3,7 +3,8 @@ import path from 'path';
 import ignore, { type Ignore } from 'ignore';
 import { getFormatter } from '../formatters/index.js';
 import type { CacheProvider } from '../core/cache-provider.js';
-import type { Config, Linter } from '../core/linter.js';
+import type { Config } from '../core/linter.js';
+import type { Linter } from '../index.js';
 import type { LintResult } from '../core/types.js';
 import { createNodeEnvironment } from '../adapters/node/environment.js';
 import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths.js';
@@ -41,9 +42,9 @@ export interface PrepareEnvironmentOptions {
 export async function prepareEnvironment(
   options: PrepareEnvironmentOptions,
 ): Promise<Environment> {
-  const [{ loadConfig }, { Linter }, { loadIgnore }] = await Promise.all([
+  const [{ loadConfig }, { createLinter }, { loadIgnore }] = await Promise.all([
     import('../config/loader.js'),
-    import('../core/linter.js'),
+    import('../index.js'),
     import('../core/ignore.js'),
   ]);
 
@@ -65,7 +66,7 @@ export async function prepareEnvironment(
   });
   const cache = env.cacheProvider;
   const linterRef = {
-    current: new Linter(config, env),
+    current: createLinter(config, env),
   };
   const pluginPaths = await linterRef.current.getPluginPaths();
 

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -6,8 +6,9 @@ import chokidar from 'chokidar';
 import chalk from 'chalk';
 import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths.js';
 import { loadConfig } from '../config/loader.js';
-import { Linter } from '../core/linter.js';
+import { createLinter } from '../index.js';
 import type { Config } from '../core/linter.js';
+import type { Linter } from '../index.js';
 import { createNodeEnvironment } from '../adapters/node/environment.js';
 import type { CacheProvider } from '../core/cache-provider.js';
 import type { Ignore } from 'ignore';
@@ -193,7 +194,7 @@ export async function startWatch(ctx: WatchOptions) {
         patterns: config.patterns,
       });
       cache = env.cacheProvider;
-      linterRef.current = new Linter(config, env);
+      linterRef.current = createLinter(config, env);
       await refreshIgnore();
       const newPluginPaths = await linterRef.current.getPluginPaths();
       const toRemove = pluginPaths.filter((p) => !newPluginPaths.includes(p));

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,6 @@
 export { Linter, type Config } from './linter.js';
+export { LintService } from './lint-service.js';
+export { setupLinter } from './setup.js';
 export { applyFixes } from './apply-fixes.js';
 export { Runner } from './runner.js';
 export { PluginError, ConfigError } from './errors.js';

--- a/src/core/lint-service.ts
+++ b/src/core/lint-service.ts
@@ -1,0 +1,45 @@
+import type { Config } from './linter.js';
+import type { Environment } from './environment.js';
+import type { LintResult } from './types.js';
+import { Linter } from './linter.js';
+
+export class LintService {
+  private config: Config;
+  private source: Environment['documentSource'];
+  private cache?: Environment['cacheProvider'];
+  private linter: Linter;
+
+  constructor(linter: Linter, config: Config, env: Environment) {
+    this.linter = linter;
+    this.config = config;
+    this.source = env.documentSource;
+    this.cache = env.cacheProvider;
+  }
+
+  async lintTargets(
+    targets: string[],
+    fix = false,
+    ignore: string[] = [],
+  ): Promise<{
+    results: LintResult[];
+    ignoreFiles: string[];
+    warning?: string;
+  }> {
+    const {
+      documents,
+      ignoreFiles: scanIgnores,
+      warning: scanWarning,
+    } = await this.source.scan(targets, this.config, ignore);
+    const {
+      results,
+      ignoreFiles: runIgnores,
+      warning: runWarning,
+    } = await this.linter.lintDocuments(documents, fix, this.cache);
+    const ignoreFiles = Array.from(new Set([...scanIgnores, ...runIgnores]));
+    return {
+      results,
+      ignoreFiles,
+      warning: scanWarning ?? runWarning,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Linter, type Config } from './core/linter.js';
+import { Linter, type Config, LintService, setupLinter } from './core/index.js';
 import type { Environment } from './core/environment.js';
 
 export * from './core/index.js';
@@ -9,5 +9,12 @@ export { getFormatter } from './formatters/index.js';
 export { builtInRules } from './rules/index.js';
 
 export function createLinter(config: Config, env: Environment): Linter {
-  return new Linter(config, env);
+  return setupLinter(config, env).linter;
+}
+
+export function createLintService(
+  config: Config,
+  env: Environment,
+): LintService {
+  return setupLinter(config, env).service;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,8 +5,11 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
 import { readWhenReady } from './helpers/fs.ts';
-import { Linter } from '../src/index.ts';
-import { FileSource } from '../src/index.ts';
+import {
+  createLinter as initLinter,
+  FileSource,
+  type Linter,
+} from '../src/index.ts';
 import type { LintResult } from '../src/core/types.ts';
 import ignore from 'ignore';
 
@@ -1151,7 +1154,7 @@ void test('CLI cache updates after --fix run', async () => {
       return Promise.resolve();
     },
   };
-  const linter = new Linter(config, {
+  const linter = initLinter(config, {
     documentSource: new FileSource(),
     cacheProvider: cache,
   });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
 import { resolveConfigFile } from '../src/config/file-resolution.ts';
 import { loadTokens } from '../src/config/token-loader.ts';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 import { ConfigError } from '../src/core/errors.ts';
 
@@ -316,7 +316,7 @@ void test("rule configured as 'off' is ignored", async () => {
     }),
   );
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const res = await linter.lintText('const c = "#fff";', 'file.ts');
   assert.equal(res.messages.length, 0);
 });
@@ -329,7 +329,7 @@ void test('throws on unknown rule name', async () => {
     JSON.stringify({ rules: { 'unknown/rule': 'error' } }),
   );
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   await assert.rejects(
     () => linter.lintText('const x = 1;', 'file.ts'),
     (err) => {

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { createNodeEnvironment } from '../../src/adapters/node/environment.ts';
 
 void test('Linter integrates registry, parser and trackers', async () => {
@@ -11,7 +11,7 @@ void test('Linter integrates registry, parser and trackers', async () => {
     rules: { 'design-token/colors': 'error' },
   };
   const env = createNodeEnvironment(config);
-  const linter = new Linter(config, env);
+  const linter = initLinter(config, env);
   const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
   const file = path.join(dir, 'file.css');
   await fs.writeFile(file, 'a{color:#fff;}');

--- a/tests/core/profile.test.ts
+++ b/tests/core/profile.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../../src/adapters/node/utils/tmp.ts';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { createNodeEnvironment } from '../../src/adapters/node/environment.ts';
 import type { Config } from '../../src/core/linter.ts';
 
@@ -17,7 +17,7 @@ void test('FileSource.scan logs when DESIGNLINT_PROFILE is set', async () => {
   fs.writeFileSync(path.join(dir, 'file.ts'), '');
   const config = { tokens: {}, rules: {} };
   const env = createNodeEnvironment(config);
-  const linter = new Linter(config, env);
+  const linter = initLinter(config, env);
   const cwd = process.cwd();
   process.chdir(dir);
   process.env.DESIGNLINT_PROFILE = '1';

--- a/tests/glob.test.ts
+++ b/tests/glob.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('lintTargets expands glob patterns with globby', async () => {
@@ -14,7 +14,7 @@ void test('lintTargets expands glob patterns with globby', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter({ tokens: {}, rules: {} }, new FileSource());
+    const linter = initLinter({ tokens: {}, rules: {} }, new FileSource());
     const { results, warning } = await linter.lintTargets([
       '**/*.module.{css,scss}',
     ]);

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
 const tokens = {
@@ -26,7 +26,7 @@ void test('lintTargets ignores common directories by default', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -48,7 +48,7 @@ void test('lintTargets respects .gitignore via globby', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -74,7 +74,7 @@ void test('.designlintignore can unignore paths', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -96,7 +96,7 @@ void test('.designlintignore overrides .gitignore', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -121,7 +121,7 @@ void test('.designlintignore supports negative patterns', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -143,7 +143,7 @@ void test('.designlintignore supports Windows paths', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -164,7 +164,7 @@ void test('config ignoreFiles are respected', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       {
         tokens,
         rules: { 'design-system/deprecation': 'error' },
@@ -191,7 +191,7 @@ void test('additional ignore file is respected', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -213,7 +213,7 @@ void test('lintTargets respects nested .gitignore', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );
@@ -236,7 +236,7 @@ void test('nested .designlintignore overrides parent patterns', async () => {
   const cwd = process.cwd();
   process.chdir(dir);
   try {
-    const linter = new Linter(
+    const linter = initLinter(
       { tokens, rules: { 'design-system/deprecation': 'error' } },
       new FileSource(),
     );

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
 const tokens = {
@@ -26,7 +26,7 @@ void test('inline directives disable linting', async () => {
       '/* design-lint-enable */\n' +
       "const f = 'old';\n",
   );
-  const linter = new Linter(
+  const linter = initLinter(
     { tokens, rules: { 'design-system/deprecation': 'error' } },
     new FileSource(),
   );
@@ -43,7 +43,7 @@ void test('strings resembling directives do not disable next line', async () => 
     file,
     "const a = 'design-lint-disable-next-line';\n" + "const b = 'old';\n",
   );
-  const linter = new Linter(
+  const linter = initLinter(
     { tokens, rules: { 'design-system/deprecation': 'error' } },
     new FileSource(),
   );

--- a/tests/lint-file.test.ts
+++ b/tests/lint-file.test.ts
@@ -2,7 +2,7 @@ import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 import { createFileDocument } from '../src/adapters/node/file-document.ts';
 import { loadConfig } from '../src/config/loader.ts';
@@ -11,7 +11,7 @@ const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');
 
 void test('lintDocument matches lintTargets result', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const doc = createFileDocument(file);
   const res1 = await linter.lintDocument(doc);
@@ -22,7 +22,7 @@ void test('lintDocument matches lintTargets result', async () => {
 
 void test('lintDocument reports unreadable file', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const doc = createFileDocument(file);
   const original = fs.readFile;
@@ -50,7 +50,7 @@ void test('lintDocument reports unreadable file', async () => {
 
 void test('lintTargets reports unreadable file', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'App.svelte');
   const original = fs.readFile;
   const stub = mock.method(

--- a/tests/patterns.test.ts
+++ b/tests/patterns.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('lintTargets uses patterns option to include custom extensions', async () => {
@@ -16,10 +16,10 @@ void test('lintTargets uses patterns option to include custom extensions', async
     },
     rules: { 'design-token/colors': 'error' },
   };
-  const defaultLinter = new Linter(baseConfig, new FileSource());
+  const defaultLinter = initLinter(baseConfig, new FileSource());
   const { results: defaultResults } = await defaultLinter.lintTargets([tmp]);
   assert.equal(defaultResults.length, 0);
-  const customLinter = new Linter(
+  const customLinter = initLinter(
     { ...baseConfig, patterns: ['**/*.foo'] },
     new FileSource(),
   );

--- a/tests/performance.test.ts
+++ b/tests/performance.test.ts
@@ -4,13 +4,13 @@ import fs from 'node:fs';
 import { makeTmpDir } from '../src/adapters/node/utils/tmp.ts';
 import path from 'node:path';
 import { loadConfig } from '../src/config/loader.ts';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 
 void test('lints large projects without crashing', async () => {
   const dir = path.join(__dirname, 'fixtures', 'large-project');
   const config = await loadConfig(dir);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const { results } = await linter.lintTargets([dir]);
   assert.equal(results.length, 200);
 });
@@ -26,7 +26,7 @@ void test('lints very large projects without EMFILE', async () => {
     );
   }
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const { results } = await linter.lintTargets([tmp]);
   assert.equal(results.length, count);
   fs.rmSync(tmp, { recursive: true, force: true });
@@ -75,7 +75,7 @@ void test('respects configured concurrency limit', async () => {
   fsp.stat = trackedStat;
 
   const config = await loadConfig(tmp);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const { results } = await linter.lintTargets([tmp]);
   assert.equal(results.length, count);
   assert.ok(max <= 2);

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 import { NodePluginLoader } from '../src/adapters/node/plugin-loader.ts';
@@ -11,7 +11,7 @@ import { PluginError } from '../src/core/errors.ts';
 
 void test('external plugin rules execute', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin.ts');
-  const linter = new Linter(
+  const linter = initLinter(
     {
       plugins: [pluginPath],
       rules: { 'plugin/test': 'error' },
@@ -29,7 +29,7 @@ void test('external plugin rules execute', async () => {
 void test('plugins resolve relative to config file', async () => {
   const dir = path.join(__dirname, 'fixtures', 'plugin-relative');
   const config = await loadConfig(dir);
-  const linter = new Linter(config, {
+  const linter = initLinter(config, {
     documentSource: new FileSource(),
     pluginLoader: new NodePluginLoader(),
   });
@@ -40,7 +40,7 @@ void test('plugins resolve relative to config file', async () => {
 
 void test('loads ESM plugin modules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin-esm.mjs');
-  const linter = new Linter(
+  const linter = initLinter(
     {
       plugins: [pluginPath],
       rules: { 'plugin/esm': 'error' },
@@ -57,7 +57,7 @@ void test('loads ESM plugin modules', async () => {
 
 void test('throws for invalid plugin modules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-plugin.ts');
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: [pluginPath] },
     {
       documentSource: new FileSource(),
@@ -77,7 +77,7 @@ void test('throws for invalid plugin modules', async () => {
 
 void test('throws for invalid plugin rules', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'invalid-rule-plugin.ts');
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: [pluginPath] },
     {
       documentSource: new FileSource(),
@@ -100,7 +100,7 @@ void test('throws for invalid plugin rules', async () => {
 
 void test('throws when plugin module missing', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'missing-plugin.js');
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: [pluginPath] },
     {
       documentSource: new FileSource(),
@@ -123,7 +123,7 @@ void test('throws when plugin module missing', async () => {
 
 void test('throws when plugin rule conflicts with existing rule', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'conflict-plugin.ts');
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: [pluginPath] },
     new FileSource(),
     new NodePluginLoader(),
@@ -145,7 +145,7 @@ void test('throws when plugin rule conflicts with existing rule', async () => {
 void test('throws when two plugins define the same rule name', async () => {
   const pluginA = path.join(__dirname, 'fixtures', 'test-plugin.ts');
   const pluginB = path.join(__dirname, 'fixtures', 'duplicate-rule-plugin.ts');
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: [pluginA, pluginB] },
     {
       documentSource: new FileSource(),
@@ -170,7 +170,7 @@ void test('throws when two plugins define the same rule name', async () => {
 
 void test('getPluginPaths returns resolved plugin paths', async () => {
   const pluginPath = path.join(__dirname, 'fixtures', 'test-plugin.ts');
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: [pluginPath] },
     {
       documentSource: new FileSource(),
@@ -201,7 +201,7 @@ void test('supports custom plugin loaders', async () => {
       return Promise.resolve({ path: 'mock', plugin: { rules: [rule] } });
     }
   }
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: ['mock'], rules: { 'mock/rule': 'error' } },
     { documentSource: new FileSource(), pluginLoader: new MockLoader() },
   );

--- a/tests/rules/animation.test.ts
+++ b/tests/rules/animation.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
@@ -15,7 +15,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/animation': 'error' } },
     {
       documentSource: new FileSource(),
@@ -43,7 +43,7 @@ void test('design-token/animation accepts valid values', async () => {
 });
 
 void test('design-token/animation warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/animation': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/blur.test.ts
+++ b/tests/rules/blur.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -9,7 +9,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/blur': 'error' } },
     {
       documentSource: new FileSource(),
@@ -31,7 +31,7 @@ void test('design-token/blur accepts valid values', async () => {
 });
 
 void test('design-token/blur warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/blur': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/border-color.test.ts
+++ b/tests/rules/border-color.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -8,7 +8,7 @@ void test('design-token/border-color reports invalid value', async () => {
   const tokens = {
     borderColors: { $type: 'color', primary: { $value: '#ffffff' } },
   };
-  const linter = new Linter(
+  const linter = initLinter(
     { tokens, rules: { 'design-token/border-color': 'error' } },
     {
       documentSource: new FileSource(),
@@ -23,7 +23,7 @@ void test('design-token/border-color accepts valid values', async () => {
   const tokens = {
     borderColors: { $type: 'color', primary: { $value: '#ffffff' } },
   };
-  const linter = new Linter(
+  const linter = initLinter(
     { tokens, rules: { 'design-token/border-color': 'error' } },
     {
       documentSource: new FileSource(),
@@ -35,7 +35,7 @@ void test('design-token/border-color accepts valid values', async () => {
 });
 
 void test('design-token/border-color warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/border-color': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/border-radius.test.ts
+++ b/tests/rules/border-radius.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 function createLinter(rule: unknown = 'error') {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/border-radius': rule } },
     {
       documentSource: new FileSource(),
@@ -52,7 +52,7 @@ void test('design-token/border-radius ignores numbers in JSX props', async () =>
 });
 
 void test('design-token/border-radius warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/border-radius': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/border-width.test.ts
+++ b/tests/rules/border-width.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/border-width': 'error' } },
     {
       documentSource: new FileSource(),
@@ -79,7 +79,7 @@ void test('design-token/border-width ignores numbers in JSX props', async () => 
 });
 
 void test('design-token/border-width warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/border-width': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/box-shadow.test.ts
+++ b/tests/rules/box-shadow.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -27,7 +27,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/box-shadow': 'error' } },
     {
       documentSource: new FileSource(),
@@ -55,7 +55,7 @@ void test('design-token/box-shadow allows configured tokens', async () => {
 });
 
 void test('design-token/box-shadow warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/box-shadow': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/component-prefix.test.ts
+++ b/tests/rules/component-prefix.test.ts
@@ -1,11 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-prefix enforces prefix on components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-prefix': ['error', { prefix: 'DS' }],
@@ -19,7 +19,7 @@ void test('design-system/component-prefix enforces prefix on components', async 
 });
 
 void test('design-system/component-prefix ignores lowercase tags', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-prefix': ['error', { prefix: 'DS' }],
@@ -32,7 +32,7 @@ void test('design-system/component-prefix ignores lowercase tags', async () => {
 });
 
 void test('design-system/component-prefix fixes self-closing tags', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-prefix': ['error', { prefix: 'DS' }],
@@ -49,7 +49,7 @@ void test('design-system/component-prefix fixes self-closing tags', async () => 
 });
 
 void test('design-system/component-prefix fixes opening and closing tags', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-prefix': ['error', { prefix: 'DS' }],
@@ -66,7 +66,7 @@ void test('design-system/component-prefix fixes opening and closing tags', async
 });
 
 void test('design-system/component-prefix enforces prefix in Vue components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-prefix': ['error', { prefix: 'DS' }],
@@ -82,7 +82,7 @@ void test('design-system/component-prefix enforces prefix in Vue components', as
 });
 
 void test('design-system/component-prefix enforces prefix in Svelte components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-prefix': ['error', { prefix: 'DS' }],
@@ -95,7 +95,7 @@ void test('design-system/component-prefix enforces prefix in Svelte components',
 });
 
 void test('design-system/component-prefix enforces prefix on custom elements', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-prefix': ['error', { prefix: 'ds-' }],

--- a/tests/rules/component-usage.test.ts
+++ b/tests/rules/component-usage.test.ts
@@ -1,11 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/component-usage suggests substitutions', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-usage': [
@@ -22,7 +22,7 @@ void test('design-system/component-usage suggests substitutions', async () => {
 });
 
 void test('design-system/component-usage matches mixed-case tags', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-usage': [
@@ -39,7 +39,7 @@ void test('design-system/component-usage matches mixed-case tags', async () => {
 });
 
 void test('design-system/component-usage matches mixed-case substitution keys', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-usage': [
@@ -56,7 +56,7 @@ void test('design-system/component-usage matches mixed-case substitution keys', 
 });
 
 void test('design-system/component-usage fixes self-closing tags', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-usage': [
@@ -76,7 +76,7 @@ void test('design-system/component-usage fixes self-closing tags', async () => {
 });
 
 void test('design-system/component-usage fixes opening and closing tags', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/component-usage': [

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/deprecation flags deprecated token', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens: {
         colors: {
@@ -30,7 +30,7 @@ void test('design-system/deprecation flags deprecated token', async () => {
 });
 
 void test('design-system/deprecation ignores tokens in non-style jsx attributes', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens: {
         colors: {
@@ -54,7 +54,7 @@ void test('design-system/deprecation ignores tokens in non-style jsx attributes'
 });
 
 void test('design-system/deprecation warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/deprecation': 'warn' },
     },

--- a/tests/rules/duration.test.ts
+++ b/tests/rules/duration.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/duration': 'error' } },
     {
       documentSource: new FileSource(),
@@ -65,7 +65,7 @@ void test('design-token/duration ignores numbers in JSX props', async () => {
 });
 
 void test('design-token/duration warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/duration': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/font-family.test.ts
+++ b/tests/rules/font-family.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -9,7 +9,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     {
       tokens,
       rules: { 'design-token/font-family': 'error' },
@@ -29,7 +29,7 @@ void test('design-token/font-family reports invalid font-family', async () => {
 });
 
 void test('design-token/font-family warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/font-family': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/font-size.test.ts
+++ b/tests/rules/font-size.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     {
       tokens,
       rules: { 'design-token/font-size': 'error' },
@@ -44,7 +44,7 @@ void test('design-token/font-size accepts unit-based font-sizes', async () => {
 });
 
 void test('design-token/font-size warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/font-size': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/font-weight.test.ts
+++ b/tests/rules/font-weight.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/font-weight': 'error' } },
     {
       documentSource: new FileSource(),
@@ -52,7 +52,7 @@ void test('design-token/font-weight ignores numbers in JSX props', async () => {
 });
 
 void test('design-token/font-weight warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/font-weight': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/icon-usage.test.ts
+++ b/tests/rules/icon-usage.test.ts
@@ -1,11 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { applyFixes } from '../../src/index.ts';
 
 void test('design-system/icon-usage reports raw svg', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/icon-usage': 'error' },
     },
@@ -20,7 +20,7 @@ void test('design-system/icon-usage reports raw svg', async () => {
 });
 
 void test('design-system/icon-usage matches substitutions', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/icon-usage': [
@@ -40,7 +40,7 @@ void test('design-system/icon-usage matches substitutions', async () => {
 });
 
 void test('design-system/icon-usage fixes svg opening and closing tags', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/icon-usage': 'error' },
     },

--- a/tests/rules/import-path.test.ts
+++ b/tests/rules/import-path.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/import-path flags components from wrong package', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/import-path': [
@@ -23,7 +23,7 @@ void test('design-system/import-path flags components from wrong package', async
 });
 
 void test('design-system/import-path allows configured package', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/import-path': [
@@ -42,7 +42,7 @@ void test('design-system/import-path allows configured package', async () => {
 });
 
 void test('design-system/import-path handles default imports', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/import-path': [
@@ -58,7 +58,7 @@ void test('design-system/import-path handles default imports', async () => {
 });
 
 void test('design-system/import-path enforces package in Vue components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/import-path': [
@@ -77,7 +77,7 @@ void test('design-system/import-path enforces package in Vue components', async 
 });
 
 void test('design-system/import-path enforces package in Svelte components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/import-path': [

--- a/tests/rules/letter-spacing.test.ts
+++ b/tests/rules/letter-spacing.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/letter-spacing': 'error' } },
     {
       documentSource: new FileSource(),
@@ -52,7 +52,7 @@ void test('design-token/letter-spacing ignores numbers in JSX props', async () =
 });
 
 void test('design-token/letter-spacing warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/letter-spacing': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/line-height.test.ts
+++ b/tests/rules/line-height.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -9,7 +9,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/line-height': 'error' } },
     {
       documentSource: new FileSource(),
@@ -75,7 +75,7 @@ void test('design-token/line-height ignores numbers in JSX props', async () => {
 });
 
 void test('design-token/line-height warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/line-height': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/metadata.test.ts
+++ b/tests/rules/metadata.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import type { PluginLoader } from '../../src/core/plugin-loader.ts';
 import type { PluginModule, RuleModule } from '../../src/core/types.ts';
@@ -32,7 +32,7 @@ void test('metadata propagates through report', async () => {
       return Promise.resolve({ path: 'mock', plugin: { rules: [rule] } });
     }
   }
-  const linter = new Linter(
+  const linter = initLinter(
     { plugins: ['mock'], rules: { 'mock/rule': 'error' } },
     { documentSource: new FileSource(), pluginLoader: new MockLoader() },
   );

--- a/tests/rules/no-inline-styles.test.ts
+++ b/tests/rules/no-inline-styles.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/no-inline-styles flags style attribute on components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/no-inline-styles': 'error' },
     },
@@ -18,7 +18,7 @@ void test('design-system/no-inline-styles flags style attribute on components', 
 });
 
 void test('design-system/no-inline-styles flags className attribute on components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/no-inline-styles': 'error' },
     },
@@ -32,7 +32,7 @@ void test('design-system/no-inline-styles flags className attribute on component
 });
 
 void test('design-system/no-inline-styles ignores className when configured', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/no-inline-styles': ['error', { ignoreClassName: true }],
@@ -48,7 +48,7 @@ void test('design-system/no-inline-styles ignores className when configured', as
 });
 
 void test('design-system/no-inline-styles flags inline styles in Vue templates', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/no-inline-styles': 'error' },
     },
@@ -62,7 +62,7 @@ void test('design-system/no-inline-styles flags inline styles in Vue templates',
 });
 
 void test('design-system/no-inline-styles flags inline styles in Svelte components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/no-inline-styles': 'error' },
     },
@@ -76,7 +76,7 @@ void test('design-system/no-inline-styles flags inline styles in Svelte componen
 });
 
 void test('design-system/no-inline-styles flags inline styles on custom elements', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: { 'design-system/no-inline-styles': 'error' },
     },

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import type { Environment } from '../../src/core/environment.ts';
 
@@ -27,7 +27,7 @@ void test('design-system/no-unused-tokens reports unused tokens', async () => {
       load: () => Promise.resolve({ default: tokens }),
     },
   };
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens,
       rules: { 'design-system/no-unused-tokens': 'warn' },
@@ -61,7 +61,7 @@ void test('design-system/no-unused-tokens includes token metadata', async () => 
       load: () => Promise.resolve({ default: tokens }),
     },
   };
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens,
       rules: { 'design-system/no-unused-tokens': 'warn' },
@@ -92,7 +92,7 @@ void test('design-system/no-unused-tokens passes when tokens used', async () => 
       load: () => Promise.resolve({ default: tokens }),
     },
   };
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens,
       rules: { 'design-system/no-unused-tokens': 'error' },
@@ -120,7 +120,7 @@ void test('design-system/no-unused-tokens can ignore tokens', async () => {
       load: () => Promise.resolve({ default: tokens }),
     },
   };
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens,
       rules: {
@@ -147,7 +147,7 @@ void test('design-system/no-unused-tokens matches hex case-insensitively', async
       load: () => Promise.resolve({ default: tokens }),
     },
   };
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens,
       rules: { 'design-system/no-unused-tokens': 'warn' },

--- a/tests/rules/opacity.test.ts
+++ b/tests/rules/opacity.test.ts
@@ -1,12 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
 function createLinter(rule: unknown = 'error') {
   const tokens = { opacity: { $type: 'number', low: { $value: 0.2 } } };
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/opacity': rule } },
     {
       documentSource: new FileSource(),
@@ -50,7 +50,7 @@ void test('design-token/opacity ignores numbers in JSX props', async () => {
 });
 
 void test('design-token/opacity warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/opacity': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/outline.test.ts
+++ b/tests/rules/outline.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 import { registerTokenValidator } from '../../src/core/token-validators/index.ts';
@@ -12,7 +12,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/outline': 'error' } },
     {
       documentSource: new FileSource(),
@@ -34,7 +34,7 @@ void test('design-token/outline accepts valid values', async () => {
 });
 
 void test('design-token/outline warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/outline': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/parse-error.test.ts
+++ b/tests/rules/parse-error.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('reports CSS parse errors', async () => {
-  const linter = new Linter({}, new FileSource());
+  const linter = initLinter({}, new FileSource());
   const res = await linter.lintText('.a { color: red;', 'bad.css');
   assert.equal(res.messages.length, 1);
   assert.equal(res.messages[0].severity, 'error');

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 function createLinter(rule: unknown = ['error', { base: 4 }]) {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/spacing': rule } },
     {
       documentSource: new FileSource(),
@@ -115,7 +115,7 @@ void test('design-token/spacing supports custom units', async () => {
 });
 
 void test('design-token/spacing warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/spacing': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 const config = {
@@ -31,14 +31,14 @@ function assertIds(messages: { ruleId: string }[]) {
 }
 
 void test('reports raw tokens in .scss files', async () => {
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(cssSample, 'file.scss');
   assert.equal(res.messages.length, 3);
   assertIds(res.messages);
 });
 
 void test('reports raw tokens in Vue <style lang="scss">', async () => {
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(
     `<template><div/></template><style lang="scss">${cssSample}</style>`,
     'Comp.vue',
@@ -48,7 +48,7 @@ void test('reports raw tokens in Vue <style lang="scss">', async () => {
 });
 
 void test('reports raw tokens in Svelte <style lang="scss">', async () => {
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(
     `<div></div><style lang="scss">${cssSample}</style>`,
     'Comp.svelte',
@@ -58,7 +58,7 @@ void test('reports raw tokens in Svelte <style lang="scss">', async () => {
 });
 
 void test('reports raw tokens in string style attributes', async () => {
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const res = await linter.lintText(
     `const C = () => <div style="color: #fff; margin: 5px; opacity: 0.5"></div>;`,
     'file.tsx',
@@ -68,7 +68,7 @@ void test('reports raw tokens in string style attributes', async () => {
 });
 
 void test('reports raw tokens once for single style property', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens: { color: { $type: 'color', primary: { $value: '#000000' } } },
       rules: { 'design-token/colors': 'error' },

--- a/tests/rules/token-colors.test.ts
+++ b/tests/rules/token-colors.test.ts
@@ -1,12 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
 function createLinter(rule: unknown = 'error') {
   const tokens = { colors: { $type: 'color', primary: { $value: '#ffffff' } } };
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/colors': rule } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/token-suggestion.test.ts
+++ b/tests/rules/token-suggestion.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -13,7 +13,7 @@ const tokens = {
 };
 
 void test('suggests closest token name', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { tokens, rules: { 'design-token/font-size': 'error' } },
     {
       documentSource: new FileSource(),

--- a/tests/rules/variant-prop.test.ts
+++ b/tests/rules/variant-prop.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 
 void test('design-system/variant-prop flags invalid variant', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [
@@ -24,7 +24,7 @@ void test('design-system/variant-prop flags invalid variant', async () => {
 });
 
 void test('design-system/variant-prop allows valid variant', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [
@@ -43,7 +43,7 @@ void test('design-system/variant-prop allows valid variant', async () => {
 });
 
 void test('design-system/variant-prop flags string literals in expressions', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [
@@ -63,7 +63,7 @@ void test('design-system/variant-prop flags string literals in expressions', asy
 });
 
 void test('design-system/variant-prop ignores dynamic expressions', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [
@@ -82,7 +82,7 @@ void test('design-system/variant-prop ignores dynamic expressions', async () => 
 });
 
 void test('design-system/variant-prop supports custom prop names', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [
@@ -102,7 +102,7 @@ void test('design-system/variant-prop supports custom prop names', async () => {
 });
 
 void test('design-system/variant-prop flags invalid variant in Vue components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [
@@ -121,7 +121,7 @@ void test('design-system/variant-prop flags invalid variant in Vue components', 
 });
 
 void test('design-system/variant-prop flags invalid variant in Svelte components', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [
@@ -140,7 +140,7 @@ void test('design-system/variant-prop flags invalid variant in Svelte components
 });
 
 void test('design-system/variant-prop flags invalid variant on custom elements', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       rules: {
         'design-system/variant-prop': [

--- a/tests/rules/z-index.test.ts
+++ b/tests/rules/z-index.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../../src/core/linter.ts';
+import { createLinter as initLinter } from '../../src/index.ts';
 import { FileSource } from '../../src/adapters/node/file-source.ts';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.ts';
 
@@ -9,7 +9,7 @@ const tokens = {
 };
 
 function createLinter() {
-  return new Linter(
+  return initLinter(
     { tokens, rules: { 'design-token/z-index': 'error' } },
     {
       documentSource: new FileSource(),
@@ -47,7 +47,7 @@ void test('design-token/z-index ignores numbers in JSX props', async () => {
 });
 
 void test('design-token/z-index warns when tokens missing', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     { rules: { 'design-token/z-index': 'warn' } },
     {
       documentSource: new FileSource(),

--- a/tests/svelte-style-bindings.test.ts
+++ b/tests/svelte-style-bindings.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
@@ -9,7 +9,7 @@ const fixtureDir = path.join(__dirname, 'fixtures', 'svelte');
 
 async function lint(file: string) {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const { results } = await linter.lintTargets(
     [path.join(fixtureDir, 'src', file)],
     false,

--- a/tests/tagged-template.test.ts
+++ b/tests/tagged-template.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
@@ -9,7 +9,7 @@ const fixtureDir = path.join(__dirname, 'fixtures', 'tagged-template');
 
 void test('reports CSS in tagged template literals', async () => {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const file = path.join(fixtureDir, 'src', 'styled.ts');
   const {
     results: [res],

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -1,10 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Linter } from '../src/core/linter.js';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.js';
 
 void test('getTokenCompletions returns token paths by theme', async () => {
-  const linter = new Linter(
+  const linter = initLinter(
     {
       tokens: {
         light: {

--- a/tests/vue-style-bindings.test.ts
+++ b/tests/vue-style-bindings.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { Linter } from '../src/core/linter.ts';
+import { createLinter as initLinter } from '../src/index.ts';
 import { FileSource } from '../src/adapters/node/file-source.ts';
 import { loadConfig } from '../src/config/loader.ts';
 
@@ -9,7 +9,7 @@ const fixtureDir = path.join(__dirname, 'fixtures', 'vue');
 
 async function lint(file: string) {
   const config = await loadConfig(fixtureDir);
-  const linter = new Linter(config, { documentSource: new FileSource() });
+  const linter = initLinter(config, { documentSource: new FileSource() });
   const {
     results: [res],
   } = await linter.lintTargets([path.join(fixtureDir, 'src', file)]);


### PR DESCRIPTION
## Summary
- add setup module to configure token provider and rule registry
- introduce LintService to handle target scanning and cache use
- delegate Linter target operations to LintService and expose factory helpers

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2ad0a213c832884cfddae8d7216be