### PR TITLE
fix(svelte): traverse control-flow fragments

### DIFF
--- a/.changeset/svelte-control-flow-fragments.md
+++ b/.changeset/svelte-control-flow-fragments.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix Svelte parser to traverse fragments inside control-flow blocks

--- a/src/core/framework-parsers/svelte-parser.ts
+++ b/src/core/framework-parsers/svelte-parser.ts
@@ -69,12 +69,27 @@ export async function lintSvelte(
     }
     return decls;
   };
+  const toNodesArray = (value: unknown): unknown[] =>
+    Array.isArray(value) ? value : [];
   const getNodes = (node: Record<string, unknown>): unknown[] => {
-    if (Array.isArray(node.nodes)) return node.nodes;
-    if (Array.isArray(node.children)) return node.children;
+    const nodes: unknown[] = [];
+    nodes.push(...toNodesArray(node.nodes));
+    nodes.push(...toNodesArray(node.children));
     const frag = node.fragment;
-    if (isRecord(frag) && Array.isArray(frag.nodes)) return frag.nodes;
-    return [];
+    nodes.push(...toNodesArray(isRecord(frag) ? frag.nodes : undefined));
+    for (const key of [
+      'consequent',
+      'alternate',
+      'body',
+      'fallback',
+      'pending',
+      'then',
+      'catch',
+    ]) {
+      const value = node[key];
+      nodes.push(...toNodesArray(isRecord(value) ? value.nodes : undefined));
+    }
+    return nodes;
   };
   const walk = (node: unknown): void => {
     if (!isRecord(node)) return;

--- a/tests/fixtures/svelte/src/ControlFlow.svelte
+++ b/tests/fixtures/svelte/src/ControlFlow.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  const padding = 4;
+  const items = [];
+  const promise = Promise.resolve();
+</script>
+
+{#if true}
+  <div style="padding: {padding}px; color: {'#ffffff'}"></div>
+{:else}
+  <div style="padding: {padding}px; color: {'#ffffff'}"></div>
+{/if}
+
+{#each items as item}
+  <div style="padding: {padding}px; color: {'#ffffff'}"></div>
+{:else}
+  <div style="padding: {padding}px; color: {'#ffffff'}"></div>
+{/each}
+
+{#await promise}
+  <div style="padding: {padding}px; color: {'#ffffff'}"></div>
+{:then value}
+  <div style="padding: {padding}px; color: {'#ffffff'}"></div>
+{:catch error}
+  <div style="padding: {padding}px; color: {'#ffffff'}"></div>
+{/await}

--- a/tests/svelte-style-bindings.test.ts
+++ b/tests/svelte-style-bindings.test.ts
@@ -30,3 +30,21 @@ void test('style bindings report spacing and color violations', async () => {
     );
   }
 });
+
+void test('style bindings inside control-flow blocks report violations', async () => {
+  const res = await lint('ControlFlow.svelte');
+  const spacing = res.messages.filter(
+    (m) => m.ruleId === 'design-token/spacing',
+  );
+  const colors = res.messages.filter((m) => m.ruleId === 'design-token/colors');
+  assert.equal(
+    spacing.length,
+    7,
+    `expected 7 spacing violations, got ${String(spacing.length)}`,
+  );
+  assert.equal(
+    colors.length,
+    7,
+    `expected 7 color violations, got ${String(colors.length)}`,
+  );
+});


### PR DESCRIPTION
## Summary
- ensure Svelte parser recurses into control-flow fragments
- add test coverage for style bindings inside control-flow blocks
- add changeset

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2b0fc82d88328a14bd1ef65daaaf8