### PR TITLE
feat(cli): expose dtif metadata in tokens export

### DIFF
--- a/.changeset/canonicalize-cross-document-pointers.md
+++ b/.changeset/canonicalize-cross-document-pointers.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Support DTIF cross-document pointer handling by canonicalizing fragments with document URIs and updating path utilities to preserve them during normalization.

--- a/.changeset/dtif-deprecation-rule.md
+++ b/.changeset/dtif-deprecation-rule.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Align the `design-system/deprecation` rule with DTIF pointers by removing curly-brace alias handling and surfacing replacements as canonical JSON Pointers.

--- a/.changeset/enable-optional-dtif-validation.md
+++ b/.changeset/enable-optional-dtif-validation.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Add an optional `validate` flag to `parseDesignTokens` so consumers can enforce DTIF schema compliance using the shared validator.

--- a/.changeset/export-dtif-metadata-cli.md
+++ b/.changeset/export-dtif-metadata-cli.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Enhance the `tokens` CLI export to include DTIF alias references, fallback candidates, and override metadata.

--- a/.changeset/handle-dtif-fallbacks.md
+++ b/.changeset/handle-dtif-fallbacks.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+Add parser support for DTIF $value aliases, fallback arrays, and root-level $overrides, exposing resolved candidates and override metadata to downstream tooling.

--- a/.changeset/parse-nested-fallbacks.md
+++ b/.changeset/parse-nested-fallbacks.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': minor
+---
+
+support nested DTIF fallback chains when parsing token $value entries

--- a/src/cli/tokens.ts
+++ b/src/cli/tokens.ts
@@ -43,14 +43,27 @@ export async function exportTokens(
       onWarn,
     });
     output[theme] = {};
