### PR TITLE
feat: add plugin metadata and init hooks

### DIFF
--- a/.changeset/plugin-metadata-init.md
+++ b/.changeset/plugin-metadata-init.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+add plugin metadata and initialization hook support

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -16,7 +16,7 @@ Plugins let you package and share rules, formatters, and other extensions. This 
 - [See also](#see-also)
 
 ## Overview
-A plugin is an npm package that exports an object with a `rules` array. The package name forms the rule namespace: `<plugin>/<rule>`.
+A plugin is an npm package that exports an object with a `rules` array. Plugins may also include optional `name`, `version`, and an `init(env)` function for one-time setup. The package name forms the rule namespace: `<plugin>/<rule>`.
 
 > **Note:** Declare `@lapidist/design-lint` as a `peerDependency` to ensure users install a compatible version.
 
@@ -62,6 +62,8 @@ const noRawColors: RuleModule<unknown> = {
 };
 
 export default {
+  name: 'design-lint-plugin-acme',
+  version: '1.0.0',
   rules: [noRawColors],
 };
 ```
@@ -88,18 +90,21 @@ const rule: RuleModule<{ ignore?: string[] }> = {
 
 ### 3. Register token transforms
 If your plugin consumes design tokens from other tools, provide a transform
-to convert them to the W3C format. Register the transform during plugin
-initialisation:
+to convert them to the W3C format. Register the transform in the plugin's
+`init` function:
 
 ```ts
 import { registerTokenTransform, type DesignTokens } from '@lapidist/design-lint';
 
-export function setup(): void {
-  const unregister = registerTokenTransform((tokens: DesignTokens) =>
-    convertFromFigma(tokens),
-  );
-  // call unregister() during teardown if the transform is temporary
-}
+export default {
+  rules: [],
+  init() {
+    const unregister = registerTokenTransform((tokens: DesignTokens) =>
+      convertFromFigma(tokens),
+    );
+    // call unregister() during teardown if the transform is temporary
+  },
+};
 
 function convertFromFigma(tokens: DesignTokens): DesignTokens {
   // convert tokens here

--- a/src/adapters/node/plugin-loader.ts
+++ b/src/adapters/node/plugin-loader.ts
@@ -70,7 +70,13 @@ function resolvePlugin(mod: unknown): PluginModule {
 }
 
 function isPluginModule(value: unknown): value is PluginModule {
-  return isRecord(value) && Array.isArray(value.rules);
+  return (
+    isRecord(value) &&
+    Array.isArray(value.rules) &&
+    (value.name === undefined || typeof value.name === 'string') &&
+    (value.version === undefined || typeof value.version === 'string') &&
+    (value.init === undefined || typeof value.init === 'function')
+  );
 }
 
 function getErrorCode(e: unknown): string | undefined {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,6 +12,7 @@ export type {
   LintDocument,
 } from './environment.js';
 export type { PluginLoader, LoadedPlugin } from './plugin-loader.js';
+export type { PluginInfo } from './plugin-manager.js';
 export type { CacheProvider, CacheEntry } from './cache-provider.js';
 export type {
   LintResult,

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -91,7 +91,7 @@ export class Linter {
         tokens: inlineTokens ?? {},
       };
       deps = {
-        ruleRegistry: new RuleRegistry(resolvedConfig, env.pluginLoader),
+        ruleRegistry: new RuleRegistry(resolvedConfig, env),
         tokenTracker: new TokenTracker(provider),
         tokensReady: provider.load(),
       };
@@ -169,6 +169,10 @@ export class Linter {
 
   async getPluginPaths(): Promise<string[]> {
     return this.ruleRegistry.getPluginPaths();
+  }
+
+  async getPlugins(): Promise<import('./plugin-manager.js').PluginInfo[]> {
+    return this.ruleRegistry.getPlugins();
   }
 
   private async lintText(

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -1,32 +1,43 @@
 import type { Config } from './linter.js';
-import type { RuleModule } from './types.js';
+import type { RuleModule, PluginModule } from './types.js';
 import type { PluginLoader } from './plugin-loader.js';
+import type { Environment } from './environment.js';
 import { PluginError } from './errors.js';
 import { isRecord } from '../utils/type-guards.js';
 
+export interface PluginInfo {
+  path: string;
+  name?: string;
+  version?: string;
+}
+
 export class PluginManager {
-  private pluginPaths: string[] = [];
+  private plugins: PluginInfo[] = [];
 
   constructor(
     private config: Config,
     private ruleMap: Map<string, { rule: RuleModule; source: string }>,
     private loader: PluginLoader,
+    private env: Environment,
   ) {}
 
-  async getPlugins(): Promise<string[]> {
-    if (this.pluginPaths.length > 0) return this.pluginPaths;
+  async getPlugins(): Promise<PluginInfo[]> {
+    if (this.plugins.length > 0) return this.plugins;
     const names = this.config.plugins ?? [];
     for (const name of names) {
       const { path: pluginSource, plugin } = await this.loader.load(
         name,
         this.config.configPath,
       );
-      if (!isRecord(plugin) || !Array.isArray(plugin.rules)) {
+      if (!isPluginModule(plugin)) {
         throw new PluginError({
           message: `Invalid plugin "${pluginSource}": expected { rules: RuleModule[] }`,
           context: `Plugin "${pluginSource}"`,
           remediation: 'Export an object with a "rules" array.',
         });
+      }
+      if (typeof plugin.init === 'function') {
+        await plugin.init(this.env);
       }
       for (const rule of plugin.rules) {
         if (!isRuleModule(rule)) {
@@ -50,9 +61,13 @@ export class PluginManager {
         }
         this.ruleMap.set(rule.name, { rule, source: pluginSource });
       }
-      this.pluginPaths.push(pluginSource);
+      this.plugins.push({
+        path: pluginSource,
+        name: plugin.name,
+        version: plugin.version,
+      });
     }
-    return this.pluginPaths;
+    return this.plugins;
   }
 }
 
@@ -71,5 +86,15 @@ function isRuleModule(value: unknown): value is RuleModule {
     typeof value.meta.description === 'string' &&
     value.meta.description.trim() !== '' &&
     typeof value.create === 'function'
+  );
+}
+
+function isPluginModule(value: unknown): value is PluginModule {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.rules) &&
+    (value.name === undefined || typeof value.name === 'string') &&
+    (value.version === undefined || typeof value.version === 'string') &&
+    (value.init === undefined || typeof value.init === 'function')
   );
 }

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -29,7 +29,7 @@ export function setupLinter(
     tokens: inlineTokens ?? {},
   };
   const tokensReady = provider.load();
-  const ruleRegistry = new RuleRegistry(resolvedConfig, env.pluginLoader);
+  const ruleRegistry = new RuleRegistry(resolvedConfig, env);
   const tokenTracker = new TokenTracker(provider);
   const linter = new Linter(resolvedConfig, {
     ruleRegistry,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,6 @@
 import type ts from 'typescript';
 import type { z } from 'zod';
+import type { Environment } from './environment.js';
 
 export interface VariableDefinition {
   id: string;
@@ -92,7 +93,10 @@ export interface RuleListener {
 }
 
 export interface PluginModule {
+  name?: string;
+  version?: string;
   rules: RuleModule[];
+  init?(env: Environment): void | Promise<void>;
 }
 
 export interface CSSDeclaration {

--- a/tests/fixtures/init-plugin.ts
+++ b/tests/fixtures/init-plugin.ts
@@ -1,0 +1,17 @@
+import type { PluginModule } from '../../src/core/types.ts';
+import type { Environment } from '../../src/core/environment.ts';
+
+export let initCount = 0;
+export let receivedEnv: Environment | undefined;
+
+const plugin: PluginModule = {
+  name: 'init-plugin',
+  version: '0.1.0',
+  rules: [],
+  init(env) {
+    initCount++;
+    receivedEnv = env;
+  },
+};
+
+export default plugin;

--- a/tests/fixtures/test-plugin.ts
+++ b/tests/fixtures/test-plugin.ts
@@ -18,6 +18,8 @@ const rule: RuleModule<unknown> = {
 };
 
 const plugin: PluginModule = {
+  name: 'test-plugin',
+  version: '1.0.0',
   rules: [rule],
 };
 


### PR DESCRIPTION
## Summary
- allow plugins to declare name/version and an init(env) hook
- track and expose plugin metadata through the linter
- document plugin initialization and add tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2c73051cc83289b54dd8b6afe1dac