### PR TITLE
feat: resolve tokens by pointer fragments

### DIFF
--- a/.changeset/alias-pointers-use-pointer-fragments.md
+++ b/.changeset/alias-pointers-use-pointer-fragments.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': major
+---
+
+track token alias relationships as JSON Pointer fragments instead of dot-delimited paths

--- a/.changeset/allow-slashes-in-token-paths.md
+++ b/.changeset/allow-slashes-in-token-paths.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Allow design token paths to include forward slashes by normalizing JSON Pointer fragments rather than rejecting `/` characters. Update token parsing, flattening, and registries to preserve escaped segments and emit valid constant names for slash-containing tokens.

--- a/.changeset/cli-exports-pointer-keys.md
+++ b/.changeset/cli-exports-pointer-keys.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': major
+---
+
+Update the `tokens` CLI command and unused token reports to surface canonical JSON Pointer fragments, emitting pointer-keyed exports and pointer metadata alongside resolved token values.

--- a/.changeset/dtif-dimension-units.md
+++ b/.changeset/dtif-dimension-units.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Expand dimension token validation to accept all DTIF measurement types and align tests with the new unit semantics.

--- a/.changeset/dtif-dimension-values.md
+++ b/.changeset/dtif-dimension-values.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': major
+---
+
+migrate dimension token validation to require DTIF measurement objects and update fixtures and tests accordingly.

--- a/.changeset/enforce-dtif-validation.md
+++ b/.changeset/enforce-dtif-validation.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+Reject $deprecated replacement pointers that omit JSON Pointer fragments so metadata cannot reference tokens outside the document.

--- a/.changeset/pointer-fragment-resolution.md
+++ b/.changeset/pointer-fragment-resolution.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+Index reference resolution and overrides by canonical JSON Pointer fragments so alias tracking no longer depends on dot-delimited paths, and add coverage for document-scoped override pointers.

--- a/.changeset/resolve-inline-fallbacks.md
+++ b/.changeset/resolve-inline-fallbacks.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Handle inline DTIF fallback entries and nested fallback chains when parsing tokens.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,7 +97,7 @@ npx design-lint validate --config designlint.config.json
 ```
 
 ## Export resolved tokens
-Use the `tokens` subcommand to write flattened tokens to a file or stdout. Alias references are resolved and metadata like `$extensions` is preserved:
+Use the `tokens` subcommand to write flattened tokens to a file or stdout. Alias references are resolved, metadata like `$extensions` is preserved, and each entry is keyed by the token's canonical JSON Pointer fragment:
 
 ```bash
 npx design-lint tokens --out tokens.json

--- a/src/cli/tokens.ts
+++ b/src/cli/tokens.ts
@@ -43,11 +43,20 @@ export async function exportTokens(
       onWarn,
     });
     output[theme] = {};
