### PR TITLE
refactor(core): reuse type guard helpers

### DIFF
--- a/.changeset/add-is-object-helper.md
+++ b/.changeset/add-is-object-helper.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": patch
+---
+
+refactor: add isObject helper and reuse type guards

--- a/src/cli/init-config.ts
+++ b/src/cli/init-config.ts
@@ -1,12 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import writeFileAtomic from 'write-file-atomic';
+import { isRecord } from '../utils/type-guards.js';
 
 const supported = new Set(['json', 'js', 'cjs', 'mjs', 'ts', 'mts']);
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 export function detectInitFormat(initFormat?: string): string {
   if (initFormat && !supported.has(initFormat)) {
@@ -26,15 +23,11 @@ export function detectInitFormat(initFormat?: string): string {
           const pkgText = fs.readFileSync(pkgPath, 'utf8');
           const pkgData: unknown = JSON.parse(pkgText);
           if (isRecord(pkgData)) {
-            const deps = isRecord(pkgData.dependencies)
-              ? pkgData.dependencies
-              : undefined;
-            const devDeps = isRecord(pkgData.devDependencies)
-              ? pkgData.devDependencies
-              : undefined;
             if (
-              (deps && 'typescript' in deps) ||
-              (devDeps && 'typescript' in devDeps)
+              (isRecord(pkgData.dependencies) &&
+                'typescript' in pkgData.dependencies) ||
+              (isRecord(pkgData.devDependencies) &&
+                'typescript' in pkgData.devDependencies)
             ) {
               format = 'ts';
             }

--- a/src/core/framework-parsers/css-parser.ts
+++ b/src/core/framework-parsers/css-parser.ts
@@ -2,6 +2,7 @@ import postcss from 'postcss';
 import { parse as scssParser } from 'postcss-scss';
 import lessSyntax from 'postcss-less';
 import type { CSSDeclaration, LintMessage, RuleModule } from '../types.js';
+import { isObject } from '../../utils/type-guards.js';
 
 export function parseCSS(
   text: string,
@@ -25,7 +26,8 @@ export function parseCSS(
       });
     });
   } catch (e: unknown) {
-    const err = isRecord(e) ? e : {};
+    const err: { message?: unknown; line?: unknown; column?: unknown } =
+      isObject(e) ? e : {};
     messages.push({
       ruleId: 'parse-error',
       message:
@@ -52,8 +54,4 @@ export function lintCSS(
   for (const decl of decls) {
     for (const l of listeners) l.onCSSDeclaration?.(decl);
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }

--- a/src/core/framework-parsers/svelte-parser.ts
+++ b/src/core/framework-parsers/svelte-parser.ts
@@ -2,6 +2,7 @@ import ts from 'typescript';
 import { parseCSS } from './css-parser.js';
 import type { CSSDeclaration, LintMessage, RuleModule } from '../types.js';
 import type { parse as svelteParse } from 'svelte/compiler';
+import { isRecord } from '../../utils/type-guards.js';
 
 export async function lintSvelte(
   text: string,
@@ -170,10 +171,6 @@ export async function lintSvelte(
       for (const l of listeners) l.onCSSDeclaration?.(decl);
     }
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 function isSvelteAttr(value: unknown): value is {

--- a/src/core/parser/parse-tree.ts
+++ b/src/core/parser/parse-tree.ts
@@ -4,6 +4,7 @@ import type {
   TokenGroup,
   FlattenedToken,
 } from '../types.js';
+import { isRecord } from '../../utils/type-guards.js';
 
 const tokenLocations = new Map<string, { line: number; column: number }>();
 
@@ -22,10 +23,6 @@ const GROUP_PROPS = new Set([
   '$metadata',
 ]);
 const INVALID_NAME_CHARS = /[{}\.]/;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function isToken(node: unknown): node is Token {
   return isRecord(node) && '$value' in node;

--- a/src/core/parser/validate.ts
+++ b/src/core/parser/validate.ts
@@ -1,9 +1,6 @@
 import type { Token, FlattenedToken } from '../types.js';
 import { validatorRegistry } from '../token-validators/index.js';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { isRecord } from '../../utils/type-guards.js';
 
 function validateExtensions(value: unknown, path: string): void {
   if (value === undefined) return;

--- a/src/core/token-validators/utils.ts
+++ b/src/core/token-validators/utils.ts
@@ -1,6 +1,6 @@
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { isRecord } from '../../utils/type-guards.js';
+
+export { isRecord };
 
 export function isArray(value: unknown): value is unknown[] {
   return Array.isArray(value);

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -1,7 +1,11 @@
 import type { DesignTokens } from '../core/types.js';
 
+export function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  return isObject(value) && !Array.isArray(value);
 }
 
 export function isDesignTokens(value: unknown): value is DesignTokens {


### PR DESCRIPTION
## Summary
- add shared `isObject` helper alongside `isRecord`
- replace local type guard implementations with shared helpers

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2cf568d248328bc9c5c718447d8db