### PR TITLE
fix: restore Linter constructor overload

### DIFF
--- a/.changeset/restore-linter-constructor.md
+++ b/.changeset/restore-linter-constructor.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+restore Linter constructor overload for backward compatibility

--- a/tests/core/linter-constructor.test.ts
+++ b/tests/core/linter-constructor.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Linter } from '../../src/core/linter.ts';
+import type { Environment } from '../../src/core/environment.ts';
+
+void test('constructor accepts legacy environment', async () => {
+  const env: Environment = {
+    documentSource: {
+      scan() {
+        return Promise.resolve({ documents: [], ignoreFiles: [] });
+      },
+    },
+  };
+  const linter = new Linter({ tokens: {}, rules: {} }, env);
+  const { results, ignoreFiles } = await linter.lintTargets(['foo']);
+  assert.deepStrictEqual(results, []);
+  assert.deepStrictEqual(ignoreFiles, []);
+});


### PR DESCRIPTION
## Summary
- allow `Linter` to be constructed with legacy `Environment`
- cover legacy constructor usage with a test
- add changeset entry

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b0da8f488328b22e75eb93e0343c