### PR TITLE
chore: fix linting and prettier

### DIFF
--- a/.changeset/lint-prettier-fixes.md
+++ b/.changeset/lint-prettier-fixes.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix linting and formatting issues in tokens command and tests

--- a/src/cli/tokens.ts
+++ b/src/cli/tokens.ts
@@ -35,17 +35,18 @@ export async function exportTokens(
   const config = await loadConfig(process.cwd(), options.config);
   const tokensByTheme = toThemeRecord(config.tokens);
   const themes = options.theme ? [options.theme] : Object.keys(tokensByTheme);
-  const output: Record<string, Record<string, unknown>> = Object.create(null);
+  const output: Record<string, Record<string, unknown>> = {};
 
   for (const theme of themes) {
     const flat = getFlattenedTokens(tokensByTheme, theme, {
       nameTransform: config.nameTransform,
       onWarn,
     });
-    output[theme] = Object.create(null);
+    output[theme] = {};
     for (const { path: p, value, type, aliases, metadata } of flat) {
       // Prevent prototype pollution from malicious keys
-      if (p === '__proto__' || p === 'constructor' || p === 'prototype') continue;
+      if (p === '__proto__' || p === 'constructor' || p === 'prototype')
+        continue;
       output[theme][p] = {
         value,
         type,

--- a/src/config/token-loader.ts
+++ b/src/config/token-loader.ts
@@ -35,7 +35,7 @@ function mergeTokens(
   override: Record<string, unknown>,
 ): Record<string, unknown> {
   for (const [k, v] of Object.entries(override)) {
-    if (k === "__proto__" || k === "constructor" || k === "prototype") {
+    if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
       continue;
     }
     if (isRecord(v) && isRecord(base[k])) {

--- a/tests/cli/watch-generate.test.ts
+++ b/tests/cli/watch-generate.test.ts
@@ -10,7 +10,7 @@ const require = createRequire(import.meta.url);
 const tsxLoader = require.resolve('tsx/esm');
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-async function waitFor(check: () => boolean, timeout = 4000) {
+async function waitFor(check: () => boolean, timeout = 10000) {
   const start = Date.now();
   while (Date.now() - start < timeout) {
     if (check()) return;


### PR DESCRIPTION
## Summary
- avoid unsafe Object.create assignments in tokens CLI
- normalize formatting and increase watch test timeout

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c492fcbeb4832887efa5529f1bc631