### PR TITLE
build(tsconfig): use bundler resolution and drop .js imports

### DIFF
--- a/.changeset/remove-js-import-extensions.md
+++ b/.changeset/remove-js-import-extensions.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+use bundler module resolution and drop .js extensions from imports

--- a/src/adapters/node/environment.ts
+++ b/src/adapters/node/environment.ts
@@ -1,9 +1,9 @@
-import type { Environment } from '../../core/environment.js';
-import type { Config } from '../../core/linter.js';
-import { FileSource } from './file-source.js';
-import { NodePluginLoader } from './plugin-loader.js';
-import { NodeCacheProvider } from './node-cache-provider.js';
-import { NodeTokenProvider } from './token-provider.js';
+import type { Environment } from '../../core/environment';
+import type { Config } from '../../core/linter';
+import { FileSource } from './file-source';
+import { NodePluginLoader } from './plugin-loader';
+import { NodeCacheProvider } from './node-cache-provider';
+import { NodeTokenProvider } from './token-provider';
 
 export interface CreateNodeEnvironmentOptions {
   cacheLocation?: string;

--- a/src/adapters/node/file-document.ts
+++ b/src/adapters/node/file-document.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import type { LintDocument } from '../../core/environment.js';
+import type { LintDocument } from '../../core/environment';
 
 export function createFileDocument(sourceId: string): LintDocument {
   const absPath = path.resolve(sourceId);

--- a/src/adapters/node/file-source.ts
+++ b/src/adapters/node/file-source.ts
@@ -1,11 +1,11 @@
 import { globby } from 'globby';
 import { performance } from 'node:perf_hooks';
-import { realpathIfExists } from './utils/paths.js';
-import { getIgnorePatterns } from '../../core/ignore.js';
-import type { Config } from '../../core/linter.js';
-import type { DocumentSource } from '../../core/environment.js';
-import { createFileDocument } from './file-document.js';
-import { defaultPatterns } from '../../core/file-types.js';
+import { realpathIfExists } from './utils/paths';
+import { getIgnorePatterns } from '../../core/ignore';
+import type { Config } from '../../core/linter';
+import type { DocumentSource } from '../../core/environment';
+import { createFileDocument } from './file-document';
+import { defaultPatterns } from '../../core/file-types';
 
 export class FileSource implements DocumentSource {
   async scan(

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -1,10 +1,10 @@
-export { FileSource } from './file-source.js';
-export { createFileDocument } from './file-document.js';
-export { NodePluginLoader } from './plugin-loader.js';
-export { NodeCacheProvider } from './node-cache-provider.js';
-export { createNodeEnvironment } from './environment.js';
+export { FileSource } from './file-source';
+export { createFileDocument } from './file-document';
+export { NodePluginLoader } from './plugin-loader';
+export { NodeCacheProvider } from './node-cache-provider';
+export { createNodeEnvironment } from './environment';
 export {
   parseDesignTokensFile,
   readDesignTokensFile,
   TokenParseError,
-} from './token-parser.js';
+} from './token-parser';

--- a/src/adapters/node/node-cache-provider.ts
+++ b/src/adapters/node/node-cache-provider.ts
@@ -1,6 +1,6 @@
 import flatCache, { type FlatCache } from 'flat-cache';
 import path from 'path';
-import type { CacheProvider, CacheEntry } from '../../core/cache-provider.js';
+import type { CacheProvider, CacheEntry } from '../../core/cache-provider';
 
 export class NodeCacheProvider implements CacheProvider {
   private cache: FlatCache;

--- a/src/adapters/node/plugin-loader.ts
+++ b/src/adapters/node/plugin-loader.ts
@@ -2,11 +2,11 @@ import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
 import { pathToFileURL } from 'url';
-import { realpathIfExists, relFromCwd } from './utils/paths.js';
-import type { PluginModule } from '../../core/types.js';
-import type { PluginLoader, LoadedPlugin } from '../../core/plugin-loader.js';
-import { PluginError } from '../../core/errors.js';
-import { isRecord } from '../../utils/is-record.js';
+import { realpathIfExists, relFromCwd } from './utils/paths';
+import type { PluginModule } from '../../core/types';
+import type { PluginLoader, LoadedPlugin } from '../../core/plugin-loader';
+import { PluginError } from '../../core/errors';
+import { isRecord } from '../../utils/is-record';
 
 export class NodePluginLoader implements PluginLoader {
   async load(p: string, configPath?: string): Promise<LoadedPlugin> {

--- a/src/adapters/node/token-parser.ts
+++ b/src/adapters/node/token-parser.ts
@@ -8,11 +8,11 @@ import {
   type DocumentNode,
 } from '@humanwhocodes/momoa';
 import yamlToMomoa from 'yaml-to-momoa';
-import type { DesignTokens, FlattenedToken } from '../../core/types.js';
+import type { DesignTokens, FlattenedToken } from '../../core/types';
 import {
   parseDesignTokens,
   type ParseDesignTokensOptions,
-} from '../../core/parser/index.js';
+} from '../../core/parser/index';
 
 export class TokenParseError extends Error {
   filePath: string;

--- a/src/adapters/node/token-provider.ts
+++ b/src/adapters/node/token-provider.ts
@@ -1,8 +1,8 @@
-import type { VariableProvider } from '../../core/environment.js';
-import type { DesignTokens } from '../../core/types.js';
-import type { Config } from '../../core/linter.js';
-import { isDesignTokens } from '../../utils/is-design-tokens.js';
-import { isThemeRecord } from '../../utils/is-theme-record.js';
+import type { VariableProvider } from '../../core/environment';
+import type { DesignTokens } from '../../core/types';
+import type { Config } from '../../core/linter';
+import { isDesignTokens } from '../../utils/is-design-tokens';
+import { isThemeRecord } from '../../utils/is-theme-record';
 
 export class NodeTokenProvider implements VariableProvider {
   private tokens: Record<string, DesignTokens>;

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import ignore, { type Ignore } from 'ignore';
-import { getFormatter } from '../formatters/index.js';
-import type { CacheProvider } from '../core/cache-provider.js';
-import type { Config } from '../core/linter.js';
-import type { Linter } from '../index.js';
-import type { LintResult } from '../core/types.js';
-import { createNodeEnvironment } from '../adapters/node/environment.js';
-import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths.js';
+import { getFormatter } from '../formatters/index';
+import type { CacheProvider } from '../core/cache-provider';
+import type { Config } from '../core/linter';
+import type { Linter } from '../index';
+import type { LintResult } from '../core/types';
+import { createNodeEnvironment } from '../adapters/node/environment';
+import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths';
 
 export interface Environment {
   formatter: (results: LintResult[], useColor?: boolean) => string;
@@ -43,9 +43,9 @@ export async function prepareEnvironment(
   options: PrepareEnvironmentOptions,
 ): Promise<Environment> {
   const [{ loadConfig }, { createLinter }, { loadIgnore }] = await Promise.all([
-    import('../config/loader.js'),
-    import('../index.js'),
-    import('../core/ignore.js'),
+    import('../config/loader'),
+    import('../index'),
+    import('../core/ignore'),
   ]);
 
   const formatter = await getFormatter(options.format);

--- a/src/cli/execute.ts
+++ b/src/cli/execute.ts
@@ -1,8 +1,8 @@
 import { performance } from 'node:perf_hooks';
 import chalk from 'chalk';
 import writeFileAtomic from 'write-file-atomic';
-import type { LintResult } from '../core/types.js';
-import type { Linter } from '../core/linter.js';
+import type { LintResult } from '../core/types';
+import type { Linter } from '../core/linter';
 
 export interface ExecuteOptions {
   fix?: boolean;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,13 +3,13 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { Command } from 'commander';
 import chalk, { supportsColor } from 'chalk';
-import { TokenParseError } from '../adapters/node/token-parser.js';
-import { isRecord } from '../utils/is-record.js';
-import { prepareEnvironment, type PrepareEnvironmentOptions } from './env.js';
-import { executeLint, type ExecuteOptions } from './execute.js';
-import { watchMode } from './watch.js';
-import { initConfig } from './init-config.js';
-import { exportTokens } from './tokens.js';
+import { TokenParseError } from '../adapters/node/token-parser';
+import { isRecord } from '../utils/is-record';
+import { prepareEnvironment, type PrepareEnvironmentOptions } from './env';
+import { executeLint, type ExecuteOptions } from './execute';
+import { watchMode } from './watch';
+import { initConfig } from './init-config';
+import { exportTokens } from './tokens';
 
 type CliOptions = ExecuteOptions &
   PrepareEnvironmentOptions & {

--- a/src/cli/init-config.ts
+++ b/src/cli/init-config.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import writeFileAtomic from 'write-file-atomic';
-import { isRecord } from '../utils/is-record.js';
+import { isRecord } from '../utils/is-record';
 
 const supported = new Set(['json', 'js', 'cjs', 'mjs', 'ts', 'mts']);
 

--- a/src/cli/tokens.ts
+++ b/src/cli/tokens.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { loadConfig } from '../config/loader.js';
-import { getFlattenedTokens } from '../core/token-utils.js';
-import type { DesignTokens } from '../core/types.js';
-import { isDesignTokens } from '../utils/is-design-tokens.js';
-import { isThemeRecord } from '../utils/is-theme-record.js';
+import { loadConfig } from '../config/loader';
+import { getFlattenedTokens } from '../core/token-utils';
+import type { DesignTokens } from '../core/types';
+import { isDesignTokens } from '../utils/is-design-tokens';
+import { isThemeRecord } from '../utils/is-theme-record';
 
 interface TokensCommandOptions {
   theme?: string;

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -4,19 +4,19 @@ import { once } from 'node:events';
 import { createRequire } from 'module';
 import chokidar from 'chokidar';
 import chalk from 'chalk';
-import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths.js';
-import { loadConfig } from '../config/loader.js';
-import { createLinter } from '../index.js';
-import type { Config } from '../core/linter.js';
-import type { Linter } from '../index.js';
-import { createNodeEnvironment } from '../adapters/node/environment.js';
-import type { CacheProvider } from '../core/cache-provider.js';
+import { relFromCwd, realpathIfExists } from '../adapters/node/utils/paths';
+import { loadConfig } from '../config/loader';
+import { createLinter } from '../index';
+import type { Config } from '../core/linter';
+import type { Linter } from '../index';
+import { createNodeEnvironment } from '../adapters/node/environment';
+import type { CacheProvider } from '../core/cache-provider';
 import type { Ignore } from 'ignore';
 import {
   executeLint,
   type ExecuteServices,
   type ExecuteOptions,
-} from './execute.js';
+} from './execute';
 
 export interface WatchState {
   pluginPaths: string[];

--- a/src/config/config-token-provider.ts
+++ b/src/config/config-token-provider.ts
@@ -1,7 +1,7 @@
-import type { Config } from '../core/linter.js';
-import { parseDesignTokens } from '../core/parser/index.js';
-import { isDesignTokens } from '../utils/is-design-tokens.js';
-import { isThemeRecord } from '../utils/is-theme-record.js';
+import type { Config } from '../core/linter';
+import { parseDesignTokens } from '../core/parser/index';
+import { isDesignTokens } from '../utils/is-design-tokens';
+import { isThemeRecord } from '../utils/is-theme-record';
 
 export class ConfigTokenProvider {
   private config: Config;

--- a/src/config/define-config.ts
+++ b/src/config/define-config.ts
@@ -1,4 +1,4 @@
-import type { Config } from '../core/linter.js';
+import type { Config } from '../core/linter';
 
 /**
  * Helper to define a configuration object with type checking.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
-import type { Config } from '../core/linter.js';
-import { configSchema } from './schema.js';
-import { realpathIfExists } from '../adapters/node/utils/paths.js';
-import { resolveConfigFile } from './file-resolution.js';
-import { loadTokens } from './token-loader.js';
-import { isRecord } from '../utils/is-record.js';
-import { ConfigError } from '../core/errors.js';
+import type { Config } from '../core/linter';
+import { configSchema } from './schema';
+import { realpathIfExists } from '../adapters/node/utils/paths';
+import { resolveConfigFile } from './file-resolution';
+import { loadTokens } from './token-loader';
+import { isRecord } from '../utils/is-record';
+import { ConfigError } from '../core/errors';
 
 /**
  * Resolve and load configuration for the linter.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import { z } from 'zod';
-import type { Config } from '../core/linter.js';
-import type { DesignTokens } from '../core/types.js';
-import { isRecord } from '../utils/is-record.js';
+import type { Config } from '../core/linter';
+import type { DesignTokens } from '../core/types';
+import { isRecord } from '../utils/is-record';
 
 const severitySchema = z.union([
   z.literal('error'),

--- a/src/config/token-loader.ts
+++ b/src/config/token-loader.ts
@@ -2,11 +2,11 @@ import path from 'node:path';
 import {
   readDesignTokensFile,
   TokenParseError,
-} from '../adapters/node/token-parser.js';
-import { parseDesignTokens } from '../core/parser/index.js';
-import { isDesignTokens } from '../utils/is-design-tokens.js';
-import { isThemeRecord } from '../utils/is-theme-record.js';
-import { isRecord } from '../utils/is-record.js';
+} from '../adapters/node/token-parser';
+import { parseDesignTokens } from '../core/parser/index';
+import { isDesignTokens } from '../utils/is-design-tokens';
+import { isThemeRecord } from '../utils/is-theme-record';
+import { isRecord } from '../utils/is-record';
 
 export async function loadTokens(
   tokens: unknown,

--- a/src/core/apply-fixes.ts
+++ b/src/core/apply-fixes.ts
@@ -1,4 +1,4 @@
-import type { LintMessage, Fix } from './types.js';
+import type { LintMessage, Fix } from './types';
 
 export function applyFixes(text: string, messages: LintMessage[]): string {
   const fixes: Fix[] = messages

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -1,8 +1,8 @@
 import { stat, writeFile } from 'node:fs/promises';
-import type { CacheProvider } from './cache-provider.js';
-import type { LintResult } from './types.js';
-import type { LintDocument } from './environment.js';
-import { applyFixes } from './apply-fixes.js';
+import type { CacheProvider } from './cache-provider';
+import type { LintResult } from './types';
+import type { LintDocument } from './environment';
+import { applyFixes } from './apply-fixes';
 
 export class CacheManager {
   constructor(

--- a/src/core/cache-provider.ts
+++ b/src/core/cache-provider.ts
@@ -1,4 +1,4 @@
-import type { LintResult } from './types.js';
+import type { LintResult } from './types';
 
 export interface CacheEntry {
   mtime: number;

--- a/src/core/cache-service.ts
+++ b/src/core/cache-service.ts
@@ -1,5 +1,5 @@
-import type { CacheProvider } from './cache-provider.js';
-import { CacheManager } from './cache-manager.js';
+import type { CacheProvider } from './cache-provider';
+import { CacheManager } from './cache-manager';
 
 export const CacheService = {
   async prune(

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -1,7 +1,7 @@
-import type { Config } from './linter.js';
-import type { PluginLoader } from './plugin-loader.js';
-import type { CacheProvider } from './cache-provider.js';
-import type { DesignTokens } from './types.js';
+import type { Config } from './linter';
+import type { PluginLoader } from './plugin-loader';
+import type { CacheProvider } from './cache-provider';
+import type { DesignTokens } from './types';
 
 export interface LintDocument {
   id: string;

--- a/src/core/framework-parsers/css-parser.ts
+++ b/src/core/framework-parsers/css-parser.ts
@@ -1,8 +1,8 @@
 import postcss from 'postcss';
 import { parse as scssParser } from 'postcss-scss';
 import lessSyntax from 'postcss-less';
-import type { CSSDeclaration, LintMessage, RuleModule } from '../types.js';
-import { isObject } from '../../utils/is-object.js';
+import type { CSSDeclaration, LintMessage, RuleModule } from '../types';
+import { isObject } from '../../utils/is-object';
 
 export function parseCSS(
   text: string,

--- a/src/core/framework-parsers/svelte-parser.ts
+++ b/src/core/framework-parsers/svelte-parser.ts
@@ -1,8 +1,8 @@
 import ts from 'typescript';
-import { parseCSS } from './css-parser.js';
-import type { CSSDeclaration, LintMessage, RuleModule } from '../types.js';
+import { parseCSS } from './css-parser';
+import type { CSSDeclaration, LintMessage, RuleModule } from '../types';
 import type { parse as svelteParse } from 'svelte/compiler';
-import { isRecord } from '../../utils/is-record.js';
+import { isRecord } from '../../utils/is-record';
 
 export async function lintSvelte(
   text: string,

--- a/src/core/framework-parsers/ts-parser.ts
+++ b/src/core/framework-parsers/ts-parser.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
-import { parseCSS } from './css-parser.js';
-import type { RuleModule, LintMessage } from '../types.js';
+import { parseCSS } from './css-parser';
+import type { RuleModule, LintMessage } from '../types';
 
 export function lintTS(
   text: string,

--- a/src/core/framework-parsers/vue-parser.ts
+++ b/src/core/framework-parsers/vue-parser.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
-import { parseCSS } from './css-parser.js';
-import type { RuleModule, LintMessage } from '../types.js';
+import { parseCSS } from './css-parser';
+import type { RuleModule, LintMessage } from '../types';
 
 export async function lintVue(
   text: string,

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import ignore from 'ignore';
-import type { Config } from './linter.js';
+import type { Config } from './linter';
 
 export const defaultIgnore = [
   '**/node_modules/**',

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,19 +1,19 @@
-export { Linter, type Config } from './linter.js';
-export { LintService } from './lint-service.js';
-export { setupLinter } from './setup.js';
-export { applyFixes } from './apply-fixes.js';
-export { Runner } from './runner.js';
-export { PluginError, ConfigError } from './errors.js';
-export { FILE_TYPE_MAP, defaultPatterns } from './file-types.js';
+export { Linter, type Config } from './linter';
+export { LintService } from './lint-service';
+export { setupLinter } from './setup';
+export { applyFixes } from './apply-fixes';
+export { Runner } from './runner';
+export { PluginError, ConfigError } from './errors';
+export { FILE_TYPE_MAP, defaultPatterns } from './file-types';
 export type {
   Environment,
   TokenProvider,
   DocumentSource,
   LintDocument,
-} from './environment.js';
-export type { PluginLoader, LoadedPlugin } from './plugin-loader.js';
-export type { PluginMeta } from './plugin-manager.js';
-export type { CacheProvider, CacheEntry } from './cache-provider.js';
+} from './environment';
+export type { PluginLoader, LoadedPlugin } from './plugin-loader';
+export type { PluginMeta } from './plugin-manager';
+export type { CacheProvider, CacheEntry } from './cache-provider';
 export type {
   LintResult,
   LintMessage,
@@ -27,7 +27,7 @@ export type {
   CSSDeclaration,
   Fix,
   FlattenedToken,
-} from './types.js';
+} from './types';
 export {
   matchToken,
   closestToken,
@@ -35,10 +35,10 @@ export {
   flattenDesignTokens,
   getFlattenedTokens,
   type TokenPattern,
-} from './token-utils.js';
+} from './token-utils';
 export {
   parseDesignTokens,
   getTokenLocation,
   registerTokenTransform,
   type TokenTransform,
-} from './parser/index.js';
+} from './parser/index';

--- a/src/core/lint-service.ts
+++ b/src/core/lint-service.ts
@@ -1,7 +1,7 @@
-import type { Config } from './linter.js';
-import type { Environment } from './environment.js';
-import type { LintResult } from './types.js';
-import { Linter } from './linter.js';
+import type { Config } from './linter';
+import type { Environment } from './environment';
+import type { LintResult } from './types';
+import { Linter } from './linter';
 
 export class LintService {
   private config: Config;

--- a/src/core/linter.ts
+++ b/src/core/linter.ts
@@ -4,22 +4,18 @@ import type {
   RuleContext,
   DesignTokens,
   RuleModule,
-} from './types.js';
-import { getFlattenedTokens as flattenTokens } from './token-utils.js';
-export { defaultIgnore } from './ignore.js';
-import { RuleRegistry } from './rule-registry.js';
-import type { PluginMeta } from './plugin-manager.js';
-import { TokenTracker } from './token-tracker.js';
-import { Runner } from './runner.js';
-import type {
-  LintDocument,
-  Environment,
-  TokenProvider,
-} from './environment.js';
-import type { CacheProvider } from './cache-provider.js';
-import { LintService } from './lint-service.js';
-import { parserRegistry } from './parser-registry.js';
-import { FILE_TYPE_MAP } from './file-types.js';
+} from './types';
+import { getFlattenedTokens as flattenTokens } from './token-utils';
+export { defaultIgnore } from './ignore';
+import { RuleRegistry } from './rule-registry';
+import type { PluginMeta } from './plugin-manager';
+import { TokenTracker } from './token-tracker';
+import { Runner } from './runner';
+import type { LintDocument, Environment, TokenProvider } from './environment';
+import type { CacheProvider } from './cache-provider';
+import { LintService } from './lint-service';
+import { parserRegistry } from './parser-registry';
+import { FILE_TYPE_MAP } from './file-types';
 
 export interface Config {
   tokens?:
@@ -299,7 +295,7 @@ export class Linter {
   }
 }
 
-export { applyFixes } from './apply-fixes.js';
+export { applyFixes } from './apply-fixes';
 
 function isDesignTokens(val: unknown): val is DesignTokens {
   return typeof val === 'object' && val !== null;

--- a/src/core/parser-registry.ts
+++ b/src/core/parser-registry.ts
@@ -1,8 +1,8 @@
-import type { LintMessage, RuleModule } from './types.js';
-import { lintVue } from './framework-parsers/vue-parser.js';
-import { lintSvelte } from './framework-parsers/svelte-parser.js';
-import { lintTS } from './framework-parsers/ts-parser.js';
-import { lintCSS } from './framework-parsers/css-parser.js';
+import type { LintMessage, RuleModule } from './types';
+import { lintVue } from './framework-parsers/vue-parser';
+import { lintSvelte } from './framework-parsers/svelte-parser';
+import { lintTS } from './framework-parsers/ts-parser';
+import { lintCSS } from './framework-parsers/css-parser';
 
 export type ParserStrategy = (
   text: string,

--- a/src/core/parser/alias.ts
+++ b/src/core/parser/alias.ts
@@ -1,4 +1,4 @@
-import type { Token } from '../types.js';
+import type { Token } from '../types';
 
 const ALIAS_GLOBAL = /\{([^}]+)\}/g;
 const ALIAS_EXACT = /^\{([^}]+)\}$/;

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -1,8 +1,8 @@
-import type { DesignTokens, FlattenedToken } from '../types.js';
-import { buildParseTree } from './parse-tree.js';
-import { normalizeTokens } from './normalize.js';
-import { normalizeColorValues, type ColorSpace } from './normalize-colors.js';
-import { validateTokens } from './validate.js';
+import type { DesignTokens, FlattenedToken } from '../types';
+import { buildParseTree } from './parse-tree';
+import { normalizeTokens } from './normalize';
+import { normalizeColorValues, type ColorSpace } from './normalize-colors';
+import { validateTokens } from './validate';
 
 export type TokenTransform = (tokens: DesignTokens) => DesignTokens;
 
@@ -16,7 +16,7 @@ export function registerTokenTransform(transform: TokenTransform): () => void {
   };
 }
 
-export { getTokenLocation } from './parse-tree.js';
+export { getTokenLocation } from './parse-tree';
 
 export interface ParseDesignTokensOptions {
   colorSpace?: ColorSpace;

--- a/src/core/parser/normalize-colors.ts
+++ b/src/core/parser/normalize-colors.ts
@@ -1,5 +1,5 @@
 import { parse, formatRgb, formatHex, formatHsl } from 'culori';
-import type { FlattenedToken } from '../types.js';
+import type { FlattenedToken } from '../types';
 
 export type ColorSpace = 'rgb' | 'hsl' | 'hex';
 

--- a/src/core/parser/normalize.ts
+++ b/src/core/parser/normalize.ts
@@ -1,5 +1,5 @@
-import type { FlattenedToken } from '../types.js';
-import { resolveAliases } from './alias.js';
+import type { FlattenedToken } from '../types';
+import { resolveAliases } from './alias';
 
 export function normalizeTokens(tokens: FlattenedToken[]): FlattenedToken[] {
   const tokenMap = new Map(tokens.map((t) => [t.path, t.token]));

--- a/src/core/parser/parse-tree.ts
+++ b/src/core/parser/parse-tree.ts
@@ -1,10 +1,5 @@
-import type {
-  DesignTokens,
-  Token,
-  TokenGroup,
-  FlattenedToken,
-} from '../types.js';
-import { isRecord } from '../../utils/is-record.js';
+import type { DesignTokens, Token, TokenGroup, FlattenedToken } from '../types';
+import { isRecord } from '../../utils/is-record';
 
 const tokenLocations = new Map<string, { line: number; column: number }>();
 

--- a/src/core/parser/validate.ts
+++ b/src/core/parser/validate.ts
@@ -1,6 +1,6 @@
-import type { Token, FlattenedToken } from '../types.js';
-import { validatorRegistry } from '../token-validators/index.js';
-import { isRecord } from '../../utils/is-record.js';
+import type { Token, FlattenedToken } from '../types';
+import { validatorRegistry } from '../token-validators/index';
+import { isRecord } from '../../utils/is-record';
 
 function validateExtensions(value: unknown, path: string): void {
   if (value === undefined) return;

--- a/src/core/plugin-loader.ts
+++ b/src/core/plugin-loader.ts
@@ -1,4 +1,4 @@
-import type { PluginModule } from './types.js';
+import type { PluginModule } from './types';
 
 export interface LoadedPlugin {
   path: string;

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -1,10 +1,10 @@
-import type { Config } from './linter.js';
-import type { RuleModule } from './types.js';
-import type { PluginLoader } from './plugin-loader.js';
-import type { Environment } from './environment.js';
-import { PluginError } from './errors.js';
-import { isRecord } from '../utils/is-record.js';
-import { isRuleModule } from '../utils/is-rule-module.js';
+import type { Config } from './linter';
+import type { RuleModule } from './types';
+import type { PluginLoader } from './plugin-loader';
+import type { Environment } from './environment';
+import { PluginError } from './errors';
+import { isRecord } from '../utils/is-record';
+import { isRuleModule } from '../utils/is-rule-module';
 
 export interface PluginMeta {
   path: string;

--- a/src/core/rule-registry.ts
+++ b/src/core/rule-registry.ts
@@ -1,9 +1,9 @@
-import type { Config } from './linter.js';
-import type { RuleModule } from './types.js';
-import type { Environment } from './environment.js';
-import { builtInRules } from '../rules/index.js';
-import { PluginManager, type PluginMeta } from './plugin-manager.js';
-import { ConfigError } from './errors.js';
+import type { Config } from './linter';
+import type { RuleModule } from './types';
+import type { Environment } from './environment';
+import { builtInRules } from '../rules/index';
+import { PluginManager, type PluginMeta } from './plugin-manager';
+import { ConfigError } from './errors';
 
 export class RuleRegistry {
   private ruleMap = new Map<string, { rule: RuleModule; source: string }>();

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -1,11 +1,11 @@
 import pLimit from 'p-limit';
 import os from 'node:os';
-import type { Config } from './linter.js';
-import type { CacheProvider } from './cache-provider.js';
-import type { LintResult } from './types.js';
-import { CacheService } from './cache-service.js';
-import { TokenTracker } from './token-tracker.js';
-import type { LintDocument } from './environment.js';
+import type { Config } from './linter';
+import type { CacheProvider } from './cache-provider';
+import type { LintResult } from './types';
+import { CacheService } from './cache-service';
+import { TokenTracker } from './token-tracker';
+import type { LintDocument } from './environment';
 
 export interface RunnerOptions {
   config: Config;

--- a/src/core/setup.ts
+++ b/src/core/setup.ts
@@ -1,10 +1,10 @@
-import { Linter, type Config } from './linter.js';
-import type { Environment, TokenProvider } from './environment.js';
-import { RuleRegistry } from './rule-registry.js';
-import { TokenTracker } from './token-tracker.js';
-import { LintService } from './lint-service.js';
-import { getFlattenedTokens as flattenTokens } from './token-utils.js';
-import type { DesignTokens } from './types.js';
+import { Linter, type Config } from './linter';
+import type { Environment, TokenProvider } from './environment';
+import { RuleRegistry } from './rule-registry';
+import { TokenTracker } from './token-tracker';
+import { LintService } from './lint-service';
+import { getFlattenedTokens as flattenTokens } from './token-utils';
+import type { DesignTokens } from './types';
 
 function isDesignTokens(val: unknown): val is DesignTokens {
   return typeof val === 'object' && val !== null;

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -1,7 +1,7 @@
-import type { LintResult, DesignTokens, FlattenedToken } from './types.js';
-import type { TokenProvider } from './environment.js';
-import { isRecord } from '../utils/is-record.js';
-import { getFlattenedTokens, extractVarName } from './token-utils.js';
+import type { LintResult, DesignTokens, FlattenedToken } from './types';
+import type { TokenProvider } from './environment';
+import { isRecord } from '../utils/is-record';
+import { getFlattenedTokens, extractVarName } from './token-utils';
 
 type TokenType = 'cssVar' | 'hexColor' | 'numeric' | 'string';
 

--- a/src/core/token-utils.ts
+++ b/src/core/token-utils.ts
@@ -1,7 +1,7 @@
-import type { DesignTokens, FlattenedToken } from './types.js';
+import type { DesignTokens, FlattenedToken } from './types';
 import picomatch from 'picomatch';
 import leven from 'leven';
-import { parseDesignTokens } from './parser/index.js';
+import { parseDesignTokens } from './parser/index';
 
 export type TokenPattern = string | RegExp;
 

--- a/src/core/token-validators/dimension.ts
+++ b/src/core/token-validators/dimension.ts
@@ -1,4 +1,4 @@
-import { isRecord } from '../../utils/is-record.js';
+import { isRecord } from '../../utils/is-record';
 
 const DIMENSION_UNITS = new Set(['px', 'rem']);
 

--- a/src/core/token-validators/duration.ts
+++ b/src/core/token-validators/duration.ts
@@ -1,4 +1,4 @@
-import { isRecord } from '../../utils/is-record.js';
+import { isRecord } from '../../utils/is-record';
 
 const DURATION_UNITS = new Set(['ms', 's']);
 

--- a/src/core/token-validators/gradient.ts
+++ b/src/core/token-validators/gradient.ts
@@ -1,6 +1,6 @@
-import { isArray } from '../../utils/is-array.js';
-import { isRecord } from '../../utils/is-record.js';
-import { validateColor } from './color.js';
+import { isArray } from '../../utils/is-array';
+import { isRecord } from '../../utils/is-record';
+import { validateColor } from './color';
 
 export function validateGradient(value: unknown, path: string): void {
   if (!isArray(value) || value.length === 0) {

--- a/src/core/token-validators/index.ts
+++ b/src/core/token-validators/index.ts
@@ -1,15 +1,15 @@
-import type { Token } from '../types.js';
-import { validateColor } from './color.js';
-import { validateDimension } from './dimension.js';
-import { validateNumber } from './number.js';
-import { validateFontFamily } from './fontFamily.js';
-import { validateFontWeight } from './fontWeight.js';
-import { validateDuration } from './duration.js';
-import { validateCubicBezier } from './cubicBezier.js';
-import { validateShadow } from './shadow.js';
-import { validateStrokeStyle } from './strokeStyle.js';
-import { validateGradient } from './gradient.js';
-import { validateTypography } from './typography.js';
+import type { Token } from '../types';
+import { validateColor } from './color';
+import { validateDimension } from './dimension';
+import { validateNumber } from './number';
+import { validateFontFamily } from './fontFamily';
+import { validateFontWeight } from './fontWeight';
+import { validateDuration } from './duration';
+import { validateCubicBezier } from './cubicBezier';
+import { validateShadow } from './shadow';
+import { validateStrokeStyle } from './strokeStyle';
+import { validateGradient } from './gradient';
+import { validateTypography } from './typography';
 
 export type TokenValidator = (
   value: unknown,

--- a/src/core/token-validators/shadow.ts
+++ b/src/core/token-validators/shadow.ts
@@ -1,7 +1,7 @@
-import { isRecord } from '../../utils/is-record.js';
-import { toArray } from '../../utils/to-array.js';
-import { validateColor } from './color.js';
-import { validateDimension } from './dimension.js';
+import { isRecord } from '../../utils/is-record';
+import { toArray } from '../../utils/to-array';
+import { validateColor } from './color';
+import { validateDimension } from './dimension';
 
 export function validateShadow(value: unknown, path: string): void {
   const items = toArray(value);

--- a/src/core/token-validators/strokeStyle.ts
+++ b/src/core/token-validators/strokeStyle.ts
@@ -1,5 +1,5 @@
-import { isRecord } from '../../utils/is-record.js';
-import { validateDimension } from './dimension.js';
+import { isRecord } from '../../utils/is-record';
+import { validateDimension } from './dimension';
 
 const STROKE_STYLE_KEYWORDS = new Set([
   'solid',

--- a/src/core/token-validators/typography.ts
+++ b/src/core/token-validators/typography.ts
@@ -1,8 +1,8 @@
-import { isRecord } from '../../utils/is-record.js';
-import { validateFontFamily } from './fontFamily.js';
-import { validateDimension } from './dimension.js';
-import { validateFontWeight } from './fontWeight.js';
-import { validateNumber } from './number.js';
+import { isRecord } from '../../utils/is-record';
+import { validateFontFamily } from './fontFamily';
+import { validateDimension } from './dimension';
+import { validateFontWeight } from './fontWeight';
+import { validateNumber } from './number';
 
 export function validateTypography(value: unknown, path: string): void {
   if (!isRecord(value)) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 import type ts from 'typescript';
 import type { z } from 'zod';
-import type { Environment } from './environment.js';
+import type { Environment } from './environment';
 
 export interface VariableDefinition {
   id: string;

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { LintResult } from '../core/types.js';
-import { stylish } from './stylish.js';
-import { jsonFormatter } from './json.js';
-import { sarifFormatter } from './sarif.js';
-import { isRecord } from '../utils/is-record.js';
+import type { LintResult } from '../core/types';
+import { stylish } from './stylish';
+import { jsonFormatter } from './json';
+import { sarifFormatter } from './sarif';
+import { isRecord } from '../utils/is-record';
 
 type Formatter = (results: LintResult[], useColor?: boolean) => string;
 

--- a/src/formatters/json.ts
+++ b/src/formatters/json.ts
@@ -1,4 +1,4 @@
-import type { LintResult } from '../core/types.js';
+import type { LintResult } from '../core/types';
 
 export function jsonFormatter(results: LintResult[], _useColor = true): string {
   void _useColor;

--- a/src/formatters/sarif.ts
+++ b/src/formatters/sarif.ts
@@ -1,4 +1,4 @@
-import type { LintResult } from '../core/types.js';
+import type { LintResult } from '../core/types';
 
 interface SarifLog {
   version: string;

--- a/src/formatters/stylish.ts
+++ b/src/formatters/stylish.ts
@@ -1,5 +1,5 @@
-import type { LintResult } from '../core/types.js';
-import { relFromCwd } from '../adapters/node/utils/paths.js';
+import type { LintResult } from '../core/types';
+import { relFromCwd } from '../adapters/node/utils/paths';
 
 const codes = {
   red: (s: string) => `\x1b[31m${s}\x1b[0m`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,14 @@ import {
   setupLinter,
   type Config,
   type Environment,
-} from './core/index.js';
+} from './core/index';
 
-export * from './core/index.js';
-export * from './adapters/node/index.js';
-export { loadConfig } from './config/loader.js';
-export { defineConfig } from './config/define-config.js';
-export { getFormatter } from './formatters/index.js';
-export { builtInRules } from './rules/index.js';
+export * from './core/index';
+export * from './adapters/node/index';
+export { loadConfig } from './config/loader';
+export { defineConfig } from './config/define-config';
+export { getFormatter } from './formatters/index';
+export { builtInRules } from './rules/index';
 
 export function createLinter(config: Config, env: Environment): Linter {
   return setupLinter(config, env).linter;

--- a/src/rules/component-prefix.ts
+++ b/src/rules/component-prefix.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule } from '../core/types';
 
 interface ComponentPrefixOptions {
   prefix?: string;

--- a/src/rules/component-usage.ts
+++ b/src/rules/component-usage.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule } from '../core/types';
 
 export interface ComponentUsageOptions {
   substitutions?: Record<string, string>;

--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
-import { isInNonStyleJsx } from '../utils/is-in-non-style-jsx.js';
+import type { RuleModule } from '../core/types';
+import { isInNonStyleJsx } from '../utils/is-in-non-style-jsx';
 
 export const deprecationRule: RuleModule = {
   name: 'design-system/deprecation',

--- a/src/rules/icon-usage.ts
+++ b/src/rules/icon-usage.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule } from '../core/types';
 
 interface IconUsageOptions {
   /** Map of disallowed icon elements or components to their replacements. */

--- a/src/rules/import-path.ts
+++ b/src/rules/import-path.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule } from '../core/types';
 
 interface ImportPathOptions {
   packages?: string[];

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,8 +1,8 @@
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { globby } from 'globby';
-import type { RuleModule } from '../core/types.js';
-import { isRuleModule } from '../utils/is-rule-module.js';
+import type { RuleModule } from '../core/types';
+import { isRuleModule } from '../utils/is-rule-module';
 
 const ruleDir = path.dirname(fileURLToPath(import.meta.url));
 const ruleFiles = await globby('*.{ts,js}', {

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule } from '../core/types';
 
 interface NoInlineStylesOptions {
   /** When true, the rule will ignore class/className attributes. */

--- a/src/rules/no-unused-tokens.ts
+++ b/src/rules/no-unused-tokens.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule } from '../core/types';
 
 export const noUnusedTokensRule: RuleModule = {
   name: 'design-system/no-unused-tokens',

--- a/src/rules/token-animation.ts
+++ b/src/rules/token-animation.ts
@@ -1,5 +1,5 @@
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/token-rule';
 
 const normalize = (val: string): string =>
   valueParser.stringify(valueParser(val).nodes).trim();

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -1,7 +1,7 @@
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
-import { isRecord } from '../utils/is-record.js';
+import { tokenRule } from '../utils/token-rule';
+import { isRecord } from '../utils/is-record';
 
 interface BlurRuleOptions {
   units?: string[];

--- a/src/rules/token-border-color.ts
+++ b/src/rules/token-border-color.ts
@@ -1,7 +1,7 @@
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
-import { tokenRule } from '../utils/token-rule.js';
-import { detectColorFormat } from '../utils/color-format.js';
+import { tokenRule } from '../utils/token-rule';
+import { detectColorFormat } from '../utils/color-format';
 
 export const borderColorRule = tokenRule({
   name: 'design-token/border-color',

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -1,8 +1,8 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
 
 interface BorderRadiusOptions {
   units?: string[];

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -1,9 +1,9 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
-import { isRecord } from '../utils/is-record.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
+import { isRecord } from '../utils/is-record';
 
 interface BorderWidthOptions {
   units?: string[];

--- a/src/rules/token-box-shadow.ts
+++ b/src/rules/token-box-shadow.ts
@@ -1,6 +1,6 @@
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
-import { isRecord } from '../utils/is-record.js';
+import { tokenRule } from '../utils/token-rule';
+import { isRecord } from '../utils/is-record';
 
 const normalize = (val: string): string =>
   valueParser.stringify(valueParser(val).nodes).trim();

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -2,9 +2,9 @@ import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
-import { detectColorFormat, type ColorFormat } from '../utils/color-format.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
+import { detectColorFormat, type ColorFormat } from '../utils/color-format';
 
 interface ColorRuleOptions {
   allow?: ColorFormat[];

--- a/src/rules/token-duration.ts
+++ b/src/rules/token-duration.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
 
 export const durationRule = tokenRule({
   name: 'design-token/duration',

--- a/src/rules/token-font-family.ts
+++ b/src/rules/token-font-family.ts
@@ -1,4 +1,4 @@
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/token-rule';
 
 export const fontFamilyRule = tokenRule({
   name: 'design-token/font-family',

--- a/src/rules/token-font-size.ts
+++ b/src/rules/token-font-size.ts
@@ -1,5 +1,5 @@
-import { tokenRule } from '../utils/token-rule.js';
-import { isRecord } from '../utils/is-record.js';
+import { tokenRule } from '../utils/token-rule';
+import { isRecord } from '../utils/is-record';
 
 const parseSize = (val: unknown): number | null => {
   if (

--- a/src/rules/token-font-weight.ts
+++ b/src/rules/token-font-weight.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
 
 export const fontWeightRule = tokenRule({
   name: 'design-token/font-weight',

--- a/src/rules/token-letter-spacing.ts
+++ b/src/rules/token-letter-spacing.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
-import { isRecord } from '../utils/is-record.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
+import { isRecord } from '../utils/is-record';
 
 const parse = (val: unknown): number | null => {
   if (

--- a/src/rules/token-line-height.ts
+++ b/src/rules/token-line-height.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
 
 const parse = (val: string): number | null => {
   const v = val.trim();

--- a/src/rules/token-opacity.ts
+++ b/src/rules/token-opacity.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
 
 export const opacityRule = tokenRule({
   name: 'design-token/opacity',

--- a/src/rules/token-outline.ts
+++ b/src/rules/token-outline.ts
@@ -1,5 +1,5 @@
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/token-rule';
 
 const normalize = (val: string): string =>
   valueParser.stringify(valueParser(val).nodes).trim();

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -1,8 +1,8 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
 
 interface SpacingOptions {
   base?: number;

--- a/src/rules/token-z-index.ts
+++ b/src/rules/token-z-index.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
-import { isStyleValue } from '../utils/style.js';
+import { tokenRule } from '../utils/token-rule';
+import { isStyleValue } from '../utils/style';
 
 export const zIndexRule = tokenRule({
   name: 'design-token/z-index',

--- a/src/rules/variant-prop.ts
+++ b/src/rules/variant-prop.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import { z } from 'zod';
-import type { RuleModule } from '../core/types.js';
+import type { RuleModule } from '../core/types';
 
 interface VariantPropOptions {
   components?: Record<string, string[] | undefined>;

--- a/src/utils/is-design-tokens.ts
+++ b/src/utils/is-design-tokens.ts
@@ -1,5 +1,5 @@
-import type { DesignTokens } from '../core/types.js';
-import { isRecord } from './is-record.js';
+import type { DesignTokens } from '../core/types';
+import { isRecord } from './is-record';
 
 /**
  * Determines whether a value conforms to the `DesignTokens` structure.

--- a/src/utils/is-in-non-style-jsx.ts
+++ b/src/utils/is-in-non-style-jsx.ts
@@ -5,10 +5,10 @@ import {
   isPropertyAssignment,
   type Node,
 } from 'typescript';
-import { isJsxLike } from './is-jsx-like.js';
-import { isStyleName } from './is-style-name.js';
-import { isReactCreateElementCall } from './is-react-create-element-call.js';
-import { isHyperscriptCall } from './is-hyperscript-call.js';
+import { isJsxLike } from './is-jsx-like';
+import { isStyleName } from './is-style-name';
+import { isReactCreateElementCall } from './is-react-create-element-call';
+import { isHyperscriptCall } from './is-hyperscript-call';
 
 /**
  * Determines whether a given TypeScript AST node is inside JSX (or JSX-like code)

--- a/src/utils/is-record.ts
+++ b/src/utils/is-record.ts
@@ -1,4 +1,4 @@
-import { isObject } from './is-object.js';
+import { isObject } from './is-object';
 
 /**
  * Determines whether a value is a plain object (i.e., a record) and not an array.

--- a/src/utils/is-rule-module.ts
+++ b/src/utils/is-rule-module.ts
@@ -1,5 +1,5 @@
-import type { RuleModule } from '../core/types.js';
-import { isRecord } from './is-record.js';
+import type { RuleModule } from '../core/types';
+import { isRecord } from './is-record';
 
 /**
  * Options for {@link isRuleModule}.

--- a/src/utils/is-theme-record.ts
+++ b/src/utils/is-theme-record.ts
@@ -1,5 +1,5 @@
-import type { DesignTokens } from '../core/types.js';
-import { isRecord } from './is-record.js';
+import type { DesignTokens } from '../core/types';
+import { isRecord } from './is-record';
 
 /**
  * Determines whether a value is a record of theme names mapping to design tokens.

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -5,9 +5,9 @@ import {
   isPropertyAssignment,
   type Node,
 } from 'typescript';
-import { isStyleName } from './is-style-name.js';
-import { isReactCreateElementCall } from './is-react-create-element-call.js';
-import { isHyperscriptCall } from './is-hyperscript-call.js';
+import { isStyleName } from './is-style-name';
+import { isReactCreateElementCall } from './is-react-create-element-call';
+import { isHyperscriptCall } from './is-hyperscript-call';
 
 /**
  * Determines whether a node's value belongs to a `style` attribute or `style`

--- a/src/utils/to-array.ts
+++ b/src/utils/to-array.ts
@@ -1,4 +1,4 @@
-import { isArray } from './is-array.js';
+import { isArray } from './is-array';
 
 /**
  * Normalizes a value to always be returned as an array.

--- a/src/utils/token-rule.ts
+++ b/src/utils/token-rule.ts
@@ -3,10 +3,10 @@ import type {
   RuleContext,
   RuleListener,
   RuleModule,
-} from '../core/types.js';
+} from '../core/types';
 import { z } from 'zod';
-import { isObject } from './is-object.js';
-import { toArray } from './to-array.js';
+import { isObject } from './is-object';
+import { toArray } from './to-array';
 
 /**
  * Configuration for creating a token-based rule via {@link tokenRule}.

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -12,7 +12,7 @@ import {
   parseDesignTokensFile,
   TokenParseError,
 } from '../../src/adapters/node/token-parser.ts';
-import type { DesignTokens } from '../../src/core/types.js';
+import type { DesignTokens } from '../../src/core/types';
 
 void test('parseDesignTokens flattens tokens with paths in declaration order', () => {
   const tokens: DesignTokens = {

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createLinter as initLinter } from '../src/index.ts';
-import { FileSource } from '../src/adapters/node/file-source.js';
+import { FileSource } from '../src/adapters/node/file-source';
 
 void test('getTokenCompletions returns token paths by theme', async () => {
   const linter = initLinter(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
## Summary
- configure TypeScript for ESNext modules with bundler resolution
- drop .js extensions from TypeScript imports and runtime loaders

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c2fb39c4748328a73858fe3ec61040