-    for (const { path: p, value, type, aliases, metadata } of flat) {
+    for (const token of flat) {
+      const {
+        path: p,
+        value,
+        type,
+        aliases,
+        metadata,
+        ref,
+        candidates,
+        overrides,
+      } = token;
       // Prevent prototype pollution from malicious keys
       if (p === '__proto__' || p === 'constructor' || p === 'prototype')
         continue;
       output[theme][p] = {
         value,
-        type,
-        ...(aliases ? { aliases } : {}),
+        ...(type ? { type } : {}),
+        ...(ref !== undefined ? { ref } : {}),
+        ...(aliases && aliases.length > 0 ? { aliases } : {}),
+        ...(candidates && candidates.length > 0 ? { candidates } : {}),
+        ...(overrides && overrides.length > 0 ? { overrides } : {}),
         ...metadata,
       };
     }

--- a/src/core/parser/alias.ts
+++ b/src/core/parser/alias.ts
@@ -1,19 +1,163 @@
-import { JsonPointer } from 'jsonpointerx';
-import type { FlattenedToken } from '../types.js';
+import type { FlattenedToken, TokenValueCandidate } from '../types.js';
+import { canonicalizePointer } from './pointers.js';
 
 export interface AliasResult {
   value: unknown;
   refs: string[];
   type?: string;
+  candidates: TokenValueCandidate[];
 }
 
-function canonicalizeRef(ref: string, sourcePath: string): string {
-  try {
-    return JsonPointer.compile(ref).toString();
-  } catch (error) {
-    const detail = error instanceof Error ? `: ${error.message}` : '';
-    throw new Error(`Token ${sourcePath} has invalid $ref "${ref}"${detail}`);
+type CandidateDescriptor =
+  | { kind: 'ref'; ref: string; source: string }
+  | { kind: 'value'; value: unknown; source: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function describeSource(path: string, hint: string): string {
+  if (!path) return hint;
+  return `${path}${hint}`;
+}
+
+const FALLBACK_KEYS = new Set(['$ref', '$value', '$fallback']);
+
+interface FallbackEntryObject {
+  $ref?: unknown;
+  $value?: unknown;
+  $fallback?: unknown;
+}
+
+function createRefDescriptor(ref: string, source: string): CandidateDescriptor {
+  return { kind: 'ref', ref, source };
+}
+
+function createValueDescriptor(
+  value: unknown,
+  source: string,
+): CandidateDescriptor {
+  return { kind: 'value', value, source };
+}
+
+function isFallbackEntryObject(
+  value: unknown,
+): value is FallbackEntryObject & Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length === 0) return false;
+  if (!keys.every((key) => FALLBACK_KEYS.has(key))) return false;
+  if ('$ref' in value && typeof value.$ref === 'string') return true;
+  if (Object.prototype.hasOwnProperty.call(value, '$value')) return true;
+  if ('$fallback' in value) return true;
+  return false;
+}
+
+function collectFallbackEntryCandidates(
+  entry: unknown,
+  token: FlattenedToken,
+  suffix: string,
+): CandidateDescriptor[] {
+  if (entry === undefined) {
+    return [];
   }
+
+  const source = describeSource(token.path, suffix);
+
+  if (!isFallbackEntryObject(entry)) {
+    return [createValueDescriptor(entry, source)];
+  }
+
+  const fallbackEntry: FallbackEntryObject & Record<string, unknown> = entry;
+  const descriptors: CandidateDescriptor[] = [];
+
+  if (typeof fallbackEntry.$ref === 'string') {
+    descriptors.push(
+      createRefDescriptor(
+        fallbackEntry.$ref,
+        describeSource(token.path, `${suffix}[$ref]`),
+      ),
+    );
+  }
+
+  if (Object.prototype.hasOwnProperty.call(fallbackEntry, '$value')) {
+    descriptors.push(
+      createValueDescriptor(
+        fallbackEntry.$value,
+        describeSource(token.path, `${suffix}[$value]`),
+      ),
+    );
+  }
+
+  if ('$fallback' in fallbackEntry && fallbackEntry.$fallback !== undefined) {
+    descriptors.push(
+      ...collectFallbackChainCandidates(
+        fallbackEntry.$fallback,
+        token,
+        `${suffix}[$fallback]`,
+      ),
+    );
+  }
+
+  if (descriptors.length === 0) {
+    return [createValueDescriptor(entry, source)];
+  }
+
+  return descriptors;
+}
+
+function collectFallbackChainCandidates(
+  fallback: unknown,
+  token: FlattenedToken,
+  suffix: string,
+): CandidateDescriptor[] {
+  if (fallback === undefined) {
+    return [];
+  }
+  if (Array.isArray(fallback)) {
+    const results: CandidateDescriptor[] = [];
+    fallback.forEach((entry, index) => {
+      results.push(
+        ...collectFallbackEntryCandidates(
+          entry,
+          token,
+          `${suffix}[${String(index)}]`,
+        ),
+      );
+    });
+    return results;
+  }
+  return collectFallbackEntryCandidates(fallback, token, suffix);
+}
+
+function getCandidateDescriptors(token: FlattenedToken): CandidateDescriptor[] {
+  if (typeof token.ref === 'string') {
+    return [
+      createRefDescriptor(token.ref, describeSource(token.path, '[$ref]')),
+    ];
+  }
+
+  const raw = token.value;
+
+  if (Array.isArray(raw)) {
+    const descriptors: CandidateDescriptor[] = [];
+    raw.forEach((entry, index) => {
+      descriptors.push(
+        ...collectFallbackEntryCandidates(
+          entry,
+          token,
+          `[$value[${String(index)}]]`,
+        ),
+      );
+    });
+    return descriptors;
+  }
+
+  if (raw !== undefined) {
+    return collectFallbackEntryCandidates(raw, token, '[$value]');
+  }
+
+  return [];
 }
 
 function resolvePointer(
@@ -21,7 +165,7 @@ function resolvePointer(
   tokenMap: Map<string, FlattenedToken>,
   stack: Set<string>,
   refs: Set<string>,
-): { value: unknown; type?: string } {
+): { value: unknown; type?: string; candidates: TokenValueCandidate[] } {
   const target = tokenMap.get(pointer);
   if (!target) {
     let origin = pointer;
@@ -39,7 +183,7 @@ function resolveToken(
   tokenMap: Map<string, FlattenedToken>,
   stack: Set<string>,
   refs: Set<string>,
-): { value: unknown; type?: string } {
+): { value: unknown; type?: string; candidates: TokenValueCandidate[] } {
   if (stack.has(token.path)) {
     const cycle = [...stack, token.path].join(' -> ');
     throw new Error(`Circular $ref chain detected: ${cycle}`);
@@ -47,16 +191,40 @@ function resolveToken(
 
   stack.add(token.path);
   try {
-    if (!token.ref) {
-      return { value: token.value, type: token.type };
+    const descriptors = getCandidateDescriptors(token);
+    if (descriptors.length === 0) {
+      return { value: token.value, type: token.type, candidates: [] };
     }
-    const pointer = canonicalizeRef(token.ref, token.path);
-    refs.add(pointer);
-    const result = resolvePointer(pointer, tokenMap, stack, refs);
-    if (token.aliases) {
-      for (const alias of token.aliases) refs.add(alias);
+
+    const candidates: TokenValueCandidate[] = [];
+    let resolvedValue: unknown = undefined;
+    let resolvedType: string | undefined;
+
+    for (const descriptor of descriptors) {
+      if (descriptor.kind === 'ref') {
+        const pointer = canonicalizePointer(
+          descriptor.ref,
+          `Token ${descriptor.source}`,
+          '$ref',
+        );
+        refs.add(pointer);
+        const result = resolvePointer(pointer, tokenMap, stack, refs);
+        candidates.push({ value: result.value, ref: pointer });
+        if (resolvedValue === undefined) {
+          resolvedValue = result.value;
+          resolvedType = result.type;
+        }
+        continue;
+      }
+
+      candidates.push({ value: descriptor.value });
+      if (resolvedValue === undefined) {
+        resolvedValue = descriptor.value;
+        resolvedType = token.type;
+      }
     }
-    return result;
+
+    return { value: resolvedValue, type: resolvedType, candidates };
   } finally {
     stack.delete(token.path);
   }
@@ -69,7 +237,12 @@ export function resolveAliases(
 ): AliasResult {
   const refs = new Set<string>();
   const stack = new Set<string>();
-  const { value, type } = resolveToken(token, tokenMap, stack, refs);
+  const { value, type, candidates } = resolveToken(
+    token,
+    tokenMap,
+    stack,
+    refs,
+  );
 
   if (token.type && type && token.type !== type) {
     warnings.push(
@@ -77,5 +250,5 @@ export function resolveAliases(
     );
   }
 
-  return { value, refs: [...refs], type };
+  return { value, refs: [...refs], type, candidates };
 }

--- a/src/core/parser/normalize.ts
+++ b/src/core/parser/normalize.ts
@@ -8,12 +8,27 @@ export function normalizeTokens(
   const tokenMap = new Map(tokens.map((t) => [t.path, t]));
   const warnings: string[] = [];
   for (const token of tokens) {
-    const { value, refs, type } = resolveAliases(token, tokenMap, warnings);
+    const rawValue = token.value;
+    const hadArrayValue = Array.isArray(rawValue);
+    const { value, refs, type, candidates } = resolveAliases(
+      token,
+      tokenMap,
+      warnings,
+    );
     token.value = value;
+    if (hadArrayValue || candidates.length > 1) {
+      token.candidates = candidates;
+    } else {
+      delete token.candidates;
+    }
     if (!token.type && type) {
       token.type = type;
     }
-    if (token.ref && refs.length > 0) {
+    if (candidates.length > 0 && candidates[0].ref) {
+      token.ref = candidates[0].ref;
+    } else if (hadArrayValue) {
+      delete token.ref;
+    } else if (token.ref && refs.length > 0) {
       token.ref = refs[0];
     }
     if (refs.length) {

--- a/src/core/parser/overrides.ts
+++ b/src/core/parser/overrides.ts
@@ -1,0 +1,179 @@
+import type {
+  FallbackEntry,
+  OverrideRule,
+  Overrides,
+} from '@lapidist/dtif-schema';
+import type {
+  FlattenedToken,
+  TokenOverride,
+  TokenValueCandidate,
+} from '../types.js';
+import { canonicalizePointer, segmentsToPointer } from './pointers.js';
+
+function warnTypeMismatch(
+  target: FlattenedToken,
+  referenced: FlattenedToken,
+  context: string,
+  warn?: (msg: string) => void,
+): void {
+  if (!warn) return;
+  if (!target.type || !referenced.type) return;
+  if (target.type === referenced.type) return;
+  warn(
+    `Override ${context} for token ${target.path} references ${referenced.path} of type ${referenced.type} (expected ${target.type})`,
+  );
+}
+
+type OverrideFallback = NonNullable<OverrideRule['$fallback']>;
+
+type TokenMap = Map<string, FlattenedToken>;
+
+function collectFallbackEntry(
+  entry: FallbackEntry,
+  target: FlattenedToken,
+  segments: (string | number)[],
+  tokens: TokenMap,
+  warn?: (msg: string) => void,
+): TokenValueCandidate[] {
+  const pointer = segmentsToPointer(segments);
+  const candidates: TokenValueCandidate[] = [];
+  let produced = false;
+
+  if (typeof entry.$ref === 'string') {
+    const refPointer = canonicalizePointer(
+      entry.$ref,
+      `Override ${pointer}`,
+      '$ref',
+    );
+    const referenced = tokens.get(refPointer);
+    if (!referenced) {
+      throw new Error(
+        `Override ${pointer} references unknown token ${refPointer}`,
+      );
+    }
+    candidates.push({ value: referenced.value, ref: refPointer });
+    warnTypeMismatch(target, referenced, pointer, warn);
+    produced = true;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(entry, '$value')) {
+    candidates.push({ value: entry.$value });
+    produced = true;
+  }
+
+  if (!produced && !entry.$fallback && warn) {
+    warn(`Override ${pointer} declares neither $ref nor $value; ignoring`);
+  }
+
+  if (entry.$fallback) {
+    candidates.push(
+      ...collectFallbackChain(
+        entry.$fallback,
+        target,
+        [...segments, '$fallback'],
+        tokens,
+        warn,
+      ),
+    );
+  }
+
+  return candidates;
+}
+
+function collectFallbackChain(
+  fallback: OverrideFallback,
+  target: FlattenedToken,
+  segments: (string | number)[],
+  tokens: TokenMap,
+  warn?: (msg: string) => void,
+): TokenValueCandidate[] {
+  if (Array.isArray(fallback)) {
+    const results: TokenValueCandidate[] = [];
+    fallback.forEach((entry, index) => {
+      results.push(
+        ...collectFallbackEntry(
+          entry,
+          target,
+          [...segments, index],
+          tokens,
+          warn,
+        ),
+      );
+    });
+    return results;
+  }
+  return collectFallbackEntry(fallback, target, segments, tokens, warn);
+}
+
+export function applyOverrides(
+  tokens: FlattenedToken[],
+  overrides: Overrides | undefined,
+  warn?: (msg: string) => void,
+): void {
+  if (!overrides || overrides.length === 0) return;
+  const tokenMap: TokenMap = new Map(
+    tokens.map((token) => [token.path, token]),
+  );
+
+  overrides.forEach((rule, index) => {
+    const overridePointer = segmentsToPointer(['$overrides', index]);
+    if (typeof rule.$token !== 'string') {
+      throw new Error(
+        `Override ${overridePointer} is missing a $token pointer`,
+      );
+    }
+
+    const targetPointer = canonicalizePointer(
+      rule.$token,
+      `Override ${overridePointer}`,
+      '$token',
+    );
+    const target = tokenMap.get(targetPointer);
+    if (!target) {
+      throw new Error(
+        `Override ${overridePointer} references unknown token ${targetPointer}`,
+      );
+    }
+
+    const overrideRecord: TokenOverride = {
+      source: overridePointer,
+      when: { ...rule.$when },
+    };
+
+    if (typeof rule.$ref === 'string') {
+      const refPointer = canonicalizePointer(
+        rule.$ref,
+        `Override ${overridePointer}`,
+        '$ref',
+      );
+      const referenced = tokenMap.get(refPointer);
+      if (!referenced) {
+        throw new Error(
+          `Override ${overridePointer} references unknown token ${refPointer}`,
+        );
+      }
+      overrideRecord.ref = refPointer;
+      overrideRecord.value = referenced.value;
+      warnTypeMismatch(target, referenced, overridePointer, warn);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(rule, '$value')) {
+      overrideRecord.value = rule.$value;
+    }
+
+    if (rule.$fallback) {
+      const fallbackCandidates = collectFallbackChain(
+        rule.$fallback,
+        target,
+        ['$overrides', index, '$fallback'],
+        tokenMap,
+        warn,
+      );
+      if (fallbackCandidates.length > 0) {
+        overrideRecord.fallback = fallbackCandidates;
+      }
+    }
+
+    (target.overrides ??= []).push(overrideRecord);
+  });
+}

--- a/src/core/parser/pointers.ts
+++ b/src/core/parser/pointers.ts
@@ -1,0 +1,53 @@
+import { JsonPointer } from 'jsonpointerx';
+
+function normalizeFragment(fragment: string): string {
+  if (fragment === '' || fragment === '/') {
+    return '';
+  }
+  return fragment.startsWith('/') ? fragment : `/${fragment}`;
+}
+
+export function canonicalizePointer(
+  ref: string,
+  context: string,
+  label = '$ref',
+): string {
+  try {
+    const hashIndex = ref.indexOf('#');
+    if (hashIndex === -1) {
+      if (ref === '') {
+        return '';
+      }
+      if (ref === '/' || ref === '#') {
+        return '';
+      }
+      return JsonPointer.compile(ref).toString();
+    }
+
+    const document = ref.slice(0, hashIndex);
+    const fragment = normalizeFragment(ref.slice(hashIndex + 1));
+    if (document === '') {
+      if (fragment === '') {
+        return '';
+      }
+      return JsonPointer.compile(fragment).toString();
+    }
+
+    if (fragment === '') {
+      return `${document}#`;
+    }
+
+    const pointer = JsonPointer.compile(fragment).toString();
+    return `${document}#${pointer}`;
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : '';
+    throw new Error(`${context} has invalid ${label} "${ref}"${detail}`);
+  }
+}
+
+export function segmentsToPointer(segments: (string | number)[]): string {
+  if (segments.length === 0) {
+    return '';
+  }
+  return new JsonPointer(segments.map((segment) => String(segment))).toString();
+}

--- a/src/core/parser/validate.ts
+++ b/src/core/parser/validate.ts
@@ -1,9 +1,20 @@
-/**
- * Placeholder for legacy token validation.
- *
- * DTIF schema validation occurs before this stage, so no additional
- * structural checks are performed yet.
- */
-export function validateTokens(): void {
-  // Intentionally left blank. Future DTIF-specific validation can be added here.
+import type { DesignTokens } from '../types.js';
+import {
+  DTIF_VALIDATION_MESSAGE,
+  formatDtifErrors,
+  validateDtif,
+} from '../../utils/dtif/validator.js';
+
+export function validateTokens(tokens: DesignTokens): void {
+  const result = validateDtif(tokens);
+  if (result.valid) {
+    return;
+  }
+
+  const detail = formatDtifErrors(result.errors);
+  if (detail === DTIF_VALIDATION_MESSAGE) {
+    throw new Error(DTIF_VALIDATION_MESSAGE);
+  }
+
+  throw new Error(`DTIF validation failed:\n${detail}`);
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -38,13 +38,36 @@ export type RootTokenGroup = DesignTokenInterchangeFormat;
  */
 export type DesignTokens = DesignTokenInterchangeFormat;
 
+export interface TokenValueCandidate {
+  value: unknown;
+  /** Canonical JSON Pointer reference for alias candidates. */
+  ref?: string;
+}
+
+export interface TokenOverride {
+  /** JSON Pointer to the override declaration within the token document. */
+  source: string;
+  /** Context map describing when the override applies. */
+  when: Record<string, unknown>;
+  /** Resolved override value from an inline $value or referenced token. */
+  value?: unknown;
+  /** Canonical JSON Pointer reference when the override aliases another token. */
+  ref?: string;
+  /** Ordered fallback candidates derived from the override's $fallback chain. */
+  fallback?: TokenValueCandidate[];
+}
+
 export interface FlattenedToken {
   path: string;
   value: unknown;
   type?: string;
+  /** Ordered fallback candidates derived from the token's $value array. */
+  candidates?: TokenValueCandidate[];
   /** Canonical JSON Pointer reference when the token aliases another token. */
   ref?: string;
   aliases?: string[];
+  /** Conditional overrides applied to the token. */
+  overrides?: TokenOverride[];
   metadata: {
     description?: string;
     extensions?: Record<string, unknown>;

--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -44,18 +44,7 @@ export const deprecationRule: RuleModule = {
       const canonical = normalizePath(path);
       const info: DeprecationInfo = { canonical };
       if (typeof dep === 'string') {
-        const updated = dep.replace(/\{([^}]+)\}/g, (_, inner: string) => {
-          const formatted = formatPointer(inner);
-          info.replacement ??= normalizePath(inner);
-          return `{${formatted}}`;
-        });
-        info.reason = updated;
-        if (!info.replacement) {
-          const match = /\{([^}]+)\}/.exec(dep);
-          if (match) {
-            info.replacement = normalizePath(match[1]);
-          }
-        }
+        info.reason = dep;
       } else if (dep === true) {
         // No additional metadata beyond the deprecated flag.
       } else if (hasReplacement(dep)) {
@@ -98,7 +87,7 @@ export const deprecationRule: RuleModule = {
           const message =
             info.reason ??
             (replacement
-              ? `Token ${pointer} is deprecated; use {${replacement}}`
+              ? `Token ${pointer} is deprecated; use ${replacement}`
               : `Token ${pointer} is deprecated`);
           context.report({
             message,
@@ -126,7 +115,7 @@ export const deprecationRule: RuleModule = {
         const message =
           info.reason ??
           (replacement
-            ? `Token ${pointer} is deprecated; use {${replacement}}`
+            ? `Token ${pointer} is deprecated; use ${replacement}`
             : `Token ${pointer} is deprecated`);
         context.report({
           message,

--- a/src/utils/tokens/color-values.ts
+++ b/src/utils/tokens/color-values.ts
@@ -34,26 +34,33 @@ export function collectColorTokenValues(token: FlattenedToken): string[] {
   }
 
   const values = new Set<string>();
-  const raw = token.value;
+  const rawValues =
+    token.candidates && token.candidates.length > 0
+      ? token.candidates.map((candidate) => candidate.value)
+      : [token.value];
 
-  if (typeof raw === 'string') {
-    addNormalizedValue(values, raw);
-    const parsed = parse(raw);
-    if (parsed) {
-      addNormalizedValue(values, formatRgb(parsed));
-      addNormalizedValue(values, formatHex(parsed));
-      addNormalizedValue(values, formatHsl(parsed));
+  for (const raw of rawValues) {
+    if (typeof raw === 'string') {
+      addNormalizedValue(values, raw);
+      const parsed = parse(raw);
+      if (parsed) {
+        addNormalizedValue(values, formatRgb(parsed));
+        addNormalizedValue(values, formatHex(parsed));
+        addNormalizedValue(values, formatHsl(parsed));
+      }
+      continue;
     }
-    return [...values];
-  }
 
-  if (raw && typeof raw === 'object') {
+    if (!raw || typeof raw !== 'object') {
+      continue;
+    }
+
     let value: ColorValue;
     try {
       validateColor(raw, token.path);
       value = raw;
     } catch {
-      return [...values];
+      continue;
     }
 
     addNormalizedValue(values, value.hex);

--- a/tests/core/pointers.test.ts
+++ b/tests/core/pointers.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { canonicalizePointer } from '../../src/core/parser/pointers.js';
+
+void test('canonicalizePointer normalizes same-document fragments', () => {
+  assert.equal(
+    canonicalizePointer('#/palette/primary', 'Token #/palette/primary'),
+    '/palette/primary',
+  );
+  assert.equal(canonicalizePointer('#', 'Token #'), '');
+});
+
+void test('canonicalizePointer preserves document URIs while normalizing fragments', () => {
+  assert.equal(
+    canonicalizePointer(
+      '../tokens/base.dtif.json#palette.primary',
+      'Token ../tokens/base.dtif.json#palette.primary',
+    ),
+    '../tokens/base.dtif.json#/palette.primary',
+  );
+  assert.equal(
+    canonicalizePointer(
+      'https://cdn.example.com/tokens.dtif.json#/colors/brand',
+      'Token https://cdn.example.com/tokens.dtif.json#/colors/brand',
+    ),
+    'https://cdn.example.com/tokens.dtif.json#/colors/brand',
+  );
+  assert.equal(
+    canonicalizePointer(
+      '../tokens/base.dtif.json#/foo~0bar',
+      'Token ../tokens/base.dtif.json#/foo~0bar',
+    ),
+    '../tokens/base.dtif.json#/foo~0bar',
+  );
+  assert.equal(
+    canonicalizePointer(
+      '../tokens/base.dtif.json#',
+      'Token ../tokens/base.dtif.json#',
+    ),
+    '../tokens/base.dtif.json#',
+  );
+});

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -24,7 +24,7 @@ void test('design-system/deprecation flags deprecated token', async () => {
   assert.equal(res.messages.length, 1);
   assert.equal(
     res.messages[0].message,
-    'Token #/colors/old is deprecated; use {#/colors/new}',
+    'Token #/colors/old is deprecated; use #/colors/new',
   );
   assert.deepEqual(res.messages[0].fix, {
     range: [10, 24],

--- a/tests/utils/tokens/color-values.test.ts
+++ b/tests/utils/tokens/color-values.test.ts
@@ -34,6 +34,28 @@ void test('collectColorTokenValues normalizes DTIF color objects', () => {
   assert(values.has('rgb(255, 0, 0)'));
 });
 
+void test('collectColorTokenValues includes fallback candidates', () => {
+  const token: FlattenedToken = {
+    path: '/theme/brand',
+    type: 'color',
+    value: { colorSpace: 'srgb', components: [1, 0, 0] },
+    candidates: [
+      {
+        ref: '/palette/base',
+        value: { colorSpace: 'srgb', components: [1, 0, 0] },
+      },
+      {
+        value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+    ],
+    metadata: baseMetadata,
+  };
+
+  const values = new Set(collectColorTokenValues(token));
+  assert(values.has('rgb(255, 0, 0)'));
+  assert(values.has('rgb(0, 0, 0)'));
+});
+
 void test('collectColorTokenValues ignores non-color tokens', () => {
   const token: FlattenedToken = {
     path: '/spacing/sm',

--- a/tests/utils/tokens/path.test.ts
+++ b/tests/utils/tokens/path.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  getPathSegments,
   normalizePath,
   toConstantName,
 } from '../../../src/utils/tokens/index.js';
@@ -8,15 +9,39 @@ import {
 void test('normalizePath canonicalizes JSON Pointer paths', () => {
   assert.equal(normalizePath('foo.bar'), '/foo/bar');
   assert.equal(normalizePath('/foo/bar'), '/foo/bar');
+  assert.equal(normalizePath('#/foo/bar'), '/foo/bar');
+  assert.equal(
+    normalizePath('../tokens/base.dtif.json#palette.primary'),
+    '../tokens/base.dtif.json#/palette.primary',
+  );
 });
 
 void test('normalizePath applies case transforms to pointer segments', () => {
   assert.equal(normalizePath('/Foo/BarBaz', 'kebab-case'), '/foo/bar-baz');
   assert.equal(normalizePath('/foo/bar-baz', 'camelCase'), '/foo/barBaz');
   assert.equal(normalizePath('/foo/bar-baz', 'PascalCase'), '/foo/BarBaz');
+  assert.equal(
+    normalizePath('../tokens/base.dtif.json#/Foo/Baz', 'kebab-case'),
+    '../tokens/base.dtif.json#/foo/baz',
+  );
+});
+
+void test('getPathSegments decodes pointer fragments and ignores document URIs', () => {
+  assert.deepEqual(getPathSegments('#/foo~0bar/baz~1qux'), [
+    'foo~bar',
+    'baz/qux',
+  ]);
+  assert.deepEqual(
+    getPathSegments('../tokens/base.dtif.json#/palette/primary'),
+    ['palette', 'primary'],
+  );
 });
 
 void test('toConstantName normalizes pointer segments', () => {
   assert.equal(toConstantName('/color/primary'), 'COLOR_PRIMARY');
   assert.equal(toConstantName('/color/primary-dark'), 'COLOR_PRIMARY_DARK');
+  assert.equal(
+    toConstantName('../tokens/base.dtif.json#/color/brand'),
+    'COLOR_BRAND',
+  );
 });


### PR DESCRIPTION
## Summary
- expand the `tokens` CLI export to include refs, fallback candidates, and override metadata from DTIF documents
- document the change with a minor bump changeset
- extend the CLI test fixture to exercise DTIF fallback arrays and overrides while asserting the richer export

## Testing
- npm run format:check
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03c8a9f5883288338fd159c10547f