### PR TITLE
refactor: share color format utilities

### DIFF
--- a/.changeset/shared-color-format-utils.md
+++ b/.changeset/shared-color-format-utils.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor color format utilities into shared module
+

--- a/src/rules/token-border-color.ts
+++ b/src/rules/token-border-color.ts
@@ -1,36 +1,7 @@
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
-import colorName from 'color-name';
 import { tokenRule } from './utils/token-rule.js';
-
-type ColorFormat =
-  | 'hex'
-  | 'rgb'
-  | 'rgba'
-  | 'hsl'
-  | 'hsla'
-  | 'hwb'
-  | 'lab'
-  | 'lch'
-  | 'color'
-  | 'named';
-
-const namedColors = new Set(Object.keys(colorName));
-
-function detectFormat(value: string): ColorFormat | null {
-  const v = value.toLowerCase();
-  if (v.startsWith('#')) return 'hex';
-  if (v.startsWith('rgba(')) return 'rgba';
-  if (v.startsWith('rgb(')) return 'rgb';
-  if (v.startsWith('hsla(')) return 'hsla';
-  if (v.startsWith('hsl(')) return 'hsl';
-  if (v.startsWith('hwb(')) return 'hwb';
-  if (v.startsWith('lab(')) return 'lab';
-  if (v.startsWith('lch(')) return 'lch';
-  if (v.startsWith('color(')) return 'color';
-  if (namedColors.has(v)) return 'named';
-  return null;
-}
+import { detectColorFormat } from './utils/color-format.js';
 
 export const borderColorRule = tokenRule({
   name: 'design-token/border-color',
@@ -59,7 +30,7 @@ export const borderColorRule = tokenRule({
         if (/^border(-(top|right|bottom|left))?-color$/.test(decl.prop)) {
           valueParser(decl.value).walk((node) => {
             const value = valueParser.stringify(node);
-            const format = detectFormat(value);
+            const format = detectColorFormat(value);
             if (!format) return;
             if (format !== 'named' && !colorString.get(value)) return;
             if (!allowed.has(value.toLowerCase())) {

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -1,39 +1,10 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
-import colorName from 'color-name';
 import { z } from 'zod';
 import { tokenRule } from './utils/token-rule.js';
 import { isStyleValue } from '../utils/style.js';
-
-type ColorFormat =
-  | 'hex'
-  | 'rgb'
-  | 'rgba'
-  | 'hsl'
-  | 'hsla'
-  | 'hwb'
-  | 'lab'
-  | 'lch'
-  | 'color'
-  | 'named';
-
-const namedColors = new Set(Object.keys(colorName));
-
-function detectFormat(value: string): ColorFormat | null {
-  const v = value.toLowerCase();
-  if (v.startsWith('#')) return 'hex';
-  if (v.startsWith('rgba(')) return 'rgba';
-  if (v.startsWith('rgb(')) return 'rgb';
-  if (v.startsWith('hsla(')) return 'hsla';
-  if (v.startsWith('hsl(')) return 'hsl';
-  if (v.startsWith('hwb(')) return 'hwb';
-  if (v.startsWith('lab(')) return 'lab';
-  if (v.startsWith('lch(')) return 'lch';
-  if (v.startsWith('color(')) return 'color';
-  if (namedColors.has(v)) return 'named';
-  return null;
-}
+import { detectColorFormat, type ColorFormat } from './utils/color-format.js';
 
 interface ColorRuleOptions {
   allow?: ColorFormat[];
@@ -97,7 +68,7 @@ export const colorsRule = tokenRule<ColorRuleOptions>({
       const parsed = valueParser(text);
       parsed.walk((node) => {
         const value = valueParser.stringify(node);
-        const format = detectFormat(value);
+        const format = detectColorFormat(value);
         if (!format || allowFormats.has(format)) return;
         if (parserFormats.has(format) && !colorString.get(value)) return;
         if (!allowed.has(value.toLowerCase())) {

--- a/src/rules/utils/color-format.ts
+++ b/src/rules/utils/color-format.ts
@@ -1,0 +1,30 @@
+import colorName from 'color-name';
+
+export type ColorFormat =
+  | 'hex'
+  | 'rgb'
+  | 'rgba'
+  | 'hsl'
+  | 'hsla'
+  | 'hwb'
+  | 'lab'
+  | 'lch'
+  | 'color'
+  | 'named';
+
+export const namedColors = new Set(Object.keys(colorName));
+
+export function detectColorFormat(value: string): ColorFormat | null {
+  const v = value.toLowerCase();
+  if (v.startsWith('#')) return 'hex';
+  if (v.startsWith('rgba(')) return 'rgba';
+  if (v.startsWith('rgb(')) return 'rgb';
+  if (v.startsWith('hsla(')) return 'hsla';
+  if (v.startsWith('hsl(')) return 'hsl';
+  if (v.startsWith('hwb(')) return 'hwb';
+  if (v.startsWith('lab(')) return 'lab';
+  if (v.startsWith('lch(')) return 'lch';
+  if (v.startsWith('color(')) return 'color';
+  if (namedColors.has(v)) return 'named';
+  return null;
+}


### PR DESCRIPTION
## Summary
- extract color format detection and named color list into shared utility
- update color-related rules to use shared color format utilities

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2cf58903483289e50d095aac992df