### PR TITLE
fix(color): enforce object color tokens with component arrays

### DIFF
--- a/.changeset/add-hsl-hwb-color-spaces.md
+++ b/.changeset/add-hsl-hwb-color-spaces.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+add hsl and hwb color space validation

--- a/.changeset/enforce-color-component-ranges.md
+++ b/.changeset/enforce-color-component-ranges.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': patch
+---
+
+validate color component ranges, alpha bounds, and hex format
+

--- a/.changeset/normalize-color-function-syntax.md
+++ b/.changeset/normalize-color-function-syntax.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix color normalization to use proper syntax for non-srgb color spaces

--- a/.changeset/reject-non-finite-numbers.md
+++ b/.changeset/reject-non-finite-numbers.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+reject non-finite numbers in numeric token validators

--- a/.changeset/reject-string-color-tokens.md
+++ b/.changeset/reject-string-color-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+reject raw string color values and require object format with component arrays

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,12 +59,15 @@ Inline example:
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#ff0000" },
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 0, 0] }
+      },
       "secondary": { "$type": "color", "$value": "{color.primary}" }
     },
     "space": {
-      "sm": { "$type": "dimension", "$value": "4px" },
-      "md": { "$type": "dimension", "$value": "8px" }
+      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
+      "md": { "$type": "dimension", "$value": { "value": 8, "unit": "px" } }
     }
   }
 }
@@ -78,7 +81,10 @@ Organise tokens by category—such as `color`, `space`, or `typography`—to mir
     "light": "./light.tokens.json",
     "dark": {
       "color": {
-        "primary": { "$type": "color", "$value": "#ffffff" },
+        "primary": {
+          "$type": "color",
+          "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+        },
         "secondary": { "$type": "color", "$value": "{color.primary}" }
       }
     }
@@ -164,7 +170,10 @@ import { defineConfig } from '@lapidist/design-lint';
 export default defineConfig({
   tokens: {
     color: {
-      primary: { $type: 'color', $value: '#ff0000' },
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 0, 0] },
+      },
       secondary: { $type: 'color', $value: '{color.primary}' },
     },
   },

--- a/docs/rules/design-token/letter-spacing.md
+++ b/docs/rules/design-token/letter-spacing.md
@@ -15,7 +15,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "letterSpacings": {
-      "tight": { "$type": "dimension", "$value": { "value": -0.05, "unit": "em" } },
+      "tight": { "$type": "dimension", "$value": { "value": -0.05, "unit": "rem" } },
       "loose": { "$type": "dimension", "$value": "{letterSpacings.tight}" }
     }
   },
@@ -41,7 +41,7 @@ This rule is not auto-fixable.
 ### Valid
 
 ```css
-.text { letter-spacing: -0.05em; }
+.text { letter-spacing: -0.05rem; }
 .text { letter-spacing: 0; }
 ```
 

--- a/src/core/parser/normalize-colors.ts
+++ b/src/core/parser/normalize-colors.ts
@@ -4,6 +4,46 @@ import { validateColor } from '../token-validators/color.js';
 
 export type ColorSpace = 'rgb' | 'hsl' | 'hex';
 
