### PR TITLE
refactor(node): reuse shared isRecord utility in plugin loader

### DIFF
--- a/.changeset/node-plugin-loader-isrecord.md
+++ b/.changeset/node-plugin-loader-isrecord.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+reuse shared isRecord utility in node plugin loader

--- a/src/adapters/node/plugin-loader.ts
+++ b/src/adapters/node/plugin-loader.ts
@@ -6,6 +6,7 @@ import { realpathIfExists, relFromCwd } from './utils/paths.js';
 import type { PluginModule } from '../../core/types.js';
 import type { PluginLoader, LoadedPlugin } from '../../core/plugin-loader.js';
 import { PluginError } from '../../core/errors.js';
+import { isRecord } from '../../utils/type-guards.js';
 
 export class NodePluginLoader implements PluginLoader {
   async load(p: string, configPath?: string): Promise<LoadedPlugin> {
@@ -74,8 +75,4 @@ function isPluginModule(value: unknown): value is PluginModule {
 
 function getErrorCode(e: unknown): string | undefined {
   return isRecord(e) && typeof e.code === 'string' ? e.code : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }


### PR DESCRIPTION
## Summary
- import shared isRecord helper in Node plugin loader
- remove duplicate local isRecord implementation

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2bd2667cc8328ab5d9cb576800ee1