### PR TITLE
refactor: organize token rule utility

### DIFF
--- a/.changeset/move-token-rule-util.md
+++ b/.changeset/move-token-rule-util.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor token rule utility into dedicated rules directory

--- a/src/rules/token-animation.ts
+++ b/src/rules/token-animation.ts
@@ -1,5 +1,5 @@
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 
 const normalize = (val: string): string =>
   valueParser.stringify(valueParser(val).nodes).trim();

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -1,6 +1,6 @@
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isRecord } from '../utils/is-record.js';
 
 interface BlurRuleOptions {

--- a/src/rules/token-border-color.ts
+++ b/src/rules/token-border-color.ts
@@ -1,6 +1,6 @@
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { detectColorFormat } from '../utils/color-format.js';
 
 export const borderColorRule = tokenRule({

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 
 interface BorderRadiusOptions {

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 import { isRecord } from '../utils/is-record.js';
 

--- a/src/rules/token-box-shadow.ts
+++ b/src/rules/token-box-shadow.ts
@@ -1,5 +1,5 @@
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isRecord } from '../utils/is-record.js';
 
 const normalize = (val: string): string =>

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 import { detectColorFormat, type ColorFormat } from '../utils/color-format.js';
 

--- a/src/rules/token-duration.ts
+++ b/src/rules/token-duration.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 
 export const durationRule = tokenRule({

--- a/src/rules/token-font-family.ts
+++ b/src/rules/token-font-family.ts
@@ -1,4 +1,4 @@
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 
 export const fontFamilyRule = tokenRule({
   name: 'design-token/font-family',

--- a/src/rules/token-font-size.ts
+++ b/src/rules/token-font-size.ts
@@ -1,4 +1,4 @@
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isRecord } from '../utils/is-record.js';
 
 const parseSize = (val: unknown): number | null => {

--- a/src/rules/token-font-weight.ts
+++ b/src/rules/token-font-weight.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 
 export const fontWeightRule = tokenRule({

--- a/src/rules/token-letter-spacing.ts
+++ b/src/rules/token-letter-spacing.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 import { isRecord } from '../utils/is-record.js';
 

--- a/src/rules/token-line-height.ts
+++ b/src/rules/token-line-height.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 
 const parse = (val: string): number | null => {

--- a/src/rules/token-opacity.ts
+++ b/src/rules/token-opacity.ts
@@ -1,6 +1,6 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 
 export const opacityRule = tokenRule({

--- a/src/rules/token-outline.ts
+++ b/src/rules/token-outline.ts
@@ -1,5 +1,5 @@
 import valueParser from 'postcss-value-parser';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 
 const normalize = (val: string): string =>
   valueParser.stringify(valueParser(val).nodes).trim();

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import valueParser from 'postcss-value-parser';
 import { z } from 'zod';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 
 interface SpacingOptions {

--- a/src/rules/token-z-index.ts
+++ b/src/rules/token-z-index.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { tokenRule } from '../utils/token-rule.js';
+import { tokenRule } from '../utils/rules/index.js';
 import { isStyleValue } from '../utils/style.js';
 
 export const zIndexRule = tokenRule({

--- a/src/utils/rules/index.ts
+++ b/src/utils/rules/index.ts
@@ -1,0 +1,1 @@
+export * from './token-rule.js';

--- a/src/utils/rules/token-rule.ts
+++ b/src/utils/rules/token-rule.ts
@@ -3,10 +3,10 @@ import type {
   RuleContext,
   RuleListener,
   RuleModule,
-} from '../core/types.js';
+} from '../../core/types.js';
 import { z } from 'zod';
-import { isObject } from './is-object.js';
-import { toArray } from './to-array.js';
+import { isObject } from '../is-object.js';
+import { toArray } from '../to-array.js';
 
 /**
  * Configuration for creating a token-based rule via {@link tokenRule}.

--- a/tests/utils/token-rule.test.ts
+++ b/tests/utils/token-rule.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { tokenRule } from '../../src/utils/token-rule.js';
+import { tokenRule } from '../../src/utils/rules/index.js';
 import type { RuleContext } from '../../src/core/types.js';
 
 void test('tokenRule reports when tokens are missing', () => {


### PR DESCRIPTION
## Summary
- move token-rule helper into new `src/utils/rules` directory
- update imports to use centralized rules utility index
- add changeset for token rule refactor

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c307826cfc83288bb446d55525f1f4