+function buildColorString(
+  colorSpace: string,
+  components: (number | 'none')[],
+  alpha?: number,
+): string {
+  const alphaString = typeof alpha === 'number' ? ` / ${String(alpha)}` : '';
+  const parts = components.map((c, i) => {
+    if (c === 'none') return 'none';
+    switch (colorSpace) {
+      case 'hsl':
+      case 'hwb':
+        return i === 0 ? String(c) : `${String(c)}%`;
+      case 'lab':
+      case 'lch':
+      case 'oklab':
+      case 'oklch':
+        return i === 0 ? `${String(c)}%` : String(c);
+      default:
+        return String(c);
+    }
+  });
+
+  switch (colorSpace) {
+    case 'hsl':
+      return `hsl(${parts.join(' ')}${alphaString})`;
+    case 'hwb':
+      return `hwb(${parts.join(' ')}${alphaString})`;
+    case 'lab':
+      return `lab(${parts.join(' ')}${alphaString})`;
+    case 'lch':
+      return `lch(${parts.join(' ')}${alphaString})`;
+    case 'oklab':
+      return `oklab(${parts.join(' ')}${alphaString})`;
+    case 'oklch':
+      return `oklch(${parts.join(' ')}${alphaString})`;
+    default:
+      return `color(${colorSpace} ${parts.join(' ')}${alphaString})`;
+  }
+}
+
 export function normalizeColorValues(
   tokens: FlattenedToken[],
   space: ColorSpace,
@@ -11,26 +51,8 @@ export function normalizeColorValues(
   for (const token of tokens) {
     if (token.type !== 'color') continue;
     validateColor(token.value, token.path);
-    if (typeof token.value === 'string') {
-      const parsed = parse(token.value);
-      switch (space) {
-        case 'hsl':
-          token.value = formatHsl(parsed);
-          break;
-        case 'hex':
-          token.value = formatHex(parsed);
-          break;
-        case 'rgb':
-        default:
-          token.value = formatRgb(parsed);
-          break;
-      }
-      continue;
-    }
     const { colorSpace, components, alpha } = token.value;
-    const compString = Object.values(components).join(' ');
-    const alphaString = typeof alpha === 'number' ? ` / ${String(alpha)}` : '';
-    const parsed = parse(`color(${colorSpace} ${compString}${alphaString})`);
+    const parsed = parse(buildColorString(colorSpace, components, alpha));
     switch (space) {
       case 'hsl':
         token.value = formatHsl(parsed);

--- a/src/core/token-validators/dimension.ts
+++ b/src/core/token-validators/dimension.ts
@@ -10,6 +10,7 @@ export function validateDimension(value: unknown, path: string): void {
   if (
     isRecord(value) &&
     typeof value.value === 'number' &&
+    Number.isFinite(value.value) &&
     typeof value.unit === 'string' &&
     DIMENSION_UNITS.has(value.unit)
   ) {

--- a/src/core/token-validators/duration.ts
+++ b/src/core/token-validators/duration.ts
@@ -10,6 +10,7 @@ export function validateDuration(value: unknown, path: string): void {
   if (
     isRecord(value) &&
     typeof value.value === 'number' &&
+    Number.isFinite(value.value) &&
     typeof value.unit === 'string' &&
     DURATION_UNITS.has(value.unit)
   ) {

--- a/src/core/token-validators/number.ts
+++ b/src/core/token-validators/number.ts
@@ -1,4 +1,4 @@
 export function validateNumber(value: unknown, path: string): void {
-  if (typeof value === 'number') return;
+  if (typeof value === 'number' && Number.isFinite(value)) return;
   throw new Error(`Token ${path} has invalid number value`);
 }

--- a/tests/core/color-validator.test.ts
+++ b/tests/core/color-validator.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validateColor } from '../../src/core/token-validators/color.js';
+
+void test('validateColor accepts components, alpha, and hex within range', () => {
+  const value = {
+    colorSpace: 'srgb',
+    components: [0, 0.5, 1],
+    alpha: 0.5,
+    hex: '#007fff',
+  } as const;
+  assert.doesNotThrow(() => {
+    validateColor(value, 'test');
+  });
+});
+
+void test('validateColor rejects components outside allowed range', () => {
+  const value = {
+    colorSpace: 'srgb',
+    components: [2, 0, 0],
+  } as const;
+  assert.throws(() => {
+    validateColor(value, 'test');
+  });
+});
+
+void test('validateColor rejects alpha outside 0-1', () => {
+  const value = {
+    colorSpace: 'srgb',
+    components: [0, 0, 0],
+    alpha: -0.1,
+  } as const;
+  assert.throws(() => {
+    validateColor(value, 'test');
+  });
+});
+
+void test('validateColor rejects non-6-digit hex fallback', () => {
+  const value = {
+    colorSpace: 'srgb',
+    components: [0, 0, 0],
+    hex: '#fff',
+  } as const;
+  assert.throws(() => {
+    validateColor(value, 'test');
+  });
+});

--- a/tests/core/numeric-validators.test.ts
+++ b/tests/core/numeric-validators.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateNumber } from '../../src/core/token-validators/number.js';
+import { validateDimension } from '../../src/core/token-validators/dimension.js';
+import { validateDuration } from '../../src/core/token-validators/duration.js';
+
+void test('validateNumber rejects non-finite numbers', () => {
+  assert.throws(() => {
+    validateNumber(NaN, 'num');
+  }, /invalid number/);
+  assert.throws(() => {
+    validateNumber(Infinity, 'num');
+  }, /invalid number/);
+});
+
+void test('validateDimension rejects non-finite numbers', () => {
+  assert.throws(() => {
+    validateDimension({ value: NaN, unit: 'px' }, 'dim');
+  });
+  assert.throws(() => {
+    validateDimension({ value: Infinity, unit: 'px' }, 'dim');
+  });
+});
+
+void test('validateDuration rejects non-finite numbers', () => {
+  assert.throws(() => {
+    validateDuration({ value: NaN, unit: 's' }, 'dur');
+  });
+  assert.throws(() => {
+    validateDuration({ value: Infinity, unit: 's' }, 'dur');
+  });
+});

--- a/tests/core/token-parser.test.ts
+++ b/tests/core/token-parser.test.ts
@@ -210,6 +210,56 @@ void test('parseDesignTokens rejects legacy shorthand token values', () => {
   );
 });
 
+void test('parseDesignTokens accepts hsl color space tokens', () => {
+  const tokens: DesignTokens = {
+    color: {
+      $type: 'color',
+      hsl: {
+        $value: { colorSpace: 'hsl', components: [120, 100, 50] },
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(result[0].path, 'color.hsl');
+});
+
+void test('parseDesignTokens accepts hwb color space tokens', () => {
+  const tokens: DesignTokens = {
+    color: {
+      $type: 'color',
+      hwb: {
+        $value: { colorSpace: 'hwb', components: [60, 0, 0] },
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens);
+  assert.equal(result[0].path, 'color.hwb');
+});
+
+void test('parseDesignTokens rejects out-of-range hsl components', () => {
+  const tokens = {
+    color: {
+      $type: 'color',
+      bad: {
+        $value: { colorSpace: 'hsl', components: [360, 101, -1] },
+      },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /invalid color value/i);
+});
+
+void test('parseDesignTokens rejects out-of-range hwb components', () => {
+  const tokens = {
+    color: {
+      $type: 'color',
+      bad: {
+        $value: { colorSpace: 'hwb', components: [361, -1, 101] },
+      },
+    },
+  } as unknown as DesignTokens;
+  assert.throws(() => parseDesignTokens(tokens), /invalid color value/i);
+});
+
 void test('parseDesignTokens rejects tokens with mismatched $type and value', () => {
   const tokens = {
     color: { $type: 'color', bad: { $value: 123 as unknown as string } },
@@ -902,10 +952,28 @@ void test('parseDesignTokens rejects malformed color values', () => {
 
 void test('parseDesignTokens normalizes colors to rgb when configured', () => {
   const tokens: DesignTokens = {
-    color: { $type: 'color', green: { $value: 'hsl(120, 100%, 50%)' } },
+    color: {
+      $type: 'color',
+      green: {
+        $value: { colorSpace: 'hsl', components: [120, 100, 50] },
+      },
+    },
   };
   const result = parseDesignTokens(tokens, undefined, { colorSpace: 'rgb' });
   assert.equal(result[0].value, 'rgb(0, 255, 0)');
+});
+
+void test('parseDesignTokens normalizes hwb colors to hex when configured', () => {
+  const tokens: DesignTokens = {
+    color: {
+      $type: 'color',
+      green: {
+        $value: { colorSpace: 'hwb', components: [120, 0, 0] },
+      },
+    },
+  };
+  const result = parseDesignTokens(tokens, undefined, { colorSpace: 'hex' });
+  assert.equal(result[0].value, '#00ff00');
 });
 
 void test('parseDesignTokens applies custom transforms', () => {


### PR DESCRIPTION
## Summary
- validate color tokens using array-based components
- normalize color tokens from component arrays using proper syntax for HSL, HWB, Lab, LCH, OKLab, and OKLCH color spaces
- add hsl and hwb color space validation and tests
- enforce color component ranges, alpha bounds, and 6-digit hex fallback
- update changeset and tests for component array format
- reject non-finite numbers in numeric token validators
- document color and dimension tokens with spec-compliant examples

## Testing
- `npm run format`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run lint:md`
- `npm test` *(fails: 95 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c586d0e8108328916b52ea2dbea606