### PR TITLE
feat(core): validate rule options with schemas

### DIFF
--- a/.changeset/rule-option-schema-validation.md
+++ b/.changeset/rule-option-schema-validation.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add option schema validation for rules

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -66,6 +66,26 @@ export default {
 };
 ```
 
+Rules can expose a [Zod](https://zod.dev/) schema for their options via
+`meta.schema`. The engine validates user-supplied options against the schema
+and rejects invalid configurations.
+
+```ts
+import { z } from 'zod';
+
+const rule: RuleModule<{ ignore?: string[] }> = {
+  name: 'acme/example',
+  meta: {
+    description: 'example rule',
+    schema: z.object({ ignore: z.array(z.string()).optional() }),
+  },
+  create(ctx) {
+    // ctx.options is typed and validated
+    return {};
+  },
+};
+```
+
 ### 3. Register token transforms
 If your plugin consumes design tokens from other tools, provide a transform
 to convert them to the W3C format. Register the transform during plugin

--- a/src/core/rule-registry.ts
+++ b/src/core/rule-registry.ts
@@ -59,6 +59,18 @@ export class RuleRegistry {
         severity = this.normalizeSeverity(setting);
       }
       if (severity) {
+        if (rule.meta.schema) {
+          try {
+            options = rule.meta.schema.parse(options);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            throw new ConfigError({
+              message: `Invalid options for rule ${name}: ${msg}`,
+              context: 'Config.rules',
+              remediation: 'Review and fix the configuration file.',
+            });
+          }
+        }
         entries.push({ rule, options, severity });
       }
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,5 @@
 import type ts from 'typescript';
+import type { z } from 'zod';
 
 export interface VariableDefinition {
   id: string;
@@ -80,6 +81,7 @@ export interface RuleModule<
   meta: {
     description: string;
     category?: string;
+    schema?: z.ZodType;
   };
   create(context: TContext): RuleListener;
 }

--- a/src/rules/component-prefix.ts
+++ b/src/rules/component-prefix.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 
 interface ComponentPrefixOptions {
@@ -10,6 +11,7 @@ export const componentPrefixRule: RuleModule<ComponentPrefixOptions> = {
   meta: {
     description: 'enforce a prefix for design system components',
     category: 'component',
+    schema: z.object({ prefix: z.string().optional() }).optional(),
   },
   create(context) {
     const prefix = context.options?.prefix ?? 'DS';

--- a/src/rules/component-usage.ts
+++ b/src/rules/component-usage.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 
 export interface ComponentUsageOptions {
@@ -11,6 +12,9 @@ export const componentUsageRule: RuleModule<ComponentUsageOptions> = {
     description:
       'disallow raw HTML elements when design system components exist',
     category: 'component',
+    schema: z
+      .object({ substitutions: z.record(z.string(), z.string()).optional() })
+      .optional(),
   },
   create(context) {
     const subs = context.options?.substitutions ?? {};

--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 import { isInNonStyleJsx } from '../utils/jsx.js';
 
@@ -7,6 +8,7 @@ export const deprecationRule: RuleModule = {
   meta: {
     description: 'flag deprecated tokens',
     category: 'design-token',
+    schema: z.void(),
   },
   create(context) {
     const deprecated = new Map<string, { reason?: string; suggest?: string }>();

--- a/src/rules/icon-usage.ts
+++ b/src/rules/icon-usage.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 
 interface IconUsageOptions {
@@ -12,6 +13,9 @@ export const iconUsageRule: RuleModule<IconUsageOptions> = {
     description:
       'disallow raw svg elements or non design system icon components',
     category: 'component',
+    schema: z
+      .object({ substitutions: z.record(z.string(), z.string()).optional() })
+      .optional(),
   },
   create(context) {
     const subs: Record<string, string> = {

--- a/src/rules/import-path.ts
+++ b/src/rules/import-path.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 
 interface ImportPathOptions {
@@ -12,6 +13,12 @@ export const importPathRule: RuleModule<ImportPathOptions> = {
     description:
       'ensure design system components are imported from configured packages',
     category: 'component',
+    schema: z
+      .object({
+        packages: z.array(z.string()).optional(),
+        components: z.array(z.string()).optional(),
+      })
+      .optional(),
   },
   create(context) {
     const opts: ImportPathOptions = context.options ?? {};

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 
 interface NoInlineStylesOptions {
@@ -12,6 +13,7 @@ export const noInlineStylesRule: RuleModule<NoInlineStylesOptions> = {
     description:
       'disallow inline style or className attributes on design system components',
     category: 'component',
+    schema: z.object({ ignoreClassName: z.boolean().optional() }).optional(),
   },
   create(context) {
     const ignoreClassName = context.options?.ignoreClassName ?? false;

--- a/src/rules/no-unused-tokens.ts
+++ b/src/rules/no-unused-tokens.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 
 export const noUnusedTokensRule: RuleModule = {
@@ -5,6 +6,7 @@ export const noUnusedTokensRule: RuleModule = {
   meta: {
     description: 'report unused design tokens',
     category: 'design-token',
+    schema: z.void(),
   },
   create() {
     return {};

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -1,4 +1,5 @@
 import valueParser from 'postcss-value-parser';
+import { z } from 'zod';
 import { tokenRule } from './utils/token-rule.js';
 import { isRecord } from '../utils/type-guards.js';
 
@@ -8,7 +9,11 @@ interface BlurRuleOptions {
 
 export const blurRule = tokenRule<BlurRuleOptions>({
   name: 'design-token/blur',
-  meta: { description: 'enforce blur tokens', category: 'design-token' },
+  meta: {
+    description: 'enforce blur tokens',
+    category: 'design-token',
+    schema: z.object({ units: z.array(z.string()).optional() }).optional(),
+  },
   tokens: 'dimension',
   message:
     'design-token/blur requires blur tokens; configure tokens with $type "dimension" under a "blurs" group to enable this rule.',

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -1,5 +1,6 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
+import { z } from 'zod';
 import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
 
@@ -12,6 +13,7 @@ export const borderRadiusRule = tokenRule<BorderRadiusOptions>({
   meta: {
     description: 'enforce border-radius tokens',
     category: 'design-token',
+    schema: z.object({ units: z.array(z.string()).optional() }).optional(),
   },
   tokens: 'dimension',
   message:

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -1,5 +1,6 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
+import { z } from 'zod';
 import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
 import { isRecord } from '../utils/type-guards.js';
@@ -13,6 +14,7 @@ export const borderWidthRule = tokenRule<BorderWidthOptions>({
   meta: {
     description: 'enforce border-width tokens',
     category: 'design-token',
+    schema: z.object({ units: z.array(z.string()).optional() }).optional(),
   },
   tokens: 'dimension',
   message:

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -2,6 +2,7 @@ import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
 import colorName from 'color-name';
+import { z } from 'zod';
 import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
 
@@ -40,7 +41,30 @@ interface ColorRuleOptions {
 
 export const colorsRule = tokenRule<ColorRuleOptions>({
   name: 'design-token/colors',
-  meta: { description: 'disallow raw colors', category: 'design-token' },
+  meta: {
+    description: 'disallow raw colors',
+    category: 'design-token',
+    schema: z
+      .object({
+        allow: z
+          .array(
+            z.enum([
+              'hex',
+              'rgb',
+              'rgba',
+              'hsl',
+              'hsla',
+              'hwb',
+              'lab',
+              'lch',
+              'color',
+              'named',
+            ]),
+          )
+          .optional(),
+      })
+      .optional(),
+  },
   tokens: 'color',
   message:
     'design-token/colors requires color tokens; configure tokens with $type "color" to enable this rule.',

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -1,5 +1,6 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
+import { z } from 'zod';
 import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
 
@@ -10,7 +11,16 @@ interface SpacingOptions {
 
 export const spacingRule = tokenRule<SpacingOptions>({
   name: 'design-token/spacing',
-  meta: { description: 'enforce spacing scale', category: 'design-token' },
+  meta: {
+    description: 'enforce spacing scale',
+    category: 'design-token',
+    schema: z
+      .object({
+        base: z.number().optional(),
+        units: z.array(z.string()).optional(),
+      })
+      .optional(),
+  },
   tokens: 'dimension',
   message:
     'design-token/spacing requires spacing tokens; configure tokens with $type "dimension" under a "spacing" group to enable this rule.',

--- a/src/rules/utils/token-rule.ts
+++ b/src/rules/utils/token-rule.ts
@@ -4,12 +4,14 @@ import type {
   RuleListener,
   RuleModule,
 } from '../../core/types.js';
+import { z } from 'zod';
 
 interface TokenRuleConfig<TOptions, TAllowed> {
   name: string;
   meta: {
     description: string;
     category?: string;
+    schema?: z.ZodType;
   };
   tokens: string | string[];
   message: string;
@@ -34,7 +36,7 @@ export function tokenRule<TOptions = unknown, TAllowed = Set<unknown>>(
 ): RuleModule<TOptions> {
   return {
     name: config.name,
-    meta: config.meta,
+    meta: { ...config.meta, schema: config.meta.schema ?? z.void() },
     create(context) {
       const types = Array.isArray(config.tokens)
         ? config.tokens

--- a/src/rules/variant-prop.ts
+++ b/src/rules/variant-prop.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { z } from 'zod';
 import type { RuleModule } from '../core/types.js';
 
 interface VariantPropOptions {
@@ -12,6 +13,12 @@ export const variantPropRule: RuleModule<VariantPropOptions> = {
     description:
       'ensure specified components use allowed values for their variant prop',
     category: 'component',
+    schema: z
+      .object({
+        components: z.record(z.string(), z.array(z.string())).optional(),
+        prop: z.string().optional(),
+      })
+      .optional(),
   },
   create(context) {
     const { components = {}, prop: propName = 'variant' } =

--- a/tests/core/rule-registry.test.ts
+++ b/tests/core/rule-registry.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RuleRegistry } from '../../src/core/rule-registry.ts';
 import type { Config } from '../../src/core/linter.ts';
+import { ConfigError } from '../../src/core/errors.ts';
 
 void test('RuleRegistry enables configured rules', async () => {
   const config: Config = {
@@ -14,4 +15,22 @@ void test('RuleRegistry enables configured rules', async () => {
   assert.equal(enabled.length, 1);
   assert.equal(enabled[0].rule.name, 'design-token/colors');
   assert.equal(enabled[0].severity, 'warn');
+});
+
+void test('RuleRegistry validates rule options', async () => {
+  const config: Config = {
+    tokens: {},
+    rules: { 'design-system/component-prefix': ['error', { prefix: 123 }] },
+  };
+  const registry = new RuleRegistry(config);
+  await registry.load();
+  assert.throws(
+    () => registry.getEnabledRules(),
+    (err) => {
+      if (err instanceof ConfigError) {
+        return err.message.includes('Invalid options');
+      }
+      return false;
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- allow rules to define option schemas
- validate rule options against schemas
- document schema usage for rule authors

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2c2df288c8328942554522fd050c3