### PR TITLE
fix: export color-format helpers

### DIFF
--- a/.changeset/export-color-helpers.md
+++ b/.changeset/export-color-helpers.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+export color-format helpers from utils index and move ColorFormat type to core

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,6 +27,7 @@ export type {
   CSSDeclaration,
   Fix,
   FlattenedToken,
+  ColorFormat,
 } from './types.js';
 export {
   matchToken,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -110,3 +110,18 @@ export interface Fix {
   range: [number, number];
   text: string;
 }
+
+/**
+ * Supported CSS color formats.
+ */
+export type ColorFormat =
+  | 'hex'
+  | 'rgb'
+  | 'rgba'
+  | 'hsl'
+  | 'hsla'
+  | 'hwb'
+  | 'lab'
+  | 'lch'
+  | 'color'
+  | 'named';

--- a/src/rules/token-colors.ts
+++ b/src/rules/token-colors.ts
@@ -3,7 +3,7 @@ import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
 import { z } from 'zod';
 import { rules, guards, color } from '../utils/index.js';
-import type { ColorFormat } from '../utils/index.js';
+import type { ColorFormat } from '../core/index.js';
 
 const { tokenRule } = rules;
 const {

--- a/src/utils/color/color-format.ts
+++ b/src/utils/color/color-format.ts
@@ -5,21 +5,7 @@
  */
 import colorName from 'color-name';
 
-/**
- * List of supported CSS color formats that {@link detectColorFormat} can
- * recognize.
- */
-export type ColorFormat =
-  | 'hex'
-  | 'rgb'
-  | 'rgba'
-  | 'hsl'
-  | 'hsla'
-  | 'hwb'
-  | 'lab'
-  | 'lch'
-  | 'color'
-  | 'named';
+import type { ColorFormat } from '../../core/types.js';
 
 /**
  * Set of CSS color names supported by the `color-name` package.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,6 +13,6 @@
  */
 export * as collections from './collections/index.js';
 export * as color from './color/index.js';
-export type { ColorFormat } from './color/color-format.js';
+export { detectColorFormat, namedColors } from './color/color-format.js';
 export * as guards from './guards/index.js';
 export * as rules from './rules/index.js';


### PR DESCRIPTION
## Summary
- re-export `detectColorFormat` and `namedColors` from utils index
- move `ColorFormat` type to core types and re-export from core

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c3603871788328b5a7086ac9ce3802