### PR TITLE
refactor(utils): streamline barrel exports and docs

### DIFF
--- a/.changeset/streamline-utils-barrels.md
+++ b/.changeset/streamline-utils-barrels.md
@@ -1,0 +1,9 @@
+---
+'@lapidist/design-lint': patch
+---
+
+refactor(utils): remove redundant color exports and document tokenRule generics
+
+Improve JSDoc coverage for AST guard helpers with usage examples.
+
+Clarify color format detection internals and annotate complex rule utilities with inline comments.

--- a/src/utils/color/color-format.ts
+++ b/src/utils/color/color-format.ts
@@ -33,6 +33,7 @@ export const detectColorFormat = (value: string): ColorFormat | null => {
   if (v.startsWith('lab(')) return 'lab';
   if (v.startsWith('lch(')) return 'lch';
   if (v.startsWith('color(')) return 'color';
+  // Fall back to matching named colors like "red" or "rebeccapurple".
   if (namedColors.has(v)) return 'named';
   return null;
 };

--- a/src/utils/guards/ast/is-hyperscript-call.ts
+++ b/src/utils/guards/ast/is-hyperscript-call.ts
@@ -6,6 +6,17 @@ import { isCallExpression, isIdentifier, type Node } from 'typescript';
  * Hyperscript is a JSX alternative used in some frameworks
  * (e.g. Preact, Vue render functions).
  *
+ * @example
+ * ```ts
+ * import ts from 'typescript';
+ * const node = ts.factory.createCallExpression(
+ *   ts.factory.createIdentifier('h'),
+ *   undefined,
+ *   [],
+ * );
+ * isHyperscriptCall(node); // => true
+ * ```
+ *
  * @param n - The TypeScript AST node to check.
  * @returns `true` if the node is a call to `h(...)`.
  */

--- a/src/utils/guards/ast/is-in-non-style-jsx.ts
+++ b/src/utils/guards/ast/is-in-non-style-jsx.ts
@@ -23,6 +23,15 @@ import { isHyperscriptCall } from './is-hyperscript-call.js';
  * - Returns `true` if it detects the node is inside JSX, a React `createElement` call,
  *   or a `h()` hyperscript call. Otherwise, returns `false`.
  *
+ * @example
+ * ```tsx
+ * const element = <div title="a" style={{ color: 'red' }} />;
+ * // Given a reference to the `title` attribute node:
+ * isInNonStyleJsx(titleNode); // => true
+ * // For the `color` property inside the style object:
+ * isInNonStyleJsx(colorProp); // => false
+ * ```
+ *
  * @param node - The TypeScript AST node to start from.
  * @returns `true` if the node is inside non-style JSX (or JSX-like code), `false` otherwise.
  */

