### PR TITLE
feat: add pointer lookups to token registry

### DIFF
--- a/.changeset/allow-pointer-registry-lookups.md
+++ b/.changeset/allow-pointer-registry-lookups.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": minor
+---
+
+feat: allow dot-path utilities and the token registry to accept JSON Pointer references

--- a/.changeset/dtif-json-pointer-resolution.md
+++ b/.changeset/dtif-json-pointer-resolution.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+- Swap the unmaintained `json-ptr` dependency for `@hyperjump/json-pointer` while preserving canonical DTIF fragment encoding.
+- Update pointer helpers to layer URI fragment encoding/decoding atop the shared library escapes so validation stays aligned with parser semantics and existing edge-case tests.

--- a/.changeset/dtif-overrides-parser.md
+++ b/.changeset/dtif-overrides-parser.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+support DTIF $overrides during parsing, validating inline override payloads and fallback chains, and tracking referenced aliases

--- a/.changeset/dtif-token-registry-pointer-lookups.md
+++ b/.changeset/dtif-token-registry-pointer-lookups.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Add pointer-aware lookups to the token registry so JSON Pointer fragments resolve
+consistently across themes.

--- a/.changeset/introduce-dtif-schema-validation.md
+++ b/.changeset/introduce-dtif-schema-validation.md
@@ -1,0 +1,6 @@
+---
+'@lapidist/design-lint': minor
+---
+
+- Add DTIF schema validation for token documents that declare `$version`, using `@lapidist/dtif-validator` with Ajv 2020 helpers.
+- Preserve DTIF `$value` fallback arrays by resolving aliases, exposing ordered fallbacks, and normalizing color entries alongside the primary value.

