### PR TITLE
feat(core): support additional dimension units

### DIFF
--- a/.changeset/extend-units-warning.md
+++ b/.changeset/extend-units-warning.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+extend dimension unit support and warn on unknown units

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,8 @@ Inline example:
 }
 ```
 
+Dimension tokens use objects with numeric `value` and a CSS length `unit` such as `px`, `rem`, `em`, `vh`, `vw`, `vmin`, `vmax`, or `ch`. Unknown units are preserved but emit a warning.
+
 Organise tokens by category—such as `color`, `space`, or `typography`—to mirror your design language. To support light and dark themes, supply an object keyed by theme name. Each theme may contain an inline token tree or a path to an external token file. Paths resolve relative to the configuration file:
 
 ```json

--- a/docs/rules/design-token/blur.md
+++ b/docs/rules/design-token/blur.md
@@ -24,7 +24,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```
 
 ## Options
-No additional options.
+- `units` (`string[]`): CSS units to validate. Defaults to `['px', 'rem', 'em', 'vh', 'vw', 'vmin', 'vmax', 'ch']`.
 
 This rule is not auto-fixable.
 

--- a/docs/rules/design-token/border-radius.md
+++ b/docs/rules/design-token/border-radius.md
@@ -26,7 +26,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 Border radius tokens use the `dimension` type.
 
 ## Options
-No additional options.
+- `units` (`string[]`): CSS units to validate. Defaults to `['px', 'rem', 'em', 'vh', 'vw', 'vmin', 'vmax', 'ch']`.
 
 This rule is not auto-fixable.
 

--- a/docs/rules/design-token/border-width.md
+++ b/docs/rules/design-token/border-width.md
@@ -26,7 +26,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 Border width tokens use the `dimension` type.
 
 ## Options
-No additional options.
+- `units` (`string[]`): CSS units to validate. Defaults to `['px', 'rem', 'em', 'vh', 'vw', 'vmin', 'vmax', 'ch']`.
 
 This rule is not auto-fixable.
 

--- a/docs/rules/design-token/spacing.md
+++ b/docs/rules/design-token/spacing.md
@@ -29,7 +29,7 @@ Spacing tokens use the `dimension` type.
 
 ## Options
 - `base` (`number`): values must be multiples of this number. Defaults to `4`.
-- `units` (`string[]`): CSS units to validate. Defaults to `['px', 'rem', 'em']`.
+- `units` (`string[]`): CSS units to validate. Defaults to `['px', 'rem', 'em', 'vh', 'vw', 'vmin', 'vmax', 'ch']`.
 
 Numbers that appear inside CSS functions (e.g., `calc()`, `var()`) are ignored.
 

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -42,6 +42,6 @@ export function parseDesignTokens(
   if (options?.colorSpace) {
     normalizeColorValues(tree, options.colorSpace);
   }
-  validateTokens(tree);
+  validateTokens(tree, options?.onWarn);
   return tree;
 }

--- a/src/core/parser/validate.ts
+++ b/src/core/parser/validate.ts
@@ -39,6 +39,7 @@ function validateToken(
   path: string,
   token: Token,
   tokenMap: Map<string, Token>,
+  warn?: (msg: string) => void,
 ): void {
   validateMetadata(token, path);
   if (token.$value === undefined) {
@@ -54,10 +55,13 @@ function validateToken(
   if (!validator) {
     throw new Error(`Token ${path} has unknown $type ${token.$type}`);
   }
-  validator(token.$value, path, tokenMap);
+  validator(token.$value, path, tokenMap, warn);
 }
 
-export function validateTokens(tokens: FlattenedToken[]): void {
+export function validateTokens(
+  tokens: FlattenedToken[],
+  warn?: (msg: string) => void,
+): void {
   const tokenMap = new Map<string, Token>(
     tokens.map((t) => [
       t.path,
@@ -78,6 +82,6 @@ export function validateTokens(tokens: FlattenedToken[]): void {
       $extensions: t.metadata.extensions,
       $deprecated: t.metadata.deprecated,
     };
-    validateToken(t.path, token, tokenMap);
+    validateToken(t.path, token, tokenMap, warn);
   }
 }

--- a/src/core/token-validators/dimension.ts
+++ b/src/core/token-validators/dimension.ts
@@ -1,18 +1,35 @@
 import { guards } from '../../utils/index.js';
+import type { Token } from '../types.js';
 
 const {
   data: { isRecord },
 } = guards;
 
-const DIMENSION_UNITS = new Set(['px', 'rem']);
+const DIMENSION_UNITS = new Set([
+  'px',
+  'rem',
+  'em',
+  'vh',
+  'vw',
+  'vmin',
+  'vmax',
+  'ch',
+]);
 
-export function validateDimension(value: unknown, path: string): void {
+export function validateDimension(
+  value: unknown,
+  path: string,
+  _tokenMap?: Map<string, Token>,
+  warn?: (msg: string) => void,
+): void {
   if (
     isRecord(value) &&
     typeof value.value === 'number' &&
-    typeof value.unit === 'string' &&
-    DIMENSION_UNITS.has(value.unit)
+    typeof value.unit === 'string'
   ) {
+    if (!DIMENSION_UNITS.has(value.unit)) {
+      warn?.(`Token ${path} uses unknown unit ${value.unit}`);
+    }
     return;
   }
   throw new Error(`Token ${path} has invalid dimension value`);

--- a/src/core/token-validators/index.ts
+++ b/src/core/token-validators/index.ts
@@ -15,6 +15,7 @@ export type TokenValidator = (
   value: unknown,
   path: string,
   tokenMap: Map<string, Token>,
+  warn?: (msg: string) => void,
 ) => void;
 
 export const validatorRegistry = new Map<string, TokenValidator>([

--- a/src/rules/token-blur.ts
+++ b/src/rules/token-blur.ts
@@ -34,9 +34,18 @@ export const blurRule = tokenRule<BlurRuleOptions>({
   },
   create(context, allowed) {
     const allowedUnits = new Set(
-      (context.options?.units ?? ['px', 'rem', 'em']).map((u) =>
-        u.toLowerCase(),
-      ),
+      (
+        context.options?.units ?? [
+          'px',
+          'rem',
+          'em',
+          'vh',
+          'vw',
+          'vmin',
+          'vmax',
+          'ch',
+        ]
+      ).map((u) => u.toLowerCase()),
     );
     return {
       onCSSDeclaration(decl) {

--- a/src/rules/token-border-radius.ts
+++ b/src/rules/token-border-radius.ts
@@ -38,9 +38,18 @@ export const borderRadiusRule = tokenRule<BorderRadiusOptions>({
   },
   create(context, allowed) {
     const allowedUnits = new Set(
-      (context.options?.units ?? ['px', 'rem', 'em']).map((u) =>
-        u.toLowerCase(),
-      ),
+      (
+        context.options?.units ?? [
+          'px',
+          'rem',
+          'em',
+          'vh',
+          'vw',
+          'vmin',
+          'vmax',
+          'ch',
+        ]
+      ).map((u) => u.toLowerCase()),
     );
     return {
       onNode(node) {

--- a/src/rules/token-border-width.ts
+++ b/src/rules/token-border-width.ts
@@ -36,9 +36,18 @@ export const borderWidthRule = tokenRule<BorderWidthOptions>({
   },
   create(context, allowed) {
     const allowedUnits = new Set(
-      (context.options?.units ?? ['px', 'rem', 'em']).map((u) =>
-        u.toLowerCase(),
-      ),
+      (
+        context.options?.units ?? [
+          'px',
+          'rem',
+          'em',
+          'vh',
+          'vw',
+          'vmin',
+          'vmax',
+          'ch',
+        ]
+      ).map((u) => u.toLowerCase()),
     );
     const parseValue = (text: string): number | null => {
       const trimmed = text.trim();

--- a/src/rules/token-spacing.ts
+++ b/src/rules/token-spacing.ts
@@ -47,7 +47,9 @@ export const spacingRule = tokenRule<SpacingOptions>({
     const base = opts.base ?? 4;
     const isAllowed = (n: number) => allowed.has(n) || n % base === 0;
     const allowedUnits = new Set(
-      (opts.units ?? ['px', 'rem', 'em']).map((u) => u.toLowerCase()),
+      (opts.units ?? ['px', 'rem', 'em', 'vh', 'vw', 'vmin', 'vmax', 'ch']).map(
+        (u) => u.toLowerCase(),
+      ),
     );
     const parse = (text: string): number | null => {
       const trimmed = text.trim();

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -212,10 +212,14 @@ void test('parseDesignTokens resolves alias token types', () => {
 
 void test('parseDesignTokens validates dimension tokens', () => {
   const tokens = {
-    size: { $type: 'dimension', sm: { $value: { value: 4, unit: 'px' } } },
+    size: { $type: 'dimension', sm: { $value: { value: 4, unit: 'vh' } } },
   } as unknown as DesignTokens;
-  const result = parseDesignTokens(tokens);
+  const warnings: string[] = [];
+  const result = parseDesignTokens(tokens, undefined, {
+    onWarn: (m) => warnings.push(m),
+  });
   assert.equal(result[0].type, 'dimension');
+  assert.equal(warnings.length, 0);
 
   const invalid = {
     size: { $type: 'dimension', sm: { $value: { value: 0 } } },
@@ -223,9 +227,15 @@ void test('parseDesignTokens validates dimension tokens', () => {
   assert.throws(() => parseDesignTokens(invalid), /invalid dimension value/i);
 
   const badUnit = {
-    size: { $type: 'dimension', sm: { $value: { value: 1, unit: 'em' } } },
+    size: { $type: 'dimension', sm: { $value: { value: 1, unit: 'pc' } } },
   } as unknown as DesignTokens;
-  assert.throws(() => parseDesignTokens(badUnit), /invalid dimension value/i);
+  const badWarnings: string[] = [];
+  const res = parseDesignTokens(badUnit, undefined, {
+    onWarn: (m) => badWarnings.push(m),
+  });
+  assert.equal(res.length, 1);
+  assert.equal(badWarnings.length, 1);
+  assert.match(badWarnings[0], /unknown unit/i);
 });
 
 void test('parseDesignTokens validates duration tokens', () => {

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -67,7 +67,7 @@ void test('design-token/spacing handles multi-line CSS', async () => {
 
 void test('design-token/spacing ignores unsupported units', async () => {
   const linter = createLinter(['error', { base: 4 }]);
-  const res = await linter.lintText('.a{margin:5.5vw 10%;}', 'file.css');
+  const res = await linter.lintText('.a{margin:5.5pc 10%;}', 'file.css');
   assert.equal(res.messages.length, 0);
 });
 
@@ -109,8 +109,8 @@ void test('design-token/spacing ignores nested var() fallbacks', async () => {
 });
 
 void test('design-token/spacing supports custom units', async () => {
-  const linter = createLinter(['error', { base: 4, units: ['vw'] }]);
-  const res = await linter.lintText('.a{margin:5vw;}', 'file.css');
+  const linter = createLinter(['error', { base: 4, units: ['pc'] }]);
+  const res = await linter.lintText('.a{margin:5pc;}', 'file.css');
   assert.equal(res.messages.length, 1);
 });
 


### PR DESCRIPTION
## Summary
- allow additional CSS units like `ch` and viewport units in dimension tokens
- warn instead of error for unknown dimension units
- document extended unit support and rule options

## Testing
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68c4b03cea708328bb3d0db50531255f