### PR TITLE
fix(core): initialize plugins before loading tokens

### DIFF
--- a/.changeset/init-plugins-before-tokens.md
+++ b/.changeset/init-plugins-before-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+ensure plugin init runs before token loading

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -91,10 +91,12 @@ export class Linter {
         ...config,
         tokens: inlineTokens ?? {},
       };
+      const ruleRegistry = new RuleRegistry(resolvedConfig, env);
+      const tokenTracker = new TokenTracker(provider);
       deps = {
-        ruleRegistry: new RuleRegistry(resolvedConfig, env),
-        tokenTracker: new TokenTracker(provider),
-        tokensReady: provider.load(),
+        ruleRegistry,
+        tokenTracker,
+        tokensReady: ruleRegistry.load().then(() => provider.load()),
       };
     } else {
       deps = depsOrEnv;
@@ -132,8 +134,8 @@ export class Linter {
     ignoreFiles: string[];
     warning?: string;
   }> {
-    await this.tokensReady;
     await this.ruleRegistry.load();
+    await this.tokensReady;
     const runner = new Runner({
       config: this.config,
       tokenTracker: this.tokenTracker,
@@ -196,8 +198,8 @@ export class Linter {
     docType?: string,
     metadata?: Record<string, unknown>,
   ): Promise<LintResult> {
-    await this.tokensReady;
     await this.ruleRegistry.load();
+    await this.tokensReady;
     const enabled = this.ruleRegistry.getEnabledRules();
     await this.tokenTracker.configure(enabled);
     if (this.tokenTracker.hasUnusedTokenRules()) {

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -28,9 +28,9 @@ export function setupLinter(
     ...config,
     tokens: inlineTokens ?? {},
   };
-  const tokensReady = provider.load();
   const ruleRegistry = new RuleRegistry(resolvedConfig, env);
   const tokenTracker = new TokenTracker(provider);
+  const tokensReady = ruleRegistry.load().then(() => provider.load());
   const linter = new Linter(resolvedConfig, {
     ruleRegistry,
     tokenTracker,

--- a/tests/fixtures/token-transform-plugin.ts
+++ b/tests/fixtures/token-transform-plugin.ts
@@ -1,0 +1,21 @@
+import type { PluginModule, DesignTokens, TokenGroup } from '../../src/core/types.ts';
+import { registerTokenTransform } from '../../src/core/index.ts';
+
+const plugin: PluginModule = {
+  rules: [],
+  init() {
+    registerTokenTransform((tokens: DesignTokens) => {
+      const { color, ...rest } = tokens;
+      const colors = (typeof color === 'object' && color !== null ? color : {}) as TokenGroup;
+      return {
+        ...rest,
+        color: {
+          ...colors,
+          blue: { $type: 'color', $value: '#00f' },
+        },
+      };
+    });
+  },
+};
+
+export default plugin;

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -241,3 +241,21 @@ void test('exposes plugin metadata', async () => {
     { path: pluginPath, name: 'init-plugin', version: '1.0.0' },
   ]);
 });
+
+void test('plugin init can transform tokens before load', async () => {
+  const pluginPath = path.join(
+    __dirname,
+    'fixtures',
+    'token-transform-plugin.ts',
+  );
+  const linter = initLinter(
+    {
+      plugins: [pluginPath],
+      tokens: { color: { red: { $type: 'color', $value: '#f00' } } },
+    },
+    { documentSource: new FileSource(), pluginLoader: new NodePluginLoader() },
+  );
+  await linter.lintText('const a = 1;', 'file.ts');
+  const completions = linter.getTokenCompletions();
+  assert.ok(completions.default.includes('color.blue'));
+});


### PR DESCRIPTION
## Summary
- ensure plugin init runs before token loading by awaiting plugins first
- adjust setup helper accordingly and test plugin token transforms
- document change with changeset

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2cf2f88cc8328b633f224aa06692b