--- a/.changeset/refresh-dtif-docs.md
+++ b/.changeset/refresh-dtif-docs.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+docs: align configuration guidance and examples with DTIF

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![build](https://img.shields.io/github/actions/workflow/status/bylapidist/design-lint/ci.yml?label=CI&logo=github)](https://github.com/bylapidist/design-lint/actions)
 [![license](https://img.shields.io/npm/l/%40lapidist/design-lint.svg)](LICENSE)
 
-**@lapidist/design-lint** keeps JavaScript, TypeScript and style sheets aligned with your design system. It validates design tokens, flags unsupported components and offers rich formatting options for continuous integration pipelines. The linter operates solely on the [W3C Design Tokens format](https://www.designtokens.org/technical-reports/), serving as a reference implementation of the specification.
+**@lapidist/design-lint** keeps JavaScript, TypeScript and style sheets aligned with your design system. It validates design tokens, flags unsupported components and offers rich formatting options for continuous integration pipelines. The linter operates solely on the [Design Token Interchange Format (DTIF)](https://dtif.lapidist.net/), serving as a reference implementation of the specification.
 
 > This project is not ready for production use.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,7 +69,7 @@ Key methods:
 ### Token transforms
 Design token objects may originate from sources like Figma or Tokens Studio.
 Use `registerTokenTransform()` to supply converters that adapt these formats
-to the [W3C Design Tokens specification](./glossary.md#design-tokens).
+to the [DTIF specification](./glossary.md#design-tokens).
 Transforms run before token normalization and validation.
 `parseDesignTokens()` also accepts a `transforms` array for per-call transforms.
 

--- a/docs/examples/basic/designlint.config.json
+++ b/docs/examples/basic/designlint.config.json
@@ -2,7 +2,7 @@
   "tokens": {
     "color": {
       "primary": { "$type": "color", "$value": "#ff0000" },
-      "secondary": { "$type": "color", "$value": "{color.primary}" }
+      "secondary": { "$type": "color", "$ref": "#/color/primary" }
     }
   },
   "rules": {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -18,7 +18,7 @@ Key concepts used throughout the documentation.
 - [See also](#see-also)
 
 ## Design tokens
-Named values such as colours, spacing, or typography that describe your design system. design-lint uses the [W3C Design Tokens Community Group format](https://www.designtokens.org/technical-reports/) for all token files.
+Named values such as colours, spacing, or typography that describe your design system. design-lint uses the [Design Token Interchange Format (DTIF)](https://dtif.lapidist.net/) for all token files.
 
 ## Rule
 A check that validates code against the design system. Rules may be built-in or provided by plugins.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # @lapidist/design-lint
 
-@lapidist/design-lint keeps code and style sheets aligned with your design system. It understands design tokens, knows about modern frameworks, and runs wherever Node.js \>=22 is available. The project exclusively supports the [W3C Design Tokens format](./glossary.md#design-tokens), making it a reference implementation of the standard.
+@lapidist/design-lint keeps code and style sheets aligned with your design system. It understands design tokens, knows about modern frameworks, and runs wherever Node.js \>=22 is available. The project exclusively supports the [Design Token Interchange Format (DTIF)](./glossary.md#design-tokens), making it a reference implementation of the standard.
 
 ## Table of contents
 - [Why design-lint?](#why-design-lint)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,7 +6,7 @@ sidebar_position: 12
 
 # Migration from Style Dictionary
 
-Design systems often start with [Style Dictionary](https://amzn.github.io/style-dictionary/#/). The `generate` command in design-lint provides a similar token build pipeline while adhering strictly to the W3C Design Tokens format.
+Design systems often start with [Style Dictionary](https://amzn.github.io/style-dictionary/#/). The `generate` command in design-lint provides a similar token build pipeline while adhering strictly to the Design Token Interchange Format (DTIF).
 
 ## Before
 A typical Style Dictionary setup transforms tokens into multiple outputs:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -99,7 +99,7 @@ const rule: RuleModule<{ ignore?: string[] }> = {
 
 ### 3. Register token transforms
 If your plugin consumes design tokens from other tools, provide a transform to
-convert them to the W3C format. Register the transform inside `init`:
+convert them to DTIF. Register the transform inside `init`:
 
 ```ts
 import {

--- a/docs/rules/design-system/deprecation.md
+++ b/docs/rules/design-system/deprecation.md
@@ -21,7 +21,7 @@ Enable this rule in `designlint.config.*`. See [configuration](../../configurati
         "$deprecated": { "$replacement": "#/color/new" }
       },
       "new": { "$type": "color", "$value": "#fff" },
-      "alias": { "$type": "color", "$value": "{color.new}" }
+      "alias": { "$type": "color", "$ref": "#/color/new" }
     }
   },
   "rules": { "design-system/deprecation": "error" }

--- a/docs/rules/design-system/no-unused-tokens.md
+++ b/docs/rules/design-system/no-unused-tokens.md
@@ -23,7 +23,7 @@ Given this configuration:
   "tokens": {
     "color": {
       "primary": { "$type": "color", "$value": "#000000" },
-      "unused": { "$type": "color", "$value": "{color.primary}" }
+      "unused": { "$type": "color", "$ref": "#/color/primary" }
     }
   },
   "rules": { "design-system/no-unused-tokens": "warn" }

--- a/docs/rules/design-token/animation.md
+++ b/docs/rules/design-token/animation.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "animations": {
       "spin": { "$type": "string", "$value": "spin 1s linear infinite" },
-      "wiggle": { "$type": "string", "$value": "{animations.spin}" }
+      "wiggle": { "$type": "string", "$ref": "#/animations/spin" }
     }
   },
   "rules": { "design-token/animation": "error" }

--- a/docs/rules/design-token/blur.md
+++ b/docs/rules/design-token/blur.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "blurs": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": "{blurs.sm}" }
+      "md": { "$type": "dimension", "$ref": "#/blurs/sm" }
     }
   },
   "rules": { "design-token/blur": "error" }

--- a/docs/rules/design-token/border-color.md
+++ b/docs/rules/design-token/border-color.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "borderColors": {
       "primary": { "$type": "color", "$value": "#ffffff" },
-      "secondary": { "$type": "color", "$value": "{borderColors.primary}" }
+      "secondary": { "$type": "color", "$ref": "#/borderColors/primary" }
     }
   },
   "rules": { "design-token/border-color": "error" }

--- a/docs/rules/design-token/border-radius.md
+++ b/docs/rules/design-token/border-radius.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "borderRadius": {
       "sm": { "$type": "dimension", "$value": { "value": 2, "unit": "px" } },
-      "lg": { "$type": "dimension", "$value": "{borderRadius.sm}" }
+      "lg": { "$type": "dimension", "$ref": "#/borderRadius/sm" }
     }
   },
   "rules": { "design-token/border-radius": "error" }

--- a/docs/rules/design-token/border-width.md
+++ b/docs/rules/design-token/border-width.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "borderWidths": {
       "sm": { "$type": "dimension", "$value": { "value": 1, "unit": "px" } },
-      "lg": { "$type": "dimension", "$value": "{borderWidths.sm}" }
+      "lg": { "$type": "dimension", "$ref": "#/borderWidths/sm" }
     }
   },
   "rules": { "design-token/border-width": "error" }

--- a/docs/rules/design-token/box-shadow.md
+++ b/docs/rules/design-token/box-shadow.md
@@ -25,7 +25,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
           "color": "rgba(0,0,0,0.1)"
         }
       },
-      "md": { "$type": "shadow", "$value": "{shadows.sm}" }
+      "md": { "$type": "shadow", "$ref": "#/shadows/sm" }
     }
   },
   "rules": { "design-token/box-shadow": "error" }

--- a/docs/rules/design-token/colors.md
+++ b/docs/rules/design-token/colors.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "color": {
       "primary": { "$type": "color", "$value": "#ff0000" },
-      "secondary": { "$type": "color", "$value": "{color.primary}" }
+      "secondary": { "$type": "color", "$ref": "#/color/primary" }
     }
   },
   "rules": {

--- a/docs/rules/design-token/font-family.md
+++ b/docs/rules/design-token/font-family.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Inter, sans-serif" },
-      "alt": { "$type": "fontFamily", "$value": "{fonts.sans}" }
+      "alt": { "$type": "fontFamily", "$ref": "#/fonts/sans" }
     }
   },
   "rules": { "design-token/font-family": "error" }

--- a/docs/rules/design-token/font-size.md
+++ b/docs/rules/design-token/font-size.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "fontSizes": {
       "base": { "$type": "dimension", "$value": { "value": 1, "unit": "rem" } },
-      "lg": { "$type": "dimension", "$value": "{fontSizes.base}" }
+      "lg": { "$type": "dimension", "$ref": "#/fontSizes/base" }
     }
   },
   "rules": { "design-token/font-size": "error" }

--- a/docs/rules/design-token/font-weight.md
+++ b/docs/rules/design-token/font-weight.md
@@ -17,7 +17,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
     "fontWeights": {
       "regular": { "$type": "fontWeight", "$value": 400 },
       "bold": { "$type": "fontWeight", "$value": 700 },
-      "emphasis": { "$type": "fontWeight", "$value": "{fontWeights.bold}" }
+      "emphasis": { "$type": "fontWeight", "$ref": "#/fontWeights/bold" }
     }
   },
   "rules": { "design-token/font-weight": "error" }

--- a/docs/rules/design-token/letter-spacing.md
+++ b/docs/rules/design-token/letter-spacing.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "letterSpacings": {
       "tight": { "$type": "dimension", "$value": { "value": -0.05, "unit": "rem" } },
-      "loose": { "$type": "dimension", "$value": "{letterSpacings.tight}" }
+      "loose": { "$type": "dimension", "$ref": "#/letterSpacings/tight" }
     }
   },
   "rules": { "design-token/letter-spacing": "error" }

--- a/docs/rules/design-token/line-height.md
+++ b/docs/rules/design-token/line-height.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "lineHeights": {
       "base": { "$type": "number", "$value": 1.5 },
-      "tight": { "$type": "number", "$value": "{lineHeights.base}" }
+      "tight": { "$type": "number", "$ref": "#/lineHeights/base" }
     }
   },
   "rules": { "design-token/line-height": "error" }

--- a/docs/rules/design-token/opacity.md
+++ b/docs/rules/design-token/opacity.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "opacity": {
       "low": { "$type": "number", "$value": 0.2 },
-      "high": { "$type": "number", "$value": "{opacity.low}" }
+      "high": { "$type": "number", "$ref": "#/opacity/low" }
     }
   },
   "rules": { "design-token/opacity": "error" }

--- a/docs/rules/design-token/outline.md
+++ b/docs/rules/design-token/outline.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "outlines": {
       "focus": { "$type": "string", "$value": "2px solid #000" },
-      "active": { "$type": "string", "$value": "{outlines.focus}" }
+      "active": { "$type": "string", "$ref": "#/outlines/focus" }
     }
   },
   "rules": { "design-token/outline": "error" }

--- a/docs/rules/design-token/spacing.md
+++ b/docs/rules/design-token/spacing.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": "{spacing.sm}" }
+      "md": { "$type": "dimension", "$ref": "#/spacing/sm" }
     }
   },
   "rules": {

--- a/docs/rules/design-token/z-index.md
+++ b/docs/rules/design-token/z-index.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "zIndex": {
       "modal": { "$type": "number", "$value": 1000 },
-      "dropdown": { "$type": "number", "$value": "{zIndex.modal}" }
+      "dropdown": { "$type": "number", "$ref": "#/zIndex/modal" }
     }
   },
   "rules": { "design-token/z-index": "error" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@humanwhocodes/momoa": "3.3.9",
+        "@hyperjump/json-pointer": "^1.1.1",
         "@lapidist/dtif-schema": "^0.1.7",
         "@lapidist/dtif-validator": "^0.1.7",
         "@vue/compiler-sfc": "3.5.21",
@@ -1488,6 +1489,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@hyperjump/json-pointer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@hyperjump/json-pointer/-/json-pointer-1.1.1.tgz",
+      "integrity": "sha512-M0T3s7TC2JepoWPMZQn1W6eYhFh06OXwpMqL+8c5wMVpvnCKNsPgpu9u7WyCI03xVQti8JAeAy4RzUa6SYlJLA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jdesrosiers"
       }
     },
     "node_modules/@iconify-json/simple-icons": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "license": "MIT",
   "dependencies": {
     "@humanwhocodes/momoa": "3.3.9",
+    "@hyperjump/json-pointer": "^1.1.1",
     "@lapidist/dtif-schema": "^0.1.7",
     "@lapidist/dtif-validator": "^0.1.7",
     "@vue/compiler-sfc": "3.5.21",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -13,8 +13,8 @@ import { guards } from '../utils/index.js';
  * Validation schema for configuration files.
  *
  * Uses [Zod](https://zod.dev/) to ensure user-supplied configuration matches
- * expected shapes and that token definitions adhere to the W3C Design Tokens
- * format.
+ * expected shapes and that token definitions adhere to the Design Token
+ * Interchange Format (DTIF).
  */
 
 const {
@@ -56,7 +56,7 @@ const ruleSettingSchema = z.union([
 ]);
 
 /**
- * Schema ensuring a value follows the W3C Design Tokens format.
+ * Schema ensuring a value follows the DTIF specification.
  */
 const designTokensSchema = z.custom<DesignTokens>(isDesignTokenTree, {
   message: 'Tokens must be DTIF design token collections',

--- a/src/core/parser/index.ts
+++ b/src/core/parser/index.ts
@@ -3,7 +3,11 @@ import { buildParseTree } from './parse-tree.js';
 import { normalizeTokens } from './normalize.js';
 import { normalizeColorValues, type ColorSpace } from './normalize-colors.js';
 import { validateTokens } from './validate.js';
-import { canonicalizeDesignTokens } from './validate-dtif.js';
+import {
+  canonicalizeDesignTokens,
+  validateDesignTokensDocument,
+} from './validate-dtif.js';
+import { applyOverrides } from './overrides.js';
 
 export type TokenTransform = (tokens: DesignTokens) => DesignTokens;
 
@@ -39,11 +43,13 @@ export function parseDesignTokens(
     transformed = transform(transformed);
   }
   const canonical = canonicalizeDesignTokens(transformed);
+  validateDesignTokensDocument(canonical);
   const tree = buildParseTree(canonical, getLoc, options?.onWarn);
   normalizeTokens(tree, options?.onWarn);
   if (options?.colorSpace) {
     normalizeColorValues(tree, options.colorSpace);
   }
+  applyOverrides(canonical, tree, options?.onWarn);
   validateTokens(tree);
   return tree;
 }

--- a/src/core/parser/normalize.ts
+++ b/src/core/parser/normalize.ts
@@ -8,12 +8,17 @@ export function normalizeTokens(
   const tokensByPath = new Map(tokens.map((t) => [t.path, t]));
   const warnings: string[] = [];
   for (const token of tokens) {
-    const { value, references } = resolveReferences(
+    const { value, references, fallbacks } = resolveReferences(
       token,
       tokensByPath,
       warnings,
     );
     token.value = value;
+    if (fallbacks && fallbacks.length > 0) {
+      token.fallbacks = fallbacks;
+    } else {
+      delete token.fallbacks;
+    }
     if (references.length > 0) {
       token.aliases = Array.from(new Set(references));
     } else if (token.aliases) {

--- a/src/core/parser/overrides.ts
+++ b/src/core/parser/overrides.ts
@@ -1,0 +1,300 @@
+import type {
+  FallbackEntry,
+  FallbackChain,
+  OverrideRule,
+  Overrides,
+} from '@lapidist/dtif-schema';
+import { pointerToPath } from '../../utils/tokens/index.js';
+import type {
+  DesignTokens,
+  FlattenedToken,
+  TokenOverride,
+  TokenOverrideFallback,
+} from '../types.js';
+import {
+  validatorRegistry,
+  type TokenValidator,
+  type ValidationTokenInfo,
+} from '../token-validators/index.js';
+
+function hasOwn<T extends object, K extends PropertyKey>(
+  value: T,
+  key: K,
+): value is T & Record<K, unknown> {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function describeOverrideLocation(
+  token: Pick<FlattenedToken, 'path'>,
+  index: number,
+): string {
+  return `${token.path}[$overrides][${String(index)}]`;
+}
+
+function describeOverrideValueLocation(
+  token: Pick<FlattenedToken, 'path'>,
+  index: number,
+): string {
+  return `${describeOverrideLocation(token, index)}[$value]`;
+}
+
+function describeOverrideFallbackLocation(
+  token: Pick<FlattenedToken, 'path'>,
+  index: number,
+  fallbackPath: number[],
+): string {
+  let location = describeOverrideLocation(token, index);
+  for (const segment of fallbackPath) {
+    location += `[$fallback][${String(segment)}]`;
+  }
+  return location;
+}
+
+function describeOverrideFallbackValueLocation(
+  token: Pick<FlattenedToken, 'path'>,
+  index: number,
+  fallbackPath: number[],
+): string {
+  return `${describeOverrideFallbackLocation(token, index, fallbackPath)}[$value]`;
+}
+
+interface OverrideProcessingContext {
+  token: FlattenedToken;
+  overrideIndex: number;
+  validator: TokenValidator;
+  validationMap: Map<string, ValidationTokenInfo>;
+  tokensByPath: Map<string, FlattenedToken>;
+  warnings: string[];
+  references: Set<string>;
+}
+
+function normalizeFallbackEntry(
+  entry: FallbackEntry,
+  context: OverrideProcessingContext,
+  path: number[],
+): TokenOverrideFallback {
+  const {
+    token,
+    overrideIndex,
+    validator,
+    validationMap,
+    tokensByPath,
+    warnings,
+    references,
+  } = context;
+  const normalized: TokenOverrideFallback = {};
+
+  if (typeof entry.$ref === 'string') {
+    normalized.ref = entry.$ref;
+    const refPath = pointerToPath(entry.$ref);
+    if (!refPath) {
+      warnings.push(
+        `Override for token ${token.path} references unsupported fallback $ref ${entry.$ref}`,
+      );
+    } else {
+      normalized.refPath = refPath;
+      references.add(refPath);
+      const referenced = tokensByPath.get(refPath);
+      if (!referenced) {
+        throw new Error(
+          `Override for token ${token.path} references unknown fallback $ref ${entry.$ref}`,
+        );
+      }
+      if (token.type && referenced.type && token.type !== referenced.type) {
+        warnings.push(
+          `Override for token ${token.path} references fallback $ref ${entry.$ref} with mismatched $type ${referenced.type}; expected ${token.type}`,
+        );
+      }
+    }
+  }
+
+  if (hasOwn(entry, '$value')) {
+    const location = describeOverrideFallbackValueLocation(
+      token,
+      overrideIndex,
+      path,
+    );
+    validator(entry.$value, location, validationMap);
+    normalized.value = entry.$value;
+  }
+
+  if (entry.$fallback !== undefined) {
+    normalized.fallback = normalizeOverrideFallback(
+      entry.$fallback,
+      context,
+      path,
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeOverrideFallback(
+  chain: FallbackChain,
+  context: OverrideProcessingContext,
+  ancestry: number[] = [],
+): TokenOverrideFallback[] {
+  const entries = Array.isArray(chain) ? chain : [chain];
+  return entries.map((entry, index) =>
+    normalizeFallbackEntry(entry, context, [...ancestry, index]),
+  );
+}
+
+function createValidationMap(
+  tokens: FlattenedToken[],
+): Map<string, ValidationTokenInfo> {
+  return new Map(
+    tokens.map((token) => [
+      token.path,
+      {
+        $value: token.value,
+        ...(token.type ? { $type: token.type } : {}),
+      },
+    ]),
+  );
+}
+
+function normalizeOverride(
+  rule: OverrideRule,
+  index: number,
+  tokensByPath: Map<string, FlattenedToken>,
+  validationMap: Map<string, ValidationTokenInfo>,
+  warnings: string[],
+): { override: TokenOverride; references: Set<string> } {
+  if (typeof rule.$token !== 'string') {
+    throw new Error(
+      `Override at index ${String(index)} is missing $token pointer`,
+    );
+  }
+
+  const targetPath = pointerToPath(rule.$token);
+  if (!targetPath) {
+    throw new Error(
+      `Override for $token ${rule.$token} must reference a token in the same document`,
+    );
+  }
+
+  const target = tokensByPath.get(targetPath);
+  if (!target) {
+    throw new Error(
+      `Override for $token ${rule.$token} references unknown token`,
+    );
+  }
+
+  if (!target.type) {
+    throw new Error(
+      `Override for token ${target.path} cannot be applied because the token is missing $type`,
+    );
+  }
+
+  const validator = validatorRegistry.get(target.type);
+  if (!validator) {
+    throw new Error(
+      `Override for token ${target.path} cannot be applied because $type ${target.type} is not registered`,
+    );
+  }
+
+  const override: TokenOverride = {
+    pointer: rule.$token,
+    path: target.path,
+    conditions: rule.$when,
+  };
+  const references = new Set<string>();
+
+  if (hasOwn(rule, '$ref') && typeof rule.$ref === 'string') {
+    override.ref = rule.$ref;
+    const refPath = pointerToPath(rule.$ref);
+    if (!refPath) {
+      warnings.push(
+        `Override for token ${target.path} references unsupported $ref ${rule.$ref}`,
+      );
+    } else {
+      override.refPath = refPath;
+      references.add(refPath);
+      const referenced = tokensByPath.get(refPath);
+      if (!referenced) {
+        throw new Error(
+          `Override for token ${target.path} references unknown $ref ${rule.$ref}`,
+        );
+      }
+      if (referenced.type && referenced.type !== target.type) {
+        warnings.push(
+          `Override for token ${target.path} references $ref ${rule.$ref} with mismatched $type ${referenced.type}; expected ${target.type}`,
+        );
+      }
+    }
+  }
+
+  if (hasOwn(rule, '$value')) {
+    const location = describeOverrideValueLocation(target, index);
+    validator(rule.$value, location, validationMap);
+    override.value = rule.$value;
+  }
+
+  if (rule.$fallback !== undefined) {
+    override.fallback = normalizeOverrideFallback(rule.$fallback, {
+      token: target,
+      overrideIndex: index,
+      validator,
+      validationMap,
+      tokensByPath,
+      warnings,
+      references,
+    });
+  }
+
+  if (
+    !override.ref &&
+    !hasOwn(rule, '$value') &&
+    override.fallback === undefined
+  ) {
+    throw new Error(
+      `Override for token ${target.path} must provide $ref, $value, or $fallback`,
+    );
+  }
+
+  return { override, references };
+}
+
+export function applyOverrides(
+  document: DesignTokens,
+  tokens: FlattenedToken[],
+  warn: (msg: string) => void = console.warn,
+): void {
+  const overrides: Overrides | undefined = document.$overrides;
+  if (!overrides || overrides.length === 0) {
+    return;
+  }
+
+  const tokensByPath = new Map(tokens.map((token) => [token.path, token]));
+  const validationMap = createValidationMap(tokens);
+  const warnings: string[] = [];
+
+  overrides.forEach((rule, index) => {
+    const { override, references } = normalizeOverride(
+      rule,
+      index,
+      tokensByPath,
+      validationMap,
+      warnings,
+    );
+    const target = tokensByPath.get(override.path);
+    if (!target) {
+      return;
+    }
+    target.overrides = target.overrides ?? [];
+    target.overrides.push(override);
+
+    if (references.size > 0) {
+      const aliasSet = new Set(target.aliases ?? []);
+      for (const ref of references) {
+        aliasSet.add(ref);
+      }
+      target.aliases = Array.from(aliasSet);
+    }
+  });
+
+  for (const message of warnings) {
+    warn(message);
+  }
+}

--- a/src/core/parser/parse-tree.ts
+++ b/src/core/parser/parse-tree.ts
@@ -6,6 +6,7 @@ import type {
 } from '../types.js';
 import type { DeprecationMetadata } from '@lapidist/dtif-schema';
 import { guards } from '../../utils/index.js';
+import { segmentsToPointer } from '../../utils/tokens/index.js';
 
 const {
   data: { isRecord },
@@ -93,13 +94,8 @@ function validateNodeMetadata(
   validateDescription(Reflect.get(node, '$description'), path);
 }
 
-function encodePointerSegment(segment: string): string {
-  return segment.replace(/~/g, '~0').replace(/\//g, '~1');
-}
-
 function toPointer(segments: string[]): string {
-  if (segments.length === 0) return '#';
-  return `#/${segments.map(encodePointerSegment).join('/')}`;
+  return segmentsToPointer(segments);
 }
 
 function readString(

--- a/src/core/parser/token-values.ts
+++ b/src/core/parser/token-values.ts
@@ -1,0 +1,48 @@
+import type { FlattenedToken } from '../types.js';
+
+function collectTokenValues(
+  token: Pick<FlattenedToken, 'value' | 'fallbacks'>,
+): unknown[] {
+  const values: unknown[] = [];
+  if (token.value !== undefined) {
+    values.push(token.value);
+  }
+  if (Array.isArray(token.fallbacks)) {
+    values.push(...token.fallbacks);
+  }
+  return values;
+}
+
+export function forEachTokenValue(
+  token: Pick<FlattenedToken, 'value' | 'fallbacks'>,
+  iteratee: (value: unknown, index: number) => void,
+): void {
+  const values = collectTokenValues(token);
+  values.forEach((value, index) => {
+    iteratee(value, index);
+  });
+}
+
+export function mapTokenValues(
+  token: FlattenedToken,
+  mapper: (value: unknown, index: number) => unknown,
+): void {
+  const values = collectTokenValues(token);
+  if (values.length === 0) {
+    return;
+  }
+  const transformed = values.map(mapper);
+  const [primary, ...rest] = transformed;
+  token.value = primary;
+  token.fallbacks = rest.length > 0 ? rest : undefined;
+}
+
+export function describeTokenValueLocation(
+  token: Pick<FlattenedToken, 'path'>,
+  index: number,
+): string {
+  if (index === 0) {
+    return token.path;
+  }
+  return `${token.path}[$value][${String(index)}]`;
+}

--- a/src/core/parser/validate-dtif.ts
+++ b/src/core/parser/validate-dtif.ts
@@ -1,4 +1,174 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { DesignTokens } from '../types.js';
+
+const require = createRequire(import.meta.url);
+
+let validatorModulePromise:
+  | Promise<typeof import('@lapidist/dtif-validator')>
+  | undefined;
+
+function hasOwnProperty<T extends object, K extends PropertyKey>(
+  value: T,
+  key: K,
+): value is T & Record<K, unknown> {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function isDtifValidatorModule(
+  value: unknown,
+): value is typeof import('@lapidist/dtif-validator') {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const createValidator: unknown = Reflect.get(value, 'createDtifValidator');
+  return typeof createValidator === 'function';
+}
+
+function shouldValidateDtifDocument(tokens: DesignTokens): boolean {
+  if (hasOwnProperty(tokens, '$version')) {
+    return true;
+  }
+  if (hasOwnProperty(tokens, '$schema')) {
+    const schemaRef = tokens.$schema;
+    if (typeof schemaRef === 'string' && schemaRef.includes('dtif')) {
+      return true;
+    }
+  }
+  if (hasOwnProperty(tokens, '$overrides')) {
+    return true;
+  }
+  // TODO: broaden DTIF detection once legacy DTCG documents are fully migrated.
+  return false;
+}
+
+async function importDtifValidator(): Promise<
+  typeof import('@lapidist/dtif-validator')
+> {
+  validatorModulePromise ??= (async () => {
+    try {
+      return await import('@lapidist/dtif-validator');
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        typeof error.message === 'string' &&
+        (error.message.includes("Unexpected identifier 'assert'") ||
+          error.message.includes('deprecatedImportAssert'))
+      ) {
+        const originalPath = require.resolve('@lapidist/dtif-validator');
+        const source = await fs.readFile(originalPath, 'utf8');
+        const rewritten = source.replace(
+          /assert\s*\{\s*type:\s*'json'\s*\}/g,
+          "with { type: 'json' }",
+        );
+        const cacheDir = path.join(path.dirname(originalPath), '.cache');
+        await fs.mkdir(cacheDir, { recursive: true });
+        const cachePath = path.join(cacheDir, 'index.mjs');
+        await fs.writeFile(cachePath, rewritten, 'utf8');
+        const patchedModule: unknown = await import(
+          pathToFileURL(cachePath).href
+        );
+        if (!isDtifValidatorModule(patchedModule)) {
+          throw new Error('Failed to load DTIF validator');
+        }
+        return patchedModule;
+      }
+      throw error;
+    }
+  })();
+  return validatorModulePromise;
+}
+
+const { createDtifValidator } = await importDtifValidator();
+const dtifValidator = createDtifValidator();
+
+function toPointer(error: unknown): string {
+  const instancePath: unknown =
+    typeof error === 'object' && error !== null
+      ? Reflect.get(error, 'instancePath')
+      : undefined;
+  if (typeof instancePath === 'string' && instancePath.length > 0) {
+    return `#${instancePath}`;
+  }
+  const dataPath: unknown =
+    typeof error === 'object' && error !== null
+      ? Reflect.get(error, 'dataPath')
+      : undefined;
+  if (typeof dataPath === 'string' && dataPath.length > 0) {
+    if (dataPath.startsWith('#')) {
+      return dataPath;
+    }
+    if (dataPath.startsWith('.')) {
+      return `#${dataPath}`;
+    }
+    return `#/${dataPath}`;
+  }
+  return '#';
+}
+
+function formatError(error: unknown): string {
+  const pointer = toPointer(error);
+  const keyword: unknown =
+    typeof error === 'object' && error !== null
+      ? Reflect.get(error, 'keyword')
+      : undefined;
+  const params: unknown =
+    typeof error === 'object' && error !== null
+      ? Reflect.get(error, 'params')
+      : undefined;
+  if (keyword === 'required' && typeof params === 'object' && params !== null) {
+    const missingProperty: unknown = Reflect.get(params, 'missingProperty');
+    if (typeof missingProperty === 'string') {
+      return `${pointer} must have required property '${missingProperty}'`;
+    }
+  }
+  if (
+    keyword === 'additionalProperties' &&
+    typeof params === 'object' &&
+    params !== null
+  ) {
+    const additionalProperty: unknown = Reflect.get(
+      params,
+      'additionalProperty',
+    );
+    if (typeof additionalProperty === 'string') {
+      return `${pointer} must NOT have additional property '${additionalProperty}'`;
+    }
+  }
+  if (
+    keyword === 'unevaluatedProperties' &&
+    typeof params === 'object' &&
+    params !== null
+  ) {
+    const unevaluatedProperty: unknown = Reflect.get(
+      params,
+      'unevaluatedProperty',
+    );
+    if (typeof unevaluatedProperty === 'string') {
+      return `${pointer} must NOT have additional property '${unevaluatedProperty}'`;
+    }
+  }
+  const message: unknown =
+    typeof error === 'object' && error !== null
+      ? Reflect.get(error, 'message')
+      : undefined;
+  return `${pointer} ${typeof message === 'string' ? message : 'is invalid'}`;
+}
+
+export function validateDesignTokensDocument(tokens: DesignTokens): void {
+  if (!shouldValidateDtifDocument(tokens)) {
+    return;
+  }
+  const valid = dtifValidator.validate(tokens);
+  if (valid) {
+    return;
+  }
+  const errors = dtifValidator.validate.errors ?? [];
+  const details = errors.map((error) => `- ${formatError(error)}`).join('\n');
+  throw new Error(`DTIF validation failed:\n${details}`);
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/src/core/parser/validate.ts
+++ b/src/core/parser/validate.ts
@@ -2,6 +2,10 @@ import type { FlattenedToken } from '../types.js';
 import type { ValidationTokenInfo } from '../token-validators/index.js';
 import { validatorRegistry } from '../token-validators/index.js';
 import { guards } from '../../utils/index.js';
+import {
+  describeTokenValueLocation,
+  forEachTokenValue,
+} from './token-values.js';
 
 const {
   data: { isRecord },
@@ -61,7 +65,10 @@ function validateToken(
   if (!validator) {
     throw new Error(`Token ${token.path} has unknown $type ${token.type}`);
   }
-  validator(token.value, token.path, tokenMap);
+  forEachTokenValue(token, (candidate, index) => {
+    const location = describeTokenValueLocation(token, index);
+    validator(candidate, location, tokenMap);
+  });
 }
 
 export function validateTokens(tokens: FlattenedToken[]): void {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,6 +7,7 @@ import type {
   DeprecationMetadata,
   ExtensionsMap,
   Description,
+  OverrideConditions,
 } from '@lapidist/dtif-schema';
 import type { Environment } from './environment.js';
 
@@ -35,6 +36,23 @@ export type RootTokenGroup = DesignTokenInterchangeFormat;
  */
 export type DesignTokens = DesignTokenInterchangeFormat;
 
+export interface TokenOverrideFallback {
+  ref?: string;
+  refPath?: string;
+  value?: unknown;
+  fallback?: TokenOverrideFallback[];
+}
+
+export interface TokenOverride {
+  pointer: string;
+  path: string;
+  conditions: OverrideConditions;
+  ref?: string;
+  refPath?: string;
+  value?: unknown;
+  fallback?: TokenOverrideFallback[];
+}
+
 export interface FlattenedToken {
   /**
    * Legacy dot-delimited path used by existing rules and formatters.
@@ -45,9 +63,14 @@ export interface FlattenedToken {
    */
   pointer: string;
   value: unknown;
+  /**
+   * Ordered fallback candidates resolved after the primary value.
+   */
+  fallbacks?: unknown[];
   ref?: string;
   type?: string;
   aliases?: string[];
+  overrides?: TokenOverride[];
   metadata: {
     description?: Description;
     extensions?: ExtensionsMap;

--- a/src/utils/tokens/index.ts
+++ b/src/utils/tokens/index.ts
@@ -12,6 +12,8 @@ export {
   decodePointerSegment,
   pathToPointer,
   pointerToPath,
+  segmentsToPointer,
+  isPointerFragment,
 } from './pointer.js';
 export { matchToken, closestToken, type TokenPattern } from './pattern.js';
 export {

--- a/tests/core/token-registry.test.ts
+++ b/tests/core/token-registry.test.ts
@@ -24,6 +24,8 @@ void test('getToken retrieves tokens by theme and resolves aliases', () => {
   const registry = new TokenRegistry(tokens);
   assert.equal(registry.getToken('color.primary')?.value, '#fff');
   assert.equal(registry.getToken('color.secondary')?.value, '#fff');
+  assert.equal(registry.getToken('#/color/primary')?.value, '#fff');
+  assert.equal(registry.getToken('#/color/secondary')?.value, '#fff');
   assert.equal(registry.getToken('color.primary', 'dark')?.value, '#000');
 });
 
@@ -50,4 +52,21 @@ void test('getTokens returns flattened tokens and dedupes across themes', () => 
   const dark = registry.getTokens('dark');
   assert.equal(dark.length, 1);
   assert.equal(dark[0].path, 'color.primary');
+});
+
+void test('getTokenByPointer retrieves tokens across themes', () => {
+  const registry = new TokenRegistry(tokens);
+  assert.equal(registry.getTokenByPointer('#/color/primary')?.value, '#fff');
+  assert.equal(
+    registry.getTokenByPointer('#/color/primary', 'dark')?.value,
+    '#000',
+  );
+  assert.equal(
+    registry.getTokenByPointer('design.tokens.json#/color/primary')?.value,
+    '#fff',
+  );
+  assert.throws(
+    () => registry.getTokenByPointer('color.primary'),
+    /valid JSON Pointer fragment/,
+  );
 });

--- a/tests/utils/tokens/path.test.ts
+++ b/tests/utils/tokens/path.test.ts
@@ -9,10 +9,22 @@ void test('normalizePath rejects slash separators', () => {
   assert.throws(() => normalizePath('foo/bar-baz'));
 });
 
+void test('normalizePath converts JSON Pointer fragments to dot notation', () => {
+  assert.equal(normalizePath('#/color/base'), 'color.base');
+  assert.equal(
+    normalizePath('theme.tokens.json#/color/primary', 'camelCase'),
+    'color.primary',
+  );
+});
+
 void test('normalizePath applies case transforms', () => {
   assert.equal(normalizePath('foo.barBaz', 'kebab-case'), 'foo.bar-baz');
   assert.equal(normalizePath('foo.bar-baz', 'camelCase'), 'foo.barBaz');
   assert.equal(normalizePath('foo.bar-baz', 'PascalCase'), 'foo.BarBaz');
+});
+
+void test('normalizePath rejects invalid pointer fragments', () => {
+  assert.throws(() => normalizePath('#invalid-pointer'));
 });
 
 void test('toConstantName transforms paths to upper snake case', () => {

--- a/tests/utils/tokens/pointer.test.ts
+++ b/tests/utils/tokens/pointer.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  decodePointerSegment,
+  encodePointerSegment,
+  isPointerFragment,
+  pathToPointer,
+  pointerToPath,
+} from '../../../src/utils/tokens/index.js';
+
+void test('pathToPointer encodes special characters', () => {
+  assert.equal(pathToPointer('color.primary'), '#/color/primary');
+  assert.equal(pathToPointer('icon/home'), '#/icon~1home');
+  assert.equal(pathToPointer('shape.tilde~name'), '#/shape/tilde~0name');
+  assert.equal(
+    pathToPointer('palette.brand primary'),
+    '#/palette/brand%20primary',
+  );
+});
+
+void test('pointerToPath decodes fragment identifiers', () => {
+  assert.equal(pointerToPath('#/color/primary'), 'color.primary');
+  assert.equal(pointerToPath('#/icon~1home'), 'icon/home');
+  assert.equal(pointerToPath('#/shape/tilde~0name'), 'shape.tilde~name');
+  assert.equal(
+    pointerToPath('#/palette/brand%20primary'),
+    'palette.brand primary',
+  );
+});
+
+void test('pointerToPath ignores external document pointers', () => {
+  assert.equal(pointerToPath('design-tokens.json#/color/primary'), undefined);
+});
+
+void test('pointerToPath rejects invalid pointer fragments', () => {
+  assert.equal(pointerToPath('#/invalid~2segment'), undefined);
+  assert.equal(pointerToPath('not-a-pointer'), undefined);
+});
+
+void test('encodePointerSegment mirrors decodePointerSegment', () => {
+  const original = 'icons/set with space~special/name';
+  const encoded = encodePointerSegment(original);
+  assert.equal(decodePointerSegment(encoded), original);
+  assert.equal(encoded, 'icons~1set%20with%20space~0special~1name');
+});
+
+void test('pointerToPath handles numeric segments', () => {
+  assert.equal(pointerToPath('#/palette/0'), 'palette.0');
+  assert.equal(pathToPointer('palette.0'), '#/palette/0');
+});
+
+void test('isPointerFragment validates JSON Pointer fragments', () => {
+  assert.equal(isPointerFragment('#/color/primary'), true);
+  assert.equal(isPointerFragment('#/palette/brand%20primary'), true);
+  assert.equal(isPointerFragment('#/invalid~2segment'), false);
+  assert.equal(isPointerFragment('not-a-pointer'), false);
+});


### PR DESCRIPTION
## Summary
- index flattened tokens by both dot paths and JSON Pointer fragments so pointer queries resolve reliably
- add `getTokenByPointer` for theme-aware pointer lookups and cover fragment error handling in the registry tests

## Testing
- npm run lint
- CI=1 npm run format:check
- npm test
- npm run build
- npm run lint:md

------
https://chatgpt.com/codex/tasks/task_e_68cfdb4a35ec832894fa67ab05f5a740