### PR TITLE
test: avoid writing files

### DIFF
--- a/.changeset/avoid-test-files.md
+++ b/.changeset/avoid-test-files.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+avoid writing files during tests

--- a/tests/core/linter-integration.test.ts
+++ b/tests/core/linter-integration.test.ts
@@ -1,7 +1,5 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import { createLinter as initLinter } from '../../src/index.ts';
 import { createNodeEnvironment } from '../../src/adapters/node/environment.ts';
 
@@ -12,10 +10,6 @@ void test('Linter integrates registry, parser and trackers', async () => {
   };
   const env = createNodeEnvironment(config);
   const linter = initLinter(config, env);
-  const dir = await fs.mkdtemp(path.join(process.cwd(), 'linter-int-'));
-  const file = path.join(dir, 'file.css');
-  await fs.writeFile(file, 'a{color:#fff;}');
-  const { results } = await linter.lintTargets([file]);
-  const res = results[0];
+  const res = await linter.lintText('a{color:#fff;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });


### PR DESCRIPTION
## Summary
- use in-memory documents for linter integration and runner tests
- refactor no-unused-tokens tests to avoid temp files
- add changeset for test cleanup

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2de9cf9748328a8adba26b3a742a6