### PR TITLE
refactor: centralize isRuleModule helper

### DIFF
--- a/.changeset/centralize-is-rule-module.md
+++ b/.changeset/centralize-is-rule-module.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": patch
+---
+
+refactor: centralize isRuleModule helper

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -3,6 +3,7 @@ import type { RuleModule } from './types.js';
 import type { PluginLoader } from './plugin-loader.js';
 import { PluginError } from './errors.js';
 import { isRecord } from '../utils/type-guards.js';
+import { isRuleModule } from '../rules/utils/is-rule-module.js';
 
 export class PluginManager {
   private pluginPaths: string[] = [];
@@ -29,7 +30,9 @@ export class PluginManager {
         });
       }
       for (const rule of plugin.rules) {
-        if (!isRuleModule(rule)) {
+        if (
+          !isRuleModule(rule, { requireMeta: true, requireNonEmptyName: true })
+        ) {
           const ruleName = getRuleName(rule) ?? '<unknown>';
           throw new PluginError({
             message:
@@ -60,16 +63,4 @@ function getRuleName(rule: unknown): string | undefined {
   return isRecord(rule) && typeof rule.name === 'string'
     ? rule.name
     : undefined;
-}
-
-function isRuleModule(value: unknown): value is RuleModule {
-  return (
-    isRecord(value) &&
-    typeof value.name === 'string' &&
-    value.name.trim() !== '' &&
-    isRecord(value.meta) &&
-    typeof value.meta.description === 'string' &&
-    value.meta.description.trim() !== '' &&
-    typeof value.create === 'function'
-  );
 }

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,15 +2,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { globby } from 'globby';
 import type { RuleModule } from '../core/types.js';
-
-function isRuleModule(value: unknown): value is RuleModule {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  const name: unknown = Reflect.get(value, 'name');
-  const create: unknown = Reflect.get(value, 'create');
-  return typeof name === 'string' && typeof create === 'function';
-}
+import { isRuleModule } from './utils/is-rule-module.js';
 
 const ruleDir = path.dirname(fileURLToPath(import.meta.url));
 const ruleFiles = await globby('*.{ts,js}', {
@@ -25,7 +17,7 @@ const modules = await Promise.all(
     if (typeof mod === 'object' && mod !== null) {
       values = Object.values(mod);
     }
-    return values.filter(isRuleModule);
+    return values.filter((value): value is RuleModule => isRuleModule(value));
   }),
 );
 

--- a/src/rules/utils/is-rule-module.ts
+++ b/src/rules/utils/is-rule-module.ts
@@ -1,0 +1,28 @@
+import type { RuleModule } from '../../core/types.js';
+import { isRecord } from '../../utils/type-guards.js';
+
+export interface IsRuleModuleOptions {
+  requireMeta?: boolean;
+  requireNonEmptyName?: boolean;
+}
+
+export function isRuleModule(
+  value: unknown,
+  options: IsRuleModuleOptions = {},
+): value is RuleModule {
+  if (!isRecord(value)) return false;
+  const { requireMeta = false, requireNonEmptyName = false } = options;
+  if (typeof value.name !== 'string') return false;
+  if (requireNonEmptyName && value.name.trim() === '') return false;
+  if (typeof value.create !== 'function') return false;
+  if (requireMeta) {
+    if (
+      !isRecord(value.meta) ||
+      typeof value.meta.description !== 'string' ||
+      value.meta.description.trim() === ''
+    ) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add shared `isRuleModule` helper for configurable validation
- reuse helper in core plugin manager and rule index

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2cf5a07908328a04422ed340ba5d3