-    for (const { path: p, value, type, aliases, metadata } of flat) {
+    for (const { path: p, pointer, value, type, aliases, metadata } of flat) {
       // Prevent prototype pollution from malicious keys
-      if (p === '__proto__' || p === 'constructor' || p === 'prototype')
+      if (
+        p === '__proto__' ||
+        p === 'constructor' ||
+        p === 'prototype' ||
+        pointer === '__proto__' ||
+        pointer === 'constructor' ||
+        pointer === 'prototype'
+      )
         continue;
-      output[theme][p] = {
+      output[theme][pointer] = {
+        path: p,
+        pointer,
         value,
         type,
         ...(aliases ? { aliases } : {}),

--- a/src/core/parser/normalize.ts
+++ b/src/core/parser/normalize.ts
@@ -5,12 +5,12 @@ export function normalizeTokens(
   tokens: FlattenedToken[],
   warn: (msg: string) => void = console.warn,
 ): FlattenedToken[] {
-  const tokensByPath = new Map(tokens.map((t) => [t.path, t]));
+  const tokensByPointer = new Map(tokens.map((t) => [t.pointer, t]));
   const warnings: string[] = [];
   for (const token of tokens) {
     const { value, references, fallbacks } = resolveReferences(
       token,
-      tokensByPath,
+      tokensByPointer,
       warnings,
     );
     token.value = value;

--- a/src/core/parser/validate.ts
+++ b/src/core/parser/validate.ts
@@ -74,7 +74,7 @@ function validateToken(
 export function validateTokens(tokens: FlattenedToken[]): void {
   const tokenMap = new Map<string, ValidationTokenInfo>(
     tokens.map((t) => [
-      t.path,
+      t.pointer,
       {
         $value: t.value,
         ...(t.type ? { $type: t.type } : {}),

--- a/src/core/token-tracker.ts
+++ b/src/core/token-tracker.ts
@@ -95,14 +95,18 @@ export class TokenTracker {
       if (unused.length) {
         results.push({
           sourceId: configPath,
-          messages: unused.map(([value, info]) => ({
+          messages: unused.map(([matchValue, info]) => ({
             ruleId,
-            message: `Token ${value} is defined but never used`,
+            message: `Token ${info.pointer} is defined but never used`,
             severity,
             line: 1,
             column: 1,
             metadata: {
               path: info.path,
+              pointer: info.pointer,
+              value: info.value,
+              type: info.type,
+              matchValue,
               deprecated: info.metadata.deprecated,
               extensions: info.metadata.extensions,
             },

--- a/src/core/token-validators/dimension.ts
+++ b/src/core/token-validators/dimension.ts
@@ -4,17 +4,79 @@ const {
   data: { isRecord },
 } = guards;
 
-const DIMENSION_UNITS = new Set(['px', 'rem']);
+const ALLOWED_DIMENSION_TYPES = new Set([
+  'length',
+  'angle',
+  'resolution',
+  'custom',
+]);
+const DIMENSION_KEYS = new Set(['dimensionType', 'value', 'unit', 'fontScale']);
+const LENGTH_UNIT_PATTERN = /^(?:%|[A-Za-z][A-Za-z0-9-]*)$/;
+const ANGLE_OR_RESOLUTION_UNIT_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
+const CUSTOM_UNIT_PATTERN = /^[a-z0-9]+(?:\.[a-z0-9-]+)+$/;
 
 export function validateDimension(value: unknown, path: string): void {
-  if (
-    isRecord(value) &&
-    typeof value.value === 'number' &&
-    Number.isFinite(value.value) &&
-    typeof value.unit === 'string' &&
-    DIMENSION_UNITS.has(value.unit)
-  ) {
-    return;
+  if (!isRecord(value)) {
+    throw new Error(`Token ${path} has invalid dimension value`);
   }
-  throw new Error(`Token ${path} has invalid dimension value`);
+
+  const dimensionType = Reflect.get(value, 'dimensionType');
+  const magnitude = Reflect.get(value, 'value');
+  const unit = Reflect.get(value, 'unit');
+  const fontScale = Reflect.get(value, 'fontScale');
+
+  if (
+    typeof dimensionType !== 'string' ||
+    !ALLOWED_DIMENSION_TYPES.has(dimensionType)
+  ) {
+    throw new Error(`Token ${path} has invalid dimension value`);
+  }
+
+  if (typeof magnitude !== 'number' || !Number.isFinite(magnitude)) {
+    throw new Error(`Token ${path} has invalid dimension value`);
+  }
+
+  if (typeof unit !== 'string') {
+    throw new Error(`Token ${path} has invalid dimension value`);
+  }
+
+  switch (dimensionType) {
+    case 'length':
+      if (!LENGTH_UNIT_PATTERN.test(unit)) {
+        throw new Error(`Token ${path} has invalid dimension value`);
+      }
+      break;
+    case 'angle':
+    case 'resolution':
+      if (!ANGLE_OR_RESOLUTION_UNIT_PATTERN.test(unit)) {
+        throw new Error(`Token ${path} has invalid dimension value`);
+      }
+      break;
+    case 'custom':
+      if (!CUSTOM_UNIT_PATTERN.test(unit)) {
+        throw new Error(`Token ${path} has invalid dimension value`);
+      }
+      break;
+    default:
+      throw new Error(`Token ${path} has invalid dimension value`);
+  }
+
+  if (fontScale !== undefined) {
+    if (dimensionType !== 'length') {
+      throw new Error(`Token ${path} has invalid dimension value`);
+    }
+    if (typeof fontScale !== 'boolean') {
+      throw new Error(`Token ${path} has invalid dimension value`);
+    }
+  }
+
+  for (const key of Object.keys(value)) {
+    if (!DIMENSION_KEYS.has(key)) {
+      throw new Error(`Token ${path} has invalid dimension value`);
+    }
+  }
+
+  if (dimensionType !== 'length' && 'fontScale' in value) {
+    throw new Error(`Token ${path} has invalid dimension value`);
+  }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -69,6 +69,9 @@ export interface FlattenedToken {
   fallbacks?: unknown[];
   ref?: string;
   type?: string;
+  /**
+   * Canonical JSON Pointer fragments referencing tokens this token depends on.
+   */
   aliases?: string[];
   overrides?: TokenOverride[];
   metadata: {

--- a/src/utils/tokens/flatten.ts
+++ b/src/utils/tokens/flatten.ts
@@ -7,6 +7,7 @@
 import { parseDesignTokens } from '../../core/parser/index.js';
 import type { DesignTokens, FlattenedToken } from '../../core/types.js';
 import { normalizePath, type NameTransform } from './path.js';
+import { isPointerFragment } from './pointer.js';
 
 export interface FlattenOptions {
   /** Optional transform applied to each path segment */
@@ -34,7 +35,11 @@ export function flattenDesignTokens(
     ...rest,
     path: normalizePath(path, transform),
     ...(aliases
-      ? { aliases: aliases.map((a) => normalizePath(a, transform)) }
+      ? {
+          aliases: aliases.map((alias) =>
+            isPointerFragment(alias) ? alias : normalizePath(alias, transform),
+          ),
+        }
       : {}),
   }));
 }

--- a/src/utils/tokens/index.ts
+++ b/src/utils/tokens/index.ts
@@ -13,6 +13,7 @@ export {
   pathToPointer,
   pointerToPath,
   segmentsToPointer,
+  extractPointerFragment,
   isPointerFragment,
 } from './pointer.js';
 export { matchToken, closestToken, type TokenPattern } from './pattern.js';

--- a/src/utils/tokens/path.ts
+++ b/src/utils/tokens/path.ts
@@ -33,10 +33,9 @@ function transformSegment(seg: string, transform?: NameTransform): string {
 /**
  * Normalize a token path to dot notation with optional case transforms.
  *
- * @param path - Original token path using dot separators.
+ * @param path - Original token path using dot separators or JSON Pointer fragments.
  * @param transform - Optional casing applied to each path segment.
  * @returns Normalized dot-notation path.
- * @throws If `path` contains `/` because the spec requires period-separated references.
  */
 export function normalizePath(path: string, transform?: NameTransform): string {
   let canonical = path;
@@ -57,10 +56,6 @@ export function normalizePath(path: string, transform?: NameTransform): string {
     canonical = pointerPath;
   }
 
-  if (canonical.includes('/')) {
-    throw new Error("Alias paths must use 'dot' notation; '/' is disallowed");
-  }
-
   const parts = canonical.split('.').filter(Boolean);
   return parts.map((p) => transformSegment(p, transform)).join('.');
 }
@@ -73,5 +68,5 @@ export function normalizePath(path: string, transform?: NameTransform): string {
  * @returns Upper snake-case representation of the provided path.
  */
 export function toConstantName(path: string): string {
-  return path.replace(/\./g, '_').replace(/-/g, '_').toUpperCase();
+  return path.replace(/[./]/g, '_').replace(/-/g, '_').toUpperCase();
 }

--- a/src/utils/tokens/pointer.ts
+++ b/src/utils/tokens/pointer.ts
@@ -116,6 +116,23 @@ export function segmentsToPointer(segments: readonly string[]): string {
 }
 
 /**
+ * Extract the JSON Pointer fragment portion from a pointer reference.
+ */
+export function extractPointerFragment(pointer: string): string | undefined {
+  const hashIndex = pointer.indexOf('#');
+  if (hashIndex === -1) {
+    return undefined;
+  }
+
+  const fragment = pointer.slice(hashIndex);
+  if (!isPointerFragment(fragment)) {
+    return undefined;
+  }
+
+  return fragment;
+}
+
+/**
  * Determine whether the provided fragment is a valid JSON Pointer fragment.
  */
 export function isPointerFragment(fragment: string): boolean {

--- a/tests/cli/tokens.test.ts
+++ b/tests/cli/tokens.test.ts
@@ -49,12 +49,26 @@ void test('tokens command exports resolved tokens with extensions', () => {
   assert.equal(res.status, 0);
   const out = JSON.parse(
     fs.readFileSync(path.join(dir, 'out.json'), 'utf8'),
-  ) as Record<string, Record<string, { value: unknown; extensions?: unknown }>>;
-  assert.equal(out.default['color.red'].value, '#ff0000');
-  assert.deepEqual(out.default['color.red'].extensions, {
+  ) as Record<
+    string,
+    Record<
+      string,
+      { path: string; pointer: string; value: unknown; extensions?: unknown }
+    >
+  >;
+  const red = out.default['#/color/red'];
+  assert(red);
+  assert.equal(red.value, '#ff0000');
+  assert.equal(red.path, 'color.red');
+  assert.equal(red.pointer, '#/color/red');
+  assert.deepEqual(red.extensions, {
     'vendor.ext': { foo: 'bar' },
   });
-  assert.equal(out.default['color.blue'].value, '#ff0000');
+  const blue = out.default['#/color/blue'];
+  assert(blue);
+  assert.equal(blue.value, '#ff0000');
+  assert.equal(blue.path, 'color.blue');
+  assert.equal(blue.pointer, '#/color/blue');
 });
 
 void test('tokens command reads config from outside cwd', () => {
@@ -86,9 +100,13 @@ void test('tokens command reads config from outside cwd', () => {
   assert.equal(res.status, 0);
   const out = JSON.parse(fs.readFileSync(outPath, 'utf8')) as Record<
     string,
-    Record<string, { value: unknown }>
+    Record<string, { value: unknown; path: string; pointer: string }>
   >;
-  assert.equal(out.default['color.red'].value, '#ff0000');
+  const red = out.default['#/color/red'];
+  assert(red);
+  assert.equal(red.value, '#ff0000');
+  assert.equal(red.path, 'color.red');
+  assert.equal(red.pointer, '#/color/red');
 });
 
 void test('tokens command exports themes with root tokens', () => {
@@ -115,8 +133,12 @@ void test('tokens command exports themes with root tokens', () => {
   assert.equal(res.status, 0);
   const out = JSON.parse(res.stdout) as Record<
     string,
-    Record<string, { value: unknown }>
+    Record<string, { value: unknown; path: string; pointer: string }>
   >;
-  assert.equal(out.light.primary.value, '#fff');
-  assert.equal(out.dark.primary.value, '#000');
+  assert.equal(out.light['#/primary'].value, '#fff');
+  assert.equal(out.light['#/primary'].path, 'primary');
+  assert.equal(out.light['#/primary'].pointer, '#/primary');
+  assert.equal(out.dark['#/primary'].value, '#000');
+  assert.equal(out.dark['#/primary'].path, 'primary');
+  assert.equal(out.dark['#/primary'].pointer, '#/primary');
 });

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -116,21 +116,21 @@ void test('validates additional token groups', async () => {
       tokens: {
         borderRadius: {
           $type: 'dimension',
-          sm: { $value: { value: 2, unit: 'px' } },
+          sm: { $value: { dimensionType: 'length', value: 2, unit: 'px' } },
         },
         borderWidths: {
           $type: 'dimension',
-          sm: { $value: { value: 1, unit: 'px' } },
+          sm: { $value: { dimensionType: 'length', value: 1, unit: 'px' } },
         },
         shadows: {
           $type: 'shadow',
           sm: {
             $value: {
               color: '#000',
-              offsetX: { value: 0, unit: 'px' },
-              offsetY: { value: 1, unit: 'px' },
-              blur: { value: 2, unit: 'px' },
-              spread: { value: 0, unit: 'px' },
+              offsetX: { dimensionType: 'length', value: 0, unit: 'px' },
+              offsetY: { dimensionType: 'length', value: 1, unit: 'px' },
+              blur: { dimensionType: 'length', value: 2, unit: 'px' },
+              spread: { dimensionType: 'length', value: 0, unit: 'px' },
             },
           },
         },

--- a/tests/core/flatten-design-tokens.test.ts
+++ b/tests/core/flatten-design-tokens.test.ts
@@ -18,7 +18,7 @@ void test('flattenDesignTokens collects token paths and inherits types', () => {
     size: {
       spacing: {
         $type: 'dimension',
-        small: { $value: { value: 4, unit: 'px' } },
+        small: { $value: { dimensionType: 'length', value: 4, unit: 'px' } },
       },
     },
   };
@@ -48,11 +48,29 @@ void test('flattenDesignTokens collects token paths and inherits types', () => {
     {
       path: 'size.spacing.small',
       pointer: '#/size/spacing/small',
-      value: { value: 4, unit: 'px' },
+      value: { dimensionType: 'length', value: 4, unit: 'px' },
       type: 'dimension',
       metadata: { loc: { line: 1, column: 1 } },
     },
   ]);
+});
+
+void test('flattenDesignTokens preserves slash characters in token paths', () => {
+  const tokens: DesignTokens = {
+    icons: {
+      $type: 'color',
+      'icon/home': { $value: '#000000' },
+      alias: { $ref: '#/icons/icon~1home' },
+    },
+  };
+
+  const flat = flattenDesignTokens(tokens);
+  const home = flat.find((token) => token.path === 'icons.icon/home');
+  assert(home);
+  assert.equal(home.pointer, '#/icons/icon~1home');
+  const alias = flat.find((token) => token.path === 'icons.alias');
+  assert(alias);
+  assert.deepEqual(alias.aliases, ['#/icons/icon~1home']);
 });
 
 void test('flattenDesignTokens preserves $extensions and inherits $deprecated', () => {
@@ -103,7 +121,7 @@ void test('flattenDesignTokens resolves $ref references', () => {
       value: '#fff',
       ref: '#/color/base',
       type: 'color',
-      aliases: ['color.base'],
+      aliases: ['#/color/base'],
       metadata: { loc: { line: 1, column: 1 } },
     },
   ]);
@@ -167,7 +185,7 @@ void test('flattenDesignTokens applies name transforms', () => {
       value: '#000',
       ref: '#/ColorGroup/primaryColor',
       type: 'color',
-      aliases: ['color-group.primary-color'],
+      aliases: ['#/ColorGroup/primaryColor'],
       metadata: { loc: { line: 1, column: 1 } },
     },
   ]);

--- a/tests/core/get-flattened-tokens.test.ts
+++ b/tests/core/get-flattened-tokens.test.ts
@@ -105,7 +105,7 @@ void test('getFlattenedTokens resolves $ref references', () => {
       value: '#f00',
       ref: '#/palette/base',
       type: 'color',
-      aliases: ['palette.base'],
+      aliases: ['#/palette/base'],
       metadata: {
         loc: { line: 1, column: 1 },
       },

--- a/tests/core/numeric-validators.test.ts
+++ b/tests/core/numeric-validators.test.ts
@@ -15,10 +15,58 @@ void test('validateNumber rejects non-finite numbers', () => {
 
 void test('validateDimension rejects non-finite numbers', () => {
   assert.throws(() => {
-    validateDimension({ value: NaN, unit: 'px' }, 'dim');
+    validateDimension(
+      { dimensionType: 'length', value: NaN, unit: 'px' },
+      'dim',
+    );
   });
   assert.throws(() => {
-    validateDimension({ value: Infinity, unit: 'px' }, 'dim');
+    validateDimension(
+      { dimensionType: 'length', value: Infinity, unit: 'px' },
+      'dim',
+    );
+  });
+});
+
+void test('validateDimension accepts DTIF dimension units', () => {
+  assert.doesNotThrow(() => {
+    validateDimension({ dimensionType: 'length', value: 1, unit: 'em' }, 'dim');
+  });
+  assert.doesNotThrow(() => {
+    validateDimension({ dimensionType: 'length', value: 1, unit: '%' }, 'dim');
+  });
+  assert.doesNotThrow(() => {
+    validateDimension(
+      { dimensionType: 'angle', value: 45, unit: 'deg' },
+      'dim',
+    );
+  });
+  assert.doesNotThrow(() => {
+    validateDimension(
+      { dimensionType: 'resolution', value: 2, unit: 'dppx' },
+      'dim',
+    );
+  });
+  assert.doesNotThrow(() => {
+    validateDimension(
+      { dimensionType: 'custom', value: 1, unit: 'acme.spacing.sm' },
+      'dim',
+    );
+  });
+});
+
+void test('validateDimension enforces fontScale constraints', () => {
+  assert.throws(() => {
+    validateDimension(
+      { dimensionType: 'angle', value: 1, unit: 'deg', fontScale: true },
+      'dim',
+    );
+  });
+  assert.throws(() => {
+    validateDimension(
+      { dimensionType: 'length', value: 1, unit: 'px', fontScale: 1 as never },
+      'dim',
+    );
   });
 });
 

--- a/tests/core/token-registry.test.ts
+++ b/tests/core/token-registry.test.ts
@@ -70,3 +70,17 @@ void test('getTokenByPointer retrieves tokens across themes', () => {
     /valid JSON Pointer fragment/,
   );
 });
+
+void test('TokenRegistry resolves tokens whose names contain slash characters', () => {
+  const registry = new TokenRegistry({
+    default: {
+      icons: {
+        $type: 'color',
+        'icon/home': { $value: '#000000' },
+      },
+    },
+  });
+
+  assert.equal(registry.getToken('icons.icon/home')?.value, '#000000');
+  assert.equal(registry.getToken('#/icons/icon~1home')?.value, '#000000');
+});

--- a/tests/fixtures/nextjs/designlint.config.json
+++ b/tests/fixtures/nextjs/designlint.config.json
@@ -4,10 +4,10 @@
       "primary": { "$type": "color", "$value": "#000000" }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 12, "unit": "px" } }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }

--- a/tests/fixtures/nuxt/designlint.config.json
+++ b/tests/fixtures/nuxt/designlint.config.json
@@ -4,10 +4,10 @@
       "primary": { "$type": "color", "$value": "#000000" }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 12, "unit": "px" } }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }

--- a/tests/fixtures/react-vite-css-modules/designlint.config.json
+++ b/tests/fixtures/react-vite-css-modules/designlint.config.json
@@ -5,10 +5,10 @@
       "unused": { "$type": "color", "$value": "#ffffff" }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 12, "unit": "px" } }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }

--- a/tests/fixtures/remix/designlint.config.json
+++ b/tests/fixtures/remix/designlint.config.json
@@ -4,10 +4,10 @@
       "primary": { "$type": "color", "$value": "#000000" }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 12, "unit": "px" } }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }

--- a/tests/fixtures/svelte/designlint.config.json
+++ b/tests/fixtures/svelte/designlint.config.json
@@ -4,10 +4,10 @@
       "primary": { "$type": "color", "$value": "#000000" }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 12, "unit": "px" } }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }

--- a/tests/fixtures/vue/designlint.config.json
+++ b/tests/fixtures/vue/designlint.config.json
@@ -4,10 +4,10 @@
       "primary": { "$type": "color", "$value": "#000000" }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 12, "unit": "px" } }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }

--- a/tests/fixtures/web-components/designlint.config.json
+++ b/tests/fixtures/web-components/designlint.config.json
@@ -4,10 +4,10 @@
       "primary": { "$type": "color", "$value": "#000000" }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 4, "unit": "px" } }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": { "$type": "dimension", "$value": { "dimensionType": "length", "value": 12, "unit": "px" } }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }

--- a/tests/rules/blur.test.ts
+++ b/tests/rules/blur.test.ts
@@ -5,7 +5,10 @@ import { FileSource } from '../../src/adapters/node/file-source.js';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
-  blurs: { $type: 'dimension', sm: { $value: { value: 4, unit: 'px' } } },
+  blurs: {
+    $type: 'dimension',
+    sm: { $value: { dimensionType: 'length', value: 4, unit: 'px' } },
+  },
 };
 
 function createLinter() {

--- a/tests/rules/border-radius.test.ts
+++ b/tests/rules/border-radius.test.ts
@@ -7,8 +7,8 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 const tokens = {
   radius: {
     $type: 'dimension',
-    sm: { $value: { value: 2, unit: 'px' } },
-    md: { $value: { value: 4, unit: 'px' } },
+    sm: { $value: { dimensionType: 'length', value: 2, unit: 'px' } },
+    md: { $value: { dimensionType: 'length', value: 4, unit: 'px' } },
   },
 };
 

--- a/tests/rules/border-width.test.ts
+++ b/tests/rules/border-width.test.ts
@@ -7,8 +7,8 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 const tokens = {
   borderWidths: {
     $type: 'dimension',
-    sm: { $value: { value: 1, unit: 'px' } },
-    md: { $value: { value: 2, unit: 'px' } },
+    sm: { $value: { dimensionType: 'length', value: 1, unit: 'px' } },
+    md: { $value: { dimensionType: 'length', value: 2, unit: 'px' } },
   },
 };
 

--- a/tests/rules/box-shadow.test.ts
+++ b/tests/rules/box-shadow.test.ts
@@ -9,19 +9,19 @@ const tokens = {
     $type: 'shadow',
     sm: {
       $value: {
-        offsetX: { value: 0, unit: 'px' },
-        offsetY: { value: 1, unit: 'px' },
-        blur: { value: 2, unit: 'px' },
-        spread: { value: 0, unit: 'px' },
+        offsetX: { dimensionType: 'length', value: 0, unit: 'px' },
+        offsetY: { dimensionType: 'length', value: 1, unit: 'px' },
+        blur: { dimensionType: 'length', value: 2, unit: 'px' },
+        spread: { dimensionType: 'length', value: 0, unit: 'px' },
         color: 'rgba(0,0,0,0.1)',
       },
     },
     lg: {
       $value: {
-        offsetX: { value: 0, unit: 'px' },
-        offsetY: { value: 2, unit: 'px' },
-        blur: { value: 4, unit: 'px' },
-        spread: { value: 0, unit: 'px' },
+        offsetX: { dimensionType: 'length', value: 0, unit: 'px' },
+        offsetY: { dimensionType: 'length', value: 2, unit: 'px' },
+        blur: { dimensionType: 'length', value: 4, unit: 'px' },
+        spread: { dimensionType: 'length', value: 0, unit: 'px' },
         color: 'rgba(0,0,0,0.2)',
       },
     },

--- a/tests/rules/font-size.test.ts
+++ b/tests/rules/font-size.test.ts
@@ -7,8 +7,8 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 const tokens = {
   fontSizes: {
     $type: 'dimension',
-    base: { $value: { value: 16, unit: 'px' } },
-    lg: { $value: { value: 32, unit: 'px' } },
+    base: { $value: { dimensionType: 'length', value: 16, unit: 'px' } },
+    lg: { $value: { dimensionType: 'length', value: 32, unit: 'px' } },
   },
 };
 

--- a/tests/rules/letter-spacing.test.ts
+++ b/tests/rules/letter-spacing.test.ts
@@ -7,8 +7,8 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 const tokens = {
   letterSpacings: {
     $type: 'dimension',
-    tight: { $value: { value: -0.05, unit: 'rem' } },
-    none: { $value: { value: 0, unit: 'rem' } },
+    tight: { $value: { dimensionType: 'length', value: -0.05, unit: 'rem' } },
+    none: { $value: { dimensionType: 'length', value: 0, unit: 'rem' } },
   },
 };
 

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -29,7 +29,9 @@ void test('design-system/no-unused-tokens reports unused tokens', async () => {
     .find((m) => m.ruleId === 'design-system/no-unused-tokens');
   assert(msg);
   assert.equal(msg.severity, 'warn');
-  assert.ok(msg.message.includes('#123456'));
+  assert.ok(msg.message.includes('#/color/unused'));
+  assert(msg.metadata);
+  assert.equal(msg.metadata.pointer, '#/color/unused');
 });
 
 void test('design-system/no-unused-tokens includes token metadata', async () => {
@@ -62,6 +64,9 @@ void test('design-system/no-unused-tokens includes token metadata', async () => 
   assert(msg);
   assert(msg.metadata);
   assert.equal(msg.metadata.path, 'color.unused');
+  assert.equal(msg.metadata.pointer, '#/color/unused');
+  assert.deepEqual(msg.metadata.value, '#123456');
+  assert.equal(msg.metadata.type, 'color');
   assert.equal(msg.metadata.deprecated, true);
   assert.deepEqual(msg.metadata.extensions, { 'vendor.foo': true });
 });

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -7,8 +7,8 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 const tokens = {
   spacing: {
     $type: 'dimension',
-    sm: { $value: { value: 4, unit: 'px' } },
-    md: { $value: { value: 8, unit: 'px' } },
+    sm: { $value: { dimensionType: 'length', value: 4, unit: 'px' } },
+    md: { $value: { dimensionType: 'length', value: 8, unit: 'px' } },
   },
 };
 

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -8,7 +8,7 @@ const config = {
     color: { $type: 'color', primary: { $value: '#000000' } },
     spacing: {
       $type: 'dimension',
-      sm: { $value: { value: 4, unit: 'px' } },
+      sm: { $value: { dimensionType: 'length', value: 4, unit: 'px' } },
     },
     opacity: { $type: 'number', full: { $value: 1 } },
   },

--- a/tests/rules/token-suggestion.test.ts
+++ b/tests/rules/token-suggestion.test.ts
@@ -7,8 +7,8 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 const tokens = {
   fontSizes: {
     $type: 'dimension',
-    sm: { $value: { value: 16, unit: 'px' } },
-    md: { $value: { value: 32, unit: 'px' } },
+    sm: { $value: { dimensionType: 'length', value: 16, unit: 'px' } },
+    md: { $value: { dimensionType: 'length', value: 32, unit: 'px' } },
   },
 };
 

--- a/tests/utils/tokens/path.test.ts
+++ b/tests/utils/tokens/path.test.ts
@@ -5,8 +5,9 @@ import {
   toConstantName,
 } from '../../../src/utils/tokens/index.js';
 
-void test('normalizePath rejects slash separators', () => {
-  assert.throws(() => normalizePath('foo/bar-baz'));
+void test('normalizePath preserves slash characters inside segments', () => {
+  assert.equal(normalizePath('icons.icon/home'), 'icons.icon/home');
+  assert.equal(normalizePath('#/icons/icon~1home'), 'icons.icon/home');
 });
 
 void test('normalizePath converts JSON Pointer fragments to dot notation', () => {
@@ -30,4 +31,5 @@ void test('normalizePath rejects invalid pointer fragments', () => {
 void test('toConstantName transforms paths to upper snake case', () => {
   assert.equal(toConstantName('color.primary'), 'COLOR_PRIMARY');
   assert.equal(toConstantName('color.primary-dark'), 'COLOR_PRIMARY_DARK');
+  assert.equal(toConstantName('icons.icon/home'), 'ICONS_ICON_HOME');
 });


### PR DESCRIPTION
## Summary
- reindex normalization, reference resolution, and overrides by canonical JSON Pointer fragments so pointer metadata stays consistent
- surface a reusable extractPointerFragment utility for pointer-aware modules
- validate $deprecated replacement pointers and add parser coverage for invalid metadata and document-scoped overrides

## Testing
- npm run lint
- npx prettier --log-level warn --check 'src/**/*.ts' 'tests/**/*.ts'
- npm test
- npm run build
- npm run lint:md

------
https://chatgpt.com/codex/tasks/task_e_68d00749027483288188055f598a8b93