--- a/src/utils/guards/ast/is-jsx-like.ts
+++ b/src/utils/guards/ast/is-jsx-like.ts
@@ -13,6 +13,17 @@ import {
  * - JSX self-closing elements (`<div />`)
  * - JSX fragments (`<>...</>`)
  *
+ * @example
+ * ```ts
+ * import ts from 'typescript';
+ * const node = ts.factory.createJsxSelfClosingElement(
+ *   ts.factory.createIdentifier('div'),
+ *   [],
+ *   ts.factory.createJsxAttributes([]),
+ * );
+ * isJsxLike(node); // => true
+ * ```
+ *
  * @param n - The TypeScript AST node to check.
  * @returns `true` if the node is JSX-like, `false` otherwise.
  */

--- a/src/utils/guards/ast/is-style-name.ts
+++ b/src/utils/guards/ast/is-style-name.ts
@@ -3,6 +3,13 @@ import type { Node } from 'typescript';
 /**
  * Checks if a node represents a property or attribute named `style`.
  *
+ * @example
+ * ```ts
+ * import ts from 'typescript';
+ * const prop = ts.factory.createIdentifier('style');
+ * isStyleName(prop); // => true
+ * ```
+ *
  * @param n - The TypeScript AST node to check.
  * @returns `true` if the node's text is exactly "style", `false` otherwise.
  */

--- a/src/utils/guards/ast/is-style-value.ts
+++ b/src/utils/guards/ast/is-style-value.ts
@@ -22,21 +22,42 @@ import { isHyperscriptCall } from './is-hyperscript-call.js';
  *   hyperscript call.
  * - Returns `false` otherwise.
  *
+ * @example
+ * ```tsx
+ * const element = <div style={{ color: 'red' }} title="a" />;
+ * // Given a reference to the value of the `color` property:
+ * isStyleValue(colorValueNode); // => true
+ * // Given a reference to the value of `title`:
+ * isStyleValue(titleValueNode); // => false
+ * ```
+ *
  * @param node - The TypeScript AST node to check.
  * @returns `true` if the node is a style value, `false` otherwise.
  */
 export function isStyleValue(node: Node): boolean {
+  // Climb from the current node up to the root of the AST in search of a
+  // surrounding style context.
   for (let curr: Node = node; !isSourceFile(curr); curr = curr.parent) {
+    // If we reached a JSX attribute, the value belongs to that attribute. Only
+    // consider it a style value when the attribute name is exactly "style".
     if (isJsxAttribute(curr)) return isStyleName(curr.name);
 
+    // Handle object property assignments like `{ style: { ... } }`.
     if (isPropertyAssignment(curr) && isStyleName(curr.name)) {
+      // Examine ancestors of the object property to find the surrounding JSX or
+      // createElement/hyperscript call that would indicate a style context.
       for (let p: Node = curr.parent; !isSourceFile(p); p = p.parent) {
         if (isCallExpression(p)) {
+          // A React.createElement or hyperscript h() call signals that we're
+          // inside a JSX-like factory where the property is indeed a style.
           if (isReactCreateElementCall(p) || isHyperscriptCall(p)) return true;
+          // Any other function call isn't relevant to styles; abort this path.
           break;
         }
+        // A parent JSX attribute named "style" also confirms the context.
         if (isJsxAttribute(p) && isStyleName(p.name)) return true;
       }
+      // Exhausted all ancestors without finding a style context.
       return false;
     }
   }

--- a/src/utils/guards/domain/is-rule-module.ts
+++ b/src/utils/guards/domain/is-rule-module.ts
@@ -29,12 +29,21 @@ export const isRuleModule = (
   value: unknown,
   options: IsRuleModuleOptions = {},
 ): value is RuleModule => {
+  // The value must be an object before further inspection.
   if (!isRecord(value)) return false;
+
+  // Normalize option defaults for the subsequent checks.
   const { requireMeta = false, requireNonEmptyName = false } = options;
+
+  // Ensure a `name` string is present.
   if (typeof value.name !== 'string') return false;
   if (requireNonEmptyName && value.name.trim() === '') return false;
+
+  // Ensure a `create` function exists to produce the rule implementation.
   if (typeof value.create !== 'function') return false;
+
   if (requireMeta) {
+    // When metadata is required, it must contain a non-empty description.
     if (
       !isRecord(value.meta) ||
       typeof value.meta.description !== 'string' ||

--- a/src/utils/guards/domain/is-theme-record.ts
+++ b/src/utils/guards/domain/is-theme-record.ts
@@ -19,10 +19,16 @@ import { isRecord } from '../data/index.js';
 export const isThemeRecord = (
   val: unknown,
 ): val is Record<string, DesignTokens> => {
+  // Input must be a plain object mapping theme names to token sets.
   if (!isRecord(val)) return false;
+
+  // Ignore metadata keys (those starting with `$`).
   const entries = Object.entries(val).filter(([k]) => !k.startsWith('$'));
   if (entries.length === 0) return false;
+
   if (entries.length === 1) {
+    // For a single theme, ensure it contains nested theme objects rather than
+    // only direct token definitions.
     const [, theme] = entries[0];
     if (!isRecord(theme)) return false;
     const children = Object.entries(theme)
@@ -33,14 +39,24 @@ export const isThemeRecord = (
     );
     return !allTokens;
   }
+
+  // For multiple themes, track the intersection of their token keys to ensure
+  // they share at least one common token.
   let shared: string[] | null = null;
   for (const [, theme] of entries) {
+    // Each theme must itself be a record.
     if (!isRecord(theme)) return false;
+
+    // Collect the non-metadata token keys for the current theme.
     const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
+
     if (shared === null) {
+      // Initialize the intersection with the first theme's keys.
       shared = keys;
     } else {
+      // Narrow the intersection to keys present in every theme so far.
       shared = shared.filter((k) => keys.includes(k));
+      // If no keys remain in common, the value can't be a theme record.
       if (shared.length === 0) return false;
     }
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,6 +13,5 @@
  */
 export * as collections from './collections/index.js';
 export * as color from './color/index.js';
-export { detectColorFormat, namedColors } from './color/color-format.js';
 export * as guards from './guards/index.js';
 export * as rules from './rules/index.js';


### PR DESCRIPTION
## Summary
- refactor utils index to rely solely on barrel modules
- document generics for tokenRule helper
- expand JSDoc examples for AST guard utilities
- clarify color format detection and annotate complex rule utilities
- explain style value and theme record guards with step-by-step inline comments

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3653aefb88328bfa9220b13da34de