### PR TITLE
refactor: centralize file type constants

### DIFF
--- a/.changeset/file-types-module.md
+++ b/.changeset/file-types-module.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+export file type mappings and glob patterns from dedicated module
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ Supplies raw text to the linter. The Node adapter [`FileSource`](https://github.
 Convert documents into ASTs. CSS uses PostCSS, JavaScript and TypeScript rely on the TypeScript compiler, and Vue/Svelte files compile before analysis. See [`src/core/framework-parsers`](https://github.com/bylapidist/design-lint/tree/main/src/core/framework-parsers).
 
 ### File type mapping
-File extensions are normalised via [`FILE_TYPE_MAP`](https://github.com/bylapidist/design-lint/blob/main/src/core/linter.ts). This mapping tells the linter which parser to apply. To support a new extension, add it to `FILE_TYPE_MAP` and implement or reference the appropriate parser.
+File extensions and default file search patterns live in [`file-types.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/file-types.ts). The exported `FILE_TYPE_MAP` tells the linter which parser to apply, while `defaultPatterns` lists the globs used to discover files. To support a new extension, add it to `FILE_TYPE_MAP` (and `defaultPatterns` if needed) and implement or reference the appropriate parser.
 
 ### Rule engine
 Registers rules and coordinates execution. See [`src/core/linter.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/linter.ts) and [`src/core/rule-registry.ts`](https://github.com/bylapidist/design-lint/blob/main/src/core/rule-registry.ts).

--- a/src/adapters/node/file-source.ts
+++ b/src/adapters/node/file-source.ts
@@ -5,10 +5,7 @@ import { getIgnorePatterns } from '../../core/ignore.js';
 import type { Config } from '../../core/linter.js';
 import type { DocumentSource } from '../../core/environment.js';
 import { createFileDocument } from './file-document.js';
-
-const defaultPatterns = [
-  '**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs,css,scss,sass,less,svelte,vue}',
-];
+import { defaultPatterns } from '../../core/file-types.js';
 
 export class FileSource implements DocumentSource {
   async scan(

--- a/src/core/file-types.ts
+++ b/src/core/file-types.ts
@@ -1,0 +1,20 @@
+export const FILE_TYPE_MAP: Record<string, string> = {
+  ts: 'ts',
+  tsx: 'ts',
+  mts: 'ts',
+  cts: 'ts',
+  js: 'ts',
+  jsx: 'ts',
+  mjs: 'ts',
+  cjs: 'ts',
+  css: 'css',
+  scss: 'css',
+  sass: 'css',
+  less: 'css',
+  vue: 'vue',
+  svelte: 'svelte',
+};
+
+export const defaultPatterns = [
+  '**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs,css,scss,sass,less,svelte,vue}',
+];

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,6 +4,7 @@ export { setupLinter } from './setup.js';
 export { applyFixes } from './apply-fixes.js';
 export { Runner } from './runner.js';
 export { PluginError, ConfigError } from './errors.js';
+export { FILE_TYPE_MAP, defaultPatterns } from './file-types.js';
 export type {
   Environment,
   TokenProvider,

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -18,23 +18,7 @@ import type {
 import type { CacheProvider } from './cache-provider.js';
 import { LintService } from './lint-service.js';
 import { parserRegistry } from './parser-registry.js';
-
-export const FILE_TYPE_MAP: Record<string, string> = {
-  ts: 'ts',
-  tsx: 'ts',
-  mts: 'ts',
-  cts: 'ts',
-  js: 'ts',
-  jsx: 'ts',
-  mjs: 'ts',
-  cjs: 'ts',
-  css: 'css',
-  scss: 'css',
-  sass: 'css',
-  less: 'css',
-  vue: 'vue',
-  svelte: 'svelte',
-};
+import { FILE_TYPE_MAP } from './file-types.js';
 
 export interface Config {
   tokens?:


### PR DESCRIPTION
## Summary
- centralize file type map and default patterns in a new module
- update linter and file source to import shared constants
- document file-types module in architecture overview

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2be645a8883289f9c71f6c3f41832