### PR TITLE
feat!: complete DTIF migration

### DIFF
--- a/.changeset/complete-dtif-migration.md
+++ b/.changeset/complete-dtif-migration.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': major
+---
+
+complete the DTIF migration by removing legacy DTCG syntax, hardening pointer validation, and updating documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - 054e4ce: allow empty dashArray in strokeStyle tokens
 - 054e4ce: support hex string color tokens alongside object format
 - 054e4ce: clamp gradient stop positions to the [0, 1] range
-- 054e4ce: remove non-spec $metadata property; the spec says, "The properties `$description`, `$extensions`, `$deprecated`, `$type`, and `$schema` are reserved for use by this specification."
+- 054e4ce: remove non-spec $metadata property; the spec reserves the properties $description, $extensions, $deprecated, $type, and $schema for its own use.
 - 054e4ce: validate color component ranges, alpha bounds, and hex format
 - 054e4ce: fail when token aliases cannot be resolved
 - 054e4ce: require `letterSpacing` in typography tokens; the spec says, "The value MUST be an object with the following properties: `fontFamily`, `fontSize`, `fontWeight`, `letterSpacing`, `lineHeight`."

--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ npx design-lint src
 
 See the [Usage guide](docs/usage.md) for the full command reference.
 
+## Validate DTIF documents
+
+Validate tokens in scripts or CI with the standalone DTIF validator:
+
+```ts
+import { validate } from '@lapidist/dtif-validator';
+
+const result = validate(tokens);
+
+if (!result.valid) {
+  for (const issue of result.errors ?? []) {
+    const path = issue.instancePath && issue.instancePath !== '' ? issue.instancePath : '/';
+    console.error(`${path}: ${issue.message}`);
+  }
+  process.exit(1);
+}
+```
+
+Use canonical JSON Pointers (for example `#/color/primary`) in `$ref`, `$replacement`, and `$token` fields so diagnostics line up between the validator and design-lint.
+
 ## Why design-lint?
 
 General purpose linters understand code style, not design systems. `@lapidist/design-lint` bridges that gap by enforcing token usage and component conventions across your codebase.
@@ -70,6 +90,10 @@ The complete documentation is available under the [`docs/`](docs) directory and 
 | [API](docs/api.md) | Shows programmatic usage with TypeScript types. |
 | [Migration](docs/migration.md) | Move from Style Dictionary to design-lint's token pipeline. |
 | [Architecture](docs/architecture.md) | Explains how the linter works internally. |
+
+## Migrating from DTCG
+
+Moving from the Design Tokens Community Group (DTCG) schema? Follow the [Migrating from DTCG guide](https://dtif.lapidist.net/guides/migrating-from-dtcg) to translate curly-brace aliases, `$value` shapes, and schema references into DTIF-compliant JSON Pointers.
 
 ## Contributing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,15 +63,23 @@ Inline example:
         "$type": "color",
         "$value": { "colorSpace": "srgb", "components": [1, 0, 0] }
       },
-      "secondary": { "$ref": "/color/primary" }
+      "secondary": { "$ref": "#/color/primary" }
     },
     "space": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": { "value": 8, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      },
+      "md": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 8, "unit": "px" }
+      }
     }
   }
 }
 ```
+
+Use canonical JSON Pointers (beginning with `/`) for `$ref`, `$replacement`, and other references so tokens resolve consistently across documents.
 
 Organise tokens by category—such as `color`, `space`, or `typography`—to mirror your design language. To support light and dark themes, supply an object keyed by theme name. Each theme may contain an inline token tree or a path to an external token file. Paths resolve relative to the configuration file:
 
@@ -85,7 +93,7 @@ Organise tokens by category—such as `color`, `space`, or `typography`—to mir
           "$type": "color",
           "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
         },
-        "secondary": { "$type": "color", "$value": "{color.primary}" }
+        "secondary": { "$ref": "#/color/primary" }
       }
     }
   }
@@ -169,7 +177,7 @@ export default defineConfig({
         $type: 'color',
         $value: { colorSpace: 'srgb', components: [1, 0, 0] },
       },
-      secondary: { $type: 'color', $value: '{color.primary}' },
+      secondary: { $ref: '#/color/primary' },
     },
   },
   rules: { 'design-token/colors': 'error' },

--- a/docs/examples/basic/designlint.config.json
+++ b/docs/examples/basic/designlint.config.json
@@ -1,8 +1,11 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#ff0000" },
-      "secondary": { "$type": "color", "$value": "{color.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 0, 0] }
+      },
+      "secondary": { "$ref": "#/color/primary" }
     }
   },
   "rules": {

--- a/docs/rules/design-system/deprecation.md
+++ b/docs/rules/design-system/deprecation.md
@@ -6,7 +6,7 @@ description: "Warn when using deprecated design system parts."
 # design-system/deprecation
 
 ## Summary
-Flags tokens marked with `$deprecated`. If a deprecation message references another token using alias syntax, running the linter with `--fix` will substitute the suggested token.
+Flags tokens marked with `$deprecated`. If a deprecation message references another token using a JSON Pointer, running the linter with `--fix` will substitute the suggested token.
 
 ## Configuration
 Enable this rule in `designlint.config.*`. See [configuration](../../configuration.md) for details on configuring tokens and rules.
@@ -17,16 +17,24 @@ Enable this rule in `designlint.config.*`. See [configuration](../../configurati
     "color": {
       "old": {
         "$type": "color",
-        "$value": "#000",
-        "$deprecated": "Use {color.new}"
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+        "$deprecated": {
+          "$message": "Use the new brand color",
+          "$replacement": "#/color/new"
+        }
       },
-      "new": { "$type": "color", "$value": "#fff" },
-      "alias": { "$type": "color", "$value": "{color.new}" }
+      "new": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+      },
+      "alias": { "$ref": "#/color/new" }
     }
   },
   "rules": { "design-system/deprecation": "error" }
 }
 ```
+
+Use canonical JSON Pointers (e.g. `#/color/new`) in `$deprecated.$replacement` so that auto-fixes resolve the correct token.
 
 ## Options
 No additional options.

--- a/docs/rules/design-system/no-unused-tokens.md
+++ b/docs/rules/design-system/no-unused-tokens.md
@@ -22,8 +22,11 @@ Given this configuration:
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" },
-      "unused": { "$type": "color", "$value": "{color.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      },
+      "unused": { "$ref": "#/color/primary" }
     }
   },
   "rules": { "design-system/no-unused-tokens": "warn" }
@@ -36,7 +39,7 @@ and the source:
 const color = '#000000';
 ```
 
-`#ff0000` is reported as unused.
+`#/color/unused` is reported as unused because it never appears in source files.
 
 A CSS variable can also be ignored:
 

--- a/docs/rules/design-token/animation.md
+++ b/docs/rules/design-token/animation.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "animations": {
       "spin": { "$type": "string", "$value": "spin 1s linear infinite" },
-      "wiggle": { "$type": "string", "$value": "{animations.spin}" }
+      "wiggle": { "$type": "string", "$ref": "#/animations/spin" }
     }
   },
   "rules": { "design-token/animation": "error" }

--- a/docs/rules/design-token/blur.md
+++ b/docs/rules/design-token/blur.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "blurs": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": "{blurs.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      },
+      "md": { "$type": "dimension", "$ref": "#/blurs/sm" }
     }
   },
   "rules": { "design-token/blur": "error" }

--- a/docs/rules/design-token/border-color.md
+++ b/docs/rules/design-token/border-color.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "borderColors": {
-      "primary": { "$type": "color", "$value": "#ffffff" },
-      "secondary": { "$type": "color", "$value": "{borderColors.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+      },
+      "secondary": { "$type": "color", "$ref": "#/borderColors/primary" }
     }
   },
   "rules": { "design-token/border-color": "error" }

--- a/docs/rules/design-token/border-radius.md
+++ b/docs/rules/design-token/border-radius.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "borderRadius": {
-      "sm": { "$type": "dimension", "$value": { "value": 2, "unit": "px" } },
-      "lg": { "$type": "dimension", "$value": "{borderRadius.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 2, "unit": "px" }
+      },
+      "lg": { "$type": "dimension", "$ref": "#/borderRadius/sm" }
     }
   },
   "rules": { "design-token/border-radius": "error" }

--- a/docs/rules/design-token/border-width.md
+++ b/docs/rules/design-token/border-width.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "borderWidths": {
-      "sm": { "$type": "dimension", "$value": { "value": 1, "unit": "px" } },
-      "lg": { "$type": "dimension", "$value": "{borderWidths.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 1, "unit": "px" }
+      },
+      "lg": { "$type": "dimension", "$ref": "#/borderWidths/sm" }
     }
   },
   "rules": { "design-token/border-width": "error" }

--- a/docs/rules/design-token/box-shadow.md
+++ b/docs/rules/design-token/box-shadow.md
@@ -25,14 +25,14 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
           "color": "rgba(0,0,0,0.1)"
         }
       },
-      "md": { "$type": "shadow", "$value": "{shadows.sm}" }
+      "md": { "$type": "shadow", "$ref": "#/shadows/sm" }
     }
   },
   "rules": { "design-token/box-shadow": "error" }
 }
 ```
 
-Shadow tokens use the `shadow` type with sub-values for offsets, blur, spread, and color.
+Shadow tokens use the `shadow` type with sub-values for offsets, blur, spread, and color. Reference existing shadows with JSON Pointers such as `"$ref": "#/shadows/sm"`.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/colors.md
+++ b/docs/rules/design-token/colors.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#ff0000" },
-      "secondary": { "$type": "color", "$value": "{color.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 0, 0] }
+      },
+      "secondary": { "$type": "color", "$ref": "#/color/primary" }
     }
   },
   "rules": {

--- a/docs/rules/design-token/duration.md
+++ b/docs/rules/design-token/duration.md
@@ -15,8 +15,15 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "durations": {
-      "short": { "$type": "duration", "$value": { "value": 100, "unit": "ms" } },
-      "long": { "$type": "duration", "$value": "{durations.short}" }
+      "short": {
+        "$type": "duration",
+        "$value": {
+          "durationType": "css.transition-duration",
+          "value": 100,
+          "unit": "ms"
+        }
+      },
+      "long": { "$type": "duration", "$ref": "#/durations/short" }
     }
   },
   "rules": { "design-token/duration": "error" }

--- a/docs/rules/design-token/font-family.md
+++ b/docs/rules/design-token/font-family.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Inter, sans-serif" },
-      "alt": { "$type": "fontFamily", "$value": "{fonts.sans}" }
+      "alt": { "$type": "fontFamily", "$ref": "#/fonts/sans" }
     }
   },
   "rules": { "design-token/font-family": "error" }

--- a/docs/rules/design-token/font-size.md
+++ b/docs/rules/design-token/font-size.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "fontSizes": {
-      "base": { "$type": "dimension", "$value": { "value": 1, "unit": "rem" } },
-      "lg": { "$type": "dimension", "$value": "{fontSizes.base}" }
+      "base": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 1, "unit": "rem" }
+      },
+      "lg": { "$type": "dimension", "$ref": "#/fontSizes/base" }
     }
   },
   "rules": { "design-token/font-size": "error" }

--- a/docs/rules/design-token/font-weight.md
+++ b/docs/rules/design-token/font-weight.md
@@ -17,7 +17,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
     "fontWeights": {
       "regular": { "$type": "fontWeight", "$value": 400 },
       "bold": { "$type": "fontWeight", "$value": 700 },
-      "emphasis": { "$type": "fontWeight", "$value": "{fontWeights.bold}" }
+      "emphasis": { "$type": "fontWeight", "$ref": "#/fontWeights/bold" }
     }
   },
   "rules": { "design-token/font-weight": "error" }

--- a/docs/rules/design-token/letter-spacing.md
+++ b/docs/rules/design-token/letter-spacing.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "letterSpacings": {
-      "tight": { "$type": "dimension", "$value": { "value": -0.05, "unit": "rem" } },
-      "loose": { "$type": "dimension", "$value": "{letterSpacings.tight}" }
+      "tight": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": -0.05, "unit": "rem" }
+      },
+      "loose": { "$type": "dimension", "$ref": "#/letterSpacings/tight" }
     }
   },
   "rules": { "design-token/letter-spacing": "error" }

--- a/docs/rules/design-token/line-height.md
+++ b/docs/rules/design-token/line-height.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "lineHeights": {
       "base": { "$type": "number", "$value": 1.5 },
-      "tight": { "$type": "number", "$value": "{lineHeights.base}" }
+      "tight": { "$type": "number", "$ref": "#/lineHeights/base" }
     }
   },
   "rules": { "design-token/line-height": "error" }

--- a/docs/rules/design-token/opacity.md
+++ b/docs/rules/design-token/opacity.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "opacity": {
       "low": { "$type": "number", "$value": 0.2 },
-      "high": { "$type": "number", "$value": "{opacity.low}" }
+      "high": { "$type": "number", "$ref": "#/opacity/low" }
     }
   },
   "rules": { "design-token/opacity": "error" }

--- a/docs/rules/design-token/outline.md
+++ b/docs/rules/design-token/outline.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "outlines": {
       "focus": { "$type": "string", "$value": "2px solid #000" },
-      "active": { "$type": "string", "$value": "{outlines.focus}" }
+      "active": { "$type": "string", "$ref": "#/outlines/focus" }
     }
   },
   "rules": { "design-token/outline": "error" }

--- a/docs/rules/design-token/spacing.md
+++ b/docs/rules/design-token/spacing.md
@@ -15,8 +15,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 {
   "tokens": {
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": "{spacing.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      },
+      "md": { "$type": "dimension", "$ref": "#/spacing/sm" }
     }
   },
   "rules": {

--- a/docs/rules/design-token/z-index.md
+++ b/docs/rules/design-token/z-index.md
@@ -16,7 +16,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
   "tokens": {
     "zIndex": {
       "modal": { "$type": "number", "$value": 1000 },
-      "dropdown": { "$type": "number", "$value": "{zIndex.modal}" }
+      "dropdown": { "$type": "number", "$ref": "#/zIndex/modal" }
     }
   },
   "rules": { "design-token/z-index": "error" }

--- a/src/config/token-loader.ts
+++ b/src/config/token-loader.ts
@@ -75,7 +75,7 @@ export async function loadTokens(
   // If a design token object is provided directly (i.e. all entries are objects
   // and none are file path strings aside from metadata keys), normalize it and
   // return the single theme result. This preserves any root-level metadata such
-  // as `$schema` declarations.
+  // as `$version` declarations.
   if (
     isDesignTokens(tokens) &&
     !isThemeRecord(tokens) &&

--- a/src/core/parser/pointers.ts
+++ b/src/core/parser/pointers.ts
@@ -7,6 +7,76 @@ function normalizeFragment(fragment: string): string {
   return fragment.startsWith('/') ? fragment : `/${fragment}`;
 }
 
+function assertValidPointerEscapes(
+  fragment: string,
+  ref: string,
+  context: string,
+  label: string,
+): void {
+  for (let i = 0; i < fragment.length; i += 1) {
+    if (fragment[i] !== '~') continue;
+    const next = fragment[i + 1];
+    if (next === '0' || next === '1') {
+      i += 1;
+      continue;
+    }
+    throw new Error(
+      `${context} has invalid ${label} "${ref}": "~" must be followed by 0 or 1`,
+    );
+  }
+}
+
+function assertNoPointerTraversal(
+  fragment: string,
+  ref: string,
+  context: string,
+  label: string,
+): void {
+  if (fragment === '') {
+    return;
+  }
+  const normalized = fragment.startsWith('/') ? fragment : `/${fragment}`;
+  if (/(^|\/)\.\.(?:\/|$)/.test(normalized)) {
+    throw new Error(
+      `${context} has invalid ${label} "${ref}": JSON Pointer segments must not include ".."`,
+    );
+  }
+}
+
+function assertValidPointer(
+  fragment: string,
+  ref: string,
+  context: string,
+  label: string,
+): void {
+  if (fragment === '') {
+    return;
+  }
+  assertValidPointerEscapes(fragment, ref, context, label);
+  assertNoPointerTraversal(fragment, ref, context, label);
+}
+
+function assertNoDocumentTraversal(
+  document: string,
+  ref: string,
+  context: string,
+  label: string,
+): void {
+  if (document === '') {
+    return;
+  }
+  const lower = document.toLowerCase();
+  if (lower.startsWith('http://') || lower.startsWith('https://')) {
+    return;
+  }
+  const normalized = document.replace(/\\/g, '/');
+  if (/(^|\/)\.\.(?:\/|$)/.test(normalized)) {
+    throw new Error(
+      `${context} has invalid ${label} "${ref}": document references must not traverse parent directories`,
+    );
+  }
+}
+
 export function canonicalizePointer(
   ref: string,
   context: string,
@@ -21,15 +91,19 @@ export function canonicalizePointer(
       if (ref === '/' || ref === '#') {
         return '';
       }
+      const normalized = normalizeFragment(ref);
+      assertValidPointer(normalized, ref, context, label);
       return JsonPointer.compile(ref).toString();
     }
 
     const document = ref.slice(0, hashIndex);
     const fragment = normalizeFragment(ref.slice(hashIndex + 1));
+    assertNoDocumentTraversal(document, ref, context, label);
     if (document === '') {
       if (fragment === '') {
         return '';
       }
+      assertValidPointer(fragment, ref, context, label);
       return JsonPointer.compile(fragment).toString();
     }
 
@@ -37,6 +111,7 @@ export function canonicalizePointer(
       return `${document}#`;
     }
 
+    assertValidPointer(fragment, ref, context, label);
     const pointer = JsonPointer.compile(fragment).toString();
     return `${document}#${pointer}`;
   } catch (error) {

--- a/src/rules/token-border-color.ts
+++ b/src/rules/token-border-color.ts
@@ -1,9 +1,10 @@
 import valueParser from 'postcss-value-parser';
 import colorString from 'color-string';
-import { rules, color } from '../utils/index.js';
+import { rules, color, tokens as tokenUtils } from '../utils/index.js';
 
 const { tokenRule } = rules;
 const { detectColorFormat } = color;
+const { collectColorTokenValues } = tokenUtils;
 
 export const borderColorRule = tokenRule({
   name: 'design-token/border-color',
@@ -15,15 +16,13 @@ export const borderColorRule = tokenRule({
   message:
     'design-token/border-color requires color tokens; configure tokens with $type "color" to enable this rule.',
   getAllowed(tokens) {
-    return new Set(
-      tokens
-        .map(({ value }) => {
-          return typeof value === 'string' && !value.startsWith('{')
-            ? value.toLowerCase()
-            : null;
-        })
-        .filter((v): v is string => v !== null),
-    );
+    const values = new Set<string>();
+    for (const token of tokens) {
+      for (const candidate of collectColorTokenValues(token)) {
+        values.add(candidate);
+      }
+    }
+    return values;
   },
   create(context, allowed) {
     return {

--- a/src/utils/tokens/flatten.ts
+++ b/src/utils/tokens/flatten.ts
@@ -58,6 +58,8 @@ export interface FlattenOptions {
   nameTransform?: NameTransform;
   /** Warning callback for parse or alias issues */
   onWarn?: (msg: string) => void;
+  /** Whether to validate tokens against the DTIF schema (defaults to true). */
+  validate?: boolean;
 }
 
 /**
@@ -73,6 +75,7 @@ export function flattenDesignTokens(
 ): FlattenedToken[] {
   const flat = parseDesignTokens(tokens, undefined, {
     onWarn: options?.onWarn,
+    validate: options?.validate ?? true,
   });
   const transform = options?.nameTransform;
   return flat.map((token) => {
@@ -136,6 +139,7 @@ export function getFlattenedTokens(
       return flattenDesignTokens(tokensByTheme[theme], {
         nameTransform: transform,
         onWarn: warn,
+        validate: options?.validate,
       });
     }
     return [];
@@ -145,6 +149,7 @@ export function getFlattenedTokens(
     for (const flat of flattenDesignTokens(tokens, {
       nameTransform: transform,
       onWarn: warn,
+      validate: options?.validate,
     })) {
       if (!seen.has(flat.path)) {
         seen.set(flat.path, flat);

--- a/tests/config/token-loader.test.ts
+++ b/tests/config/token-loader.test.ts
@@ -64,15 +64,15 @@ void test('parses inline design tokens object', async () => {
 void test('retains metadata on inline tokens', async () => {
   const tokens = await loadTokens(
     {
-      $schema: 'https://dtif.lapidist.net/schema/core.json',
+      $version: '1.2.3',
       color: { primary: { $type: 'color', $value: black } },
     },
     process.cwd(),
   );
   const color = tokens.color as { primary: { $value: typeof black } };
   assert.deepEqual(color.primary.$value, black);
-  const meta = tokens as { $schema: string };
-  assert.equal(meta.$schema, 'https://dtif.lapidist.net/schema/core.json');
+  const meta = tokens as { $version: string };
+  assert.equal(meta.$version, '1.2.3');
 });
 
 void test('parses inline theme record', async () => {

--- a/tests/core/get-flattened-tokens.test.ts
+++ b/tests/core/get-flattened-tokens.test.ts
@@ -7,10 +7,13 @@ void test('getFlattenedTokens flattens tokens for specified theme and preserves 
   const tokens: Record<string, DesignTokens> = {
     light: {
       palette: {
-        $type: 'color',
         $deprecated: true,
-        primary: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+        primary: {
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+        },
         secondary: {
+          $type: 'color',
           $value: { colorSpace: 'srgb', components: [0, 0, 0] },
           $extensions: { 'vendor.example': { note: true } },
         },
@@ -18,8 +21,8 @@ void test('getFlattenedTokens flattens tokens for specified theme and preserves 
     },
     dark: {
       palette: {
-        $type: 'color',
         primary: {
+          $type: 'color',
           $value: { colorSpace: 'srgb', components: [0.066, 0.066, 0.066] },
         },
       },
@@ -57,14 +60,18 @@ void test('getFlattenedTokens merges tokens from all themes when none is specifi
   const tokens: Record<string, DesignTokens> = {
     light: {
       palette: {
-        $type: 'color',
-        primary: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+        primary: {
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+        },
       },
     },
     dark: {
       palette: {
-        $type: 'color',
-        secondary: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+        secondary: {
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+        },
       },
     },
   };
@@ -99,9 +106,11 @@ void test('getFlattenedTokens resolves aliases', () => {
   const tokens: Record<string, DesignTokens> = {
     default: {
       palette: {
-        $type: 'color',
-        base: { $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
-        primary: { $ref: '/palette/base' },
+        base: {
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [1, 0, 0] },
+        },
+        primary: { $type: 'color', $ref: '#/palette/base' },
       },
     },
   };
@@ -138,14 +147,18 @@ void test('getFlattenedTokens applies name transforms', () => {
   const tokens: Record<string, DesignTokens> = {
     light: {
       ColorGroup: {
-        $type: 'color',
-        primaryColor: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+        primaryColor: {
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+        },
       },
     },
     dark: {
       ColorGroup: {
-        $type: 'color',
-        primaryColor: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+        primaryColor: {
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+        },
       },
     },
   };
@@ -174,6 +187,8 @@ void test('getFlattenedTokens returns empty array for primitive token values', (
       deprecations: { old: { replacement: 'new' } },
     },
   } as unknown as Record<string, DesignTokens>;
-  const result = getFlattenedTokens(tokens, 'default');
-  assert.deepEqual(result, []);
+  assert.throws(
+    () => getFlattenedTokens(tokens, 'default'),
+    /DTIF validation failed/i,
+  );
 });

--- a/tests/core/numeric-validators.test.ts
+++ b/tests/core/numeric-validators.test.ts
@@ -33,13 +33,13 @@ void test('validateDimension accepts references and fallbacks', () => {
     validateDimension({ dimensionType: 'length', value: 4, unit: 'px' }, 'dim');
   });
   assert.doesNotThrow(() => {
-    validateDimension({ $ref: '/spacing/sm' }, 'dim');
+    validateDimension({ $ref: '#/spacing/sm' }, 'dim');
   });
   assert.doesNotThrow(() => {
     validateDimension(
       [
-        { $ref: '/spacing/base' },
-        { fn: 'calc', parameters: [2, { $ref: '/spacing/base' }] },
+        { $ref: '#/spacing/base' },
+        { fn: 'calc', parameters: [2, { $ref: '#/spacing/base' }] },
       ],
       'dim',
     );
@@ -81,13 +81,13 @@ void test('validateDuration accepts references and fallbacks', () => {
     );
   });
   assert.doesNotThrow(() => {
-    validateDuration({ $ref: '/duration/short' }, 'dur');
+    validateDuration({ $ref: '#/duration/short' }, 'dur');
   });
   assert.doesNotThrow(() => {
     validateDuration(
       [
         { durationType: 'css.timeline.progress', value: 50, unit: '%' },
-        { $ref: '/duration/short' },
+        { $ref: '#/duration/short' },
       ],
       'dur',
     );

--- a/tests/core/pointers.test.ts
+++ b/tests/core/pointers.test.ts
@@ -13,13 +13,6 @@ void test('canonicalizePointer normalizes same-document fragments', () => {
 void test('canonicalizePointer preserves document URIs while normalizing fragments', () => {
   assert.equal(
     canonicalizePointer(
-      '../tokens/base.dtif.json#palette.primary',
-      'Token ../tokens/base.dtif.json#palette.primary',
-    ),
-    '../tokens/base.dtif.json#/palette.primary',
-  );
-  assert.equal(
-    canonicalizePointer(
       'https://cdn.example.com/tokens.dtif.json#/colors/brand',
       'Token https://cdn.example.com/tokens.dtif.json#/colors/brand',
     ),
@@ -27,16 +20,24 @@ void test('canonicalizePointer preserves document URIs while normalizing fragmen
   );
   assert.equal(
     canonicalizePointer(
-      '../tokens/base.dtif.json#/foo~0bar',
-      'Token ../tokens/base.dtif.json#/foo~0bar',
+      'tokens/base.dtif.json#/foo~0bar',
+      'Token tokens/base.dtif.json#/foo~0bar',
     ),
-    '../tokens/base.dtif.json#/foo~0bar',
+    'tokens/base.dtif.json#/foo~0bar',
   );
-  assert.equal(
+});
+
+void test('canonicalizePointer rejects document traversal and invalid escapes', () => {
+  assert.throws(() =>
     canonicalizePointer(
-      '../tokens/base.dtif.json#',
-      'Token ../tokens/base.dtif.json#',
+      '../tokens/base.dtif.json#/palette/primary',
+      'Token ../tokens/base.dtif.json#/palette/primary',
     ),
-    '../tokens/base.dtif.json#',
+  );
+  assert.throws(() =>
+    canonicalizePointer('#/palette/../primary', 'Token #/palette/../primary'),
+  );
+  assert.throws(() =>
+    canonicalizePointer('#/palette/~2primary', 'Token #/palette/~2primary'),
   );
 });

--- a/tests/core/token-registry.test.ts
+++ b/tests/core/token-registry.test.ts
@@ -7,24 +7,37 @@ import { TokenRegistry } from '../../src/core/token-registry.js';
 const tokens: Record<string, DesignTokens> = {
   default: {
     color: {
-      $type: 'color',
-      primary: { $value: '#fff' },
-      secondary: { $ref: '/color/primary' },
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+      },
+      secondary: { $type: 'color', $ref: '#/color/primary' },
     },
   },
   dark: {
     color: {
-      $type: 'color',
-      primary: { $value: '#000' },
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
     },
   },
 };
 
 void test('getToken retrieves tokens by theme and resolves aliases', () => {
   const registry = new TokenRegistry(tokens);
-  assert.equal(registry.getToken('/color/primary')?.value, '#fff');
-  assert.equal(registry.getToken('/color/secondary')?.value, '#fff');
-  assert.equal(registry.getToken('/color/primary', 'dark')?.value, '#000');
+  assert.deepEqual(registry.getToken('/color/primary')?.value, {
+    colorSpace: 'srgb',
+    components: [1, 1, 1],
+  });
+  assert.deepEqual(registry.getToken('/color/secondary')?.value, {
+    colorSpace: 'srgb',
+    components: [1, 1, 1],
+  });
+  assert.deepEqual(registry.getToken('/color/primary', 'dark')?.value, {
+    colorSpace: 'srgb',
+    components: [0, 0, 0],
+  });
 });
 
 void test('getToken normalizes paths and applies name transforms', () => {
@@ -32,16 +45,27 @@ void test('getToken normalizes paths and applies name transforms', () => {
     {
       default: {
         ColorGroup: {
-          $type: 'color',
-          primaryColor: { $value: '#111' },
-          secondaryColor: { $ref: '/ColorGroup/primaryColor' },
+          primaryColor: {
+            $type: 'color',
+            $value: { colorSpace: 'srgb', components: [0.066, 0.066, 0.066] },
+          },
+          secondaryColor: {
+            $type: 'color',
+            $ref: '#/ColorGroup/primaryColor',
+          },
         },
       },
     },
     { nameTransform: 'kebab-case' },
   );
-  assert.equal(registry.getToken('/ColorGroup/primaryColor')?.value, '#111');
-  assert.equal(registry.getToken('/color-group/primary-color')?.value, '#111');
+  assert.deepEqual(registry.getToken('/ColorGroup/primaryColor')?.value, {
+    colorSpace: 'srgb',
+    components: [0.066, 0.066, 0.066],
+  });
+  assert.deepEqual(registry.getToken('/color-group/primary-color')?.value, {
+    colorSpace: 'srgb',
+    components: [0.066, 0.066, 0.066],
+  });
 });
 
 void test('getTokens returns flattened tokens and dedupes across themes', () => {

--- a/tests/fixtures/nested-config/designlint.config.json
+++ b/tests/fixtures/nested-config/designlint.config.json
@@ -1,8 +1,20 @@
 {
   "tokens": {
     "color": {
-      "base": { "$type": "color", "$value": "#000000" }
+      "base": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     }
   },
-  "rules": { "design-token/colors": "error" }
+  "rules": {
+    "design-token/colors": "error"
+  }
 }

--- a/tests/fixtures/nested-config/packages/app/designlint.config.json
+++ b/tests/fixtures/nested-config/packages/app/designlint.config.json
@@ -1,8 +1,20 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#00ff00" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            1,
+            0
+          ]
+        }
+      }
     }
   },
-  "rules": { "design-token/colors": "error" }
+  "rules": {
+    "design-token/colors": "error"
+  }
 }

--- a/tests/fixtures/nextjs/designlint.config.json
+++ b/tests/fixtures/nextjs/designlint.config.json
@@ -1,29 +1,90 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 4,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Arial" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": "Arial"
+      }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/new-token"
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/NewComponent"
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "rules": {
     "design-token/colors": "error",
@@ -32,7 +93,11 @@
     "design-token/font-family": "error",
     "design-system/component-usage": [
       "error",
-      { "substitutions": { "button": "DSButton" } }
+      {
+        "substitutions": {
+          "button": "DSButton"
+        }
+      }
     ],
     "design-system/deprecation": "error"
   }

--- a/tests/fixtures/nuxt/designlint.config.json
+++ b/tests/fixtures/nuxt/designlint.config.json
@@ -1,29 +1,90 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 4,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Arial" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": "Arial"
+      }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/new-token"
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/NewComponent"
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "rules": {
     "design-token/colors": "error",
@@ -32,7 +93,11 @@
     "design-token/font-family": "error",
     "design-system/component-usage": [
       "error",
-      { "substitutions": { "button": "DSButton" } }
+      {
+        "substitutions": {
+          "button": "DSButton"
+        }
+      }
     ],
     "design-system/deprecation": "error"
   }

--- a/tests/fixtures/react-vite-css-modules/designlint.config.json
+++ b/tests/fixtures/react-vite-css-modules/designlint.config.json
@@ -1,30 +1,101 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" },
-      "unused": { "$type": "color", "$value": "#ffffff" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      },
+      "unused": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ]
+        }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 4,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Arial" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": "Arial"
+      }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/new-token"
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/NewComponent"
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "rules": {
     "design-token/colors": "error",
@@ -34,7 +105,11 @@
     "design-system/no-unused-tokens": "warn",
     "design-system/component-usage": [
       "error",
-      { "substitutions": { "button": "DSButton" } }
+      {
+        "substitutions": {
+          "button": "DSButton"
+        }
+      }
     ],
     "design-system/deprecation": "error"
   }

--- a/tests/fixtures/remix/designlint.config.json
+++ b/tests/fixtures/remix/designlint.config.json
@@ -1,29 +1,90 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 4,
+          "unit": "px"
+        }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 12,
+          "unit": "px"
+        }
+      }
     },
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Arial" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": "Arial"
+      }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/new-token"
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/NewComponent"
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "rules": {
     "design-token/colors": "error",
@@ -32,7 +93,11 @@
     "design-token/font-family": "error",
     "design-system/component-usage": [
       "error",
-      { "substitutions": { "button": "DSButton" } }
+      {
+        "substitutions": {
+          "button": "DSButton"
+        }
+      }
     ],
     "design-system/deprecation": "error"
   }

--- a/tests/fixtures/sample/designlint.config.json
+++ b/tests/fixtures/sample/designlint.config.json
@@ -1,8 +1,20 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     }
   },
-  "rules": { "design-token/colors": "error" }
+  "rules": {
+    "design-token/colors": "error"
+  }
 }

--- a/tests/fixtures/svelte/designlint.config.json
+++ b/tests/fixtures/svelte/designlint.config.json
@@ -1,29 +1,90 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 4,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Arial" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": "Arial"
+      }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/new-token"
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/NewComponent"
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "rules": {
     "design-token/colors": "error",
@@ -32,7 +93,11 @@
     "design-token/font-family": "error",
     "design-system/component-usage": [
       "error",
-      { "substitutions": { "button": "DSButton" } }
+      {
+        "substitutions": {
+          "button": "DSButton"
+        }
+      }
     ],
     "design-system/deprecation": "error"
   }

--- a/tests/fixtures/tagged-template/designlint.config.json
+++ b/tests/fixtures/tagged-template/designlint.config.json
@@ -1,8 +1,20 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     }
   },
-  "rules": { "design-token/colors": "error" }
+  "rules": {
+    "design-token/colors": "error"
+  }
 }

--- a/tests/fixtures/vue/designlint.config.json
+++ b/tests/fixtures/vue/designlint.config.json
@@ -1,29 +1,90 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 4,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Arial" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": "Arial"
+      }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/new-token"
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/NewComponent"
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "rules": {
     "design-token/colors": "error",
@@ -32,7 +93,11 @@
     "design-token/font-family": "error",
     "design-system/component-usage": [
       "error",
-      { "substitutions": { "button": "DSButton" } }
+      {
+        "substitutions": {
+          "button": "DSButton"
+        }
+      }
     ],
     "design-system/deprecation": "error"
   }

--- a/tests/fixtures/web-components/designlint.config.json
+++ b/tests/fixtures/web-components/designlint.config.json
@@ -1,29 +1,90 @@
 {
   "tokens": {
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0,
+            0
+          ]
+        }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 4,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px",
+          "dimensionType": "length"
+        }
+      }
     },
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Arial" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": "Arial"
+      }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/new-token"
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0,
+          0,
+          0
+        ]
+      },
+      "$deprecated": "Use #/NewComponent"
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "rules": {
     "design-token/colors": "error",
@@ -32,7 +93,11 @@
     "design-token/font-family": "error",
     "design-system/component-usage": [
       "error",
-      { "substitutions": { "button": "DSButton" } }
+      {
+        "substitutions": {
+          "button": "DSButton"
+        }
+      }
     ],
     "design-system/deprecation": "error"
   }

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -7,8 +7,15 @@ import { createLinter as initLinter } from '../src/index.js';
 import { FileSource } from '../src/adapters/node/file-source.js';
 
 const tokens = {
-  old: { $type: 'color', $value: '#000', $deprecated: 'Use {new}' },
-  new: { $type: 'color', $value: '#fff' },
+  old: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+    $deprecated: 'Use #/new',
+  },
+  new: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+  },
 };
 
 void test('lintTargets ignores common directories by default', async () => {

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -7,8 +7,15 @@ import { createLinter as initLinter } from '../src/index.js';
 import { FileSource } from '../src/adapters/node/file-source.js';
 
 const tokens = {
-  old: { $type: 'color', $value: '#000', $deprecated: 'Use {new}' },
-  new: { $type: 'color', $value: '#fff' },
+  old: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+    $deprecated: 'Use #/new',
+  },
+  new: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+  },
 };
 
 void test('inline directives disable linting', async () => {

--- a/tests/output/css.test.ts
+++ b/tests/output/css.test.ts
@@ -7,12 +7,12 @@ void test('generateCssVariables emits blocks for each theme with transformed nam
   const tokens: Record<string, DesignTokens> = {
     default: {
       ColorPalette: {
-        PrimaryColor: { $type: 'color', $value: '#fff' },
+        PrimaryColor: { $type: 'string', $value: '#fff' },
       },
     },
     dark: {
       ColorPalette: {
-        PrimaryColor: { $type: 'color', $value: '#000' },
+        PrimaryColor: { $type: 'string', $value: '#000' },
       },
     },
   };
@@ -34,17 +34,17 @@ void test('generateCssVariables sorts themes with default first', () => {
   const tokens: Record<string, DesignTokens> = {
     dark: {
       color: {
-        primary: { $type: 'color', $value: '#000' },
+        primary: { $type: 'string', $value: '#000' },
       },
     },
     default: {
       color: {
-        primary: { $type: 'color', $value: '#fff' },
+        primary: { $type: 'string', $value: '#fff' },
       },
     },
     light: {
       color: {
-        primary: { $type: 'color', $value: '#eee' },
+        primary: { $type: 'string', $value: '#eee' },
       },
     },
   };

--- a/tests/output/js.test.ts
+++ b/tests/output/js.test.ts
@@ -7,12 +7,12 @@ void test('generateJsConstants emits constants for each theme', () => {
   const tokens: Record<string, DesignTokens> = {
     default: {
       ColorPalette: {
-        PrimaryColor: { $type: 'color', $value: '#fff' },
+        PrimaryColor: { $type: 'string', $value: '#fff' },
       },
     },
     dark: {
       ColorPalette: {
-        PrimaryColor: { $type: 'color', $value: '#000' },
+        PrimaryColor: { $type: 'string', $value: '#000' },
       },
     },
   };

--- a/tests/output/ts.test.ts
+++ b/tests/output/ts.test.ts
@@ -7,12 +7,12 @@ void test('generateTsDeclarations emits typed object with themes', () => {
   const tokens: Record<string, DesignTokens> = {
     default: {
       ColorPalette: {
-        PrimaryColor: { $type: 'color', $value: '#fff' },
+        PrimaryColor: { $type: 'string', $value: '#fff' },
       },
     },
     dark: {
       ColorPalette: {
-        PrimaryColor: { $type: 'color', $value: '#000' },
+        PrimaryColor: { $type: 'string', $value: '#000' },
       },
     },
   };

--- a/tests/rules/animation.test.ts
+++ b/tests/rules/animation.test.ts
@@ -9,8 +9,7 @@ registerTokenValidator('string', () => undefined);
 
 const tokens = {
   animations: {
-    $type: 'string',
-    spin: { $value: 'spin 1s linear infinite' },
+    spin: { $type: 'string', $value: 'spin 1s linear infinite' },
   },
 };
 

--- a/tests/rules/blur.test.ts
+++ b/tests/rules/blur.test.ts
@@ -5,7 +5,12 @@ import { FileSource } from '../../src/adapters/node/file-source.js';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
-  blurs: { $type: 'dimension', sm: { $value: { value: 4, unit: 'px' } } },
+  blurs: {
+    sm: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 4, unit: 'px' },
+    },
+  },
 };
 
 function createLinter() {

--- a/tests/rules/border-color.test.ts
+++ b/tests/rules/border-color.test.ts
@@ -6,7 +6,12 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 void test('design-token/border-color reports invalid value', async () => {
   const tokens = {
-    borderColors: { $type: 'color', primary: { $value: '#ffffff' } },
+    borderColors: {
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+      },
+    },
   };
   const linter = initLinter(
     { tokens, rules: { 'design-token/border-color': 'error' } },
@@ -21,7 +26,12 @@ void test('design-token/border-color reports invalid value', async () => {
 
 void test('design-token/border-color accepts valid values', async () => {
   const tokens = {
-    borderColors: { $type: 'color', primary: { $value: '#ffffff' } },
+    borderColors: {
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+      },
+    },
   };
   const linter = initLinter(
     { tokens, rules: { 'design-token/border-color': 'error' } },

--- a/tests/rules/border-radius.test.ts
+++ b/tests/rules/border-radius.test.ts
@@ -6,9 +6,14 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   radius: {
-    $type: 'dimension',
-    sm: { $value: { value: 2, unit: 'px' } },
-    md: { $value: { value: 4, unit: 'px' } },
+    sm: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 2, unit: 'px' },
+    },
+    md: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 4, unit: 'px' },
+    },
   },
 };
 

--- a/tests/rules/border-width.test.ts
+++ b/tests/rules/border-width.test.ts
@@ -6,9 +6,14 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   borderWidths: {
-    $type: 'dimension',
-    sm: { $value: { value: 1, unit: 'px' } },
-    md: { $value: { value: 2, unit: 'px' } },
+    sm: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 1, unit: 'px' },
+    },
+    md: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 2, unit: 'px' },
+    },
   },
 };
 

--- a/tests/rules/box-shadow.test.ts
+++ b/tests/rules/box-shadow.test.ts
@@ -6,24 +6,41 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   shadows: {
-    $type: 'shadow',
     sm: {
-      $value: {
-        offsetX: { value: 0, unit: 'px' },
-        offsetY: { value: 1, unit: 'px' },
-        blur: { value: 2, unit: 'px' },
-        spread: { value: 0, unit: 'px' },
-        color: 'rgba(0,0,0,0.1)',
-      },
+      $type: 'shadow',
+      $value: [
+        {
+          shadowType: 'css.box-shadow',
+          offsetX: { dimensionType: 'length', value: 0, unit: 'px' },
+          offsetY: { dimensionType: 'length', value: 1, unit: 'px' },
+          blur: { dimensionType: 'length', value: 2, unit: 'px' },
+          spread: { dimensionType: 'length', value: 0, unit: 'px' },
+          color: {
+            colorSpace: 'srgb',
+            components: [0, 0, 0],
+            hex: '#000000',
+            alpha: 0.1,
+          },
+        },
+      ],
     },
     lg: {
-      $value: {
-        offsetX: { value: 0, unit: 'px' },
-        offsetY: { value: 2, unit: 'px' },
-        blur: { value: 4, unit: 'px' },
-        spread: { value: 0, unit: 'px' },
-        color: 'rgba(0,0,0,0.2)',
-      },
+      $type: 'shadow',
+      $value: [
+        {
+          shadowType: 'css.box-shadow',
+          offsetX: { dimensionType: 'length', value: 0, unit: 'px' },
+          offsetY: { dimensionType: 'length', value: 2, unit: 'px' },
+          blur: { dimensionType: 'length', value: 4, unit: 'px' },
+          spread: { dimensionType: 'length', value: 0, unit: 'px' },
+          color: {
+            colorSpace: 'srgb',
+            components: [0, 0, 0],
+            hex: '#000000',
+            alpha: 0.2,
+          },
+        },
+      ],
     },
   },
 };

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -10,10 +10,13 @@ void test('design-system/deprecation flags deprecated token', async () => {
         colors: {
           old: {
             $type: 'color',
-            $value: '#000',
+            $value: { colorSpace: 'srgb', components: [0, 0, 0] },
             $deprecated: { $replacement: '#/colors/new' },
           },
-          new: { $type: 'color', $value: '#fff' },
+          new: {
+            $type: 'color',
+            $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+          },
         },
       },
       rules: { 'design-system/deprecation': 'error' },
@@ -39,10 +42,13 @@ void test('design-system/deprecation ignores tokens in non-style jsx attributes'
         colors: {
           old: {
             $type: 'color',
-            $value: '#000',
+            $value: { colorSpace: 'srgb', components: [0, 0, 0] },
             $deprecated: { $replacement: '#/colors/new' },
           },
-          new: { $type: 'color', $value: '#fff' },
+          new: {
+            $type: 'color',
+            $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+          },
         },
       },
       rules: { 'design-system/deprecation': 'error' },

--- a/tests/rules/duration.test.ts
+++ b/tests/rules/duration.test.ts
@@ -6,9 +6,22 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   durations: {
-    $type: 'duration',
-    fast: { $value: { value: 200, unit: 'ms' } },
-    slow: { $value: { value: 400, unit: 'ms' } },
+    fast: {
+      $type: 'duration',
+      $value: {
+        durationType: 'css.transition-duration',
+        value: 200,
+        unit: 'ms',
+      },
+    },
+    slow: {
+      $type: 'duration',
+      $value: {
+        durationType: 'css.transition-duration',
+        value: 400,
+        unit: 'ms',
+      },
+    },
   },
 };
 

--- a/tests/rules/font-family.test.ts
+++ b/tests/rules/font-family.test.ts
@@ -5,7 +5,7 @@ import { FileSource } from '../../src/adapters/node/file-source.js';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
-  fonts: { $type: 'fontFamily', sans: { $value: 'Inter' } },
+  fonts: { sans: { $type: 'fontFamily', $value: 'Inter' } },
 };
 
 function createLinter() {

--- a/tests/rules/font-size.test.ts
+++ b/tests/rules/font-size.test.ts
@@ -6,9 +6,14 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   fontSizes: {
-    $type: 'dimension',
-    base: { $value: { value: 16, unit: 'px' } },
-    lg: { $value: { value: 32, unit: 'px' } },
+    base: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 16, unit: 'px' },
+    },
+    lg: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 32, unit: 'px' },
+    },
   },
 };
 

--- a/tests/rules/font-weight.test.ts
+++ b/tests/rules/font-weight.test.ts
@@ -6,9 +6,8 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   fontWeights: {
-    $type: 'fontWeight',
-    regular: { $value: 400 },
-    bold: { $value: 700 },
+    regular: { $type: 'fontWeight', $value: 400 },
+    bold: { $type: 'fontWeight', $value: 700 },
   },
 };
 

--- a/tests/rules/letter-spacing.test.ts
+++ b/tests/rules/letter-spacing.test.ts
@@ -6,9 +6,14 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   letterSpacings: {
-    $type: 'dimension',
-    tight: { $value: { value: -0.05, unit: 'rem' } },
-    none: { $value: { value: 0, unit: 'rem' } },
+    tight: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: -0.05, unit: 'rem' },
+    },
+    none: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 0, unit: 'rem' },
+    },
   },
 };
 

--- a/tests/rules/line-height.test.ts
+++ b/tests/rules/line-height.test.ts
@@ -5,7 +5,10 @@ import { FileSource } from '../../src/adapters/node/file-source.js';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
-  lineHeights: { $type: 'number', base: { $value: 1.5 }, tight: { $value: 2 } },
+  lineHeights: {
+    base: { $type: 'number', $value: 1.5 },
+    tight: { $type: 'number', $value: 2 },
+  },
 };
 
 function createLinter() {

--- a/tests/rules/no-unused-tokens.test.ts
+++ b/tests/rules/no-unused-tokens.test.ts
@@ -7,8 +7,17 @@ import type { LintDocument } from '../../src/core/environment.js';
 void test('design-system/no-unused-tokens reports unused tokens', async () => {
   const tokens = {
     color: {
-      primary: { $value: '#000000', $type: 'color' },
-      unused: { $value: '#123456', $type: 'color' },
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+      unused: {
+        $type: 'color',
+        $value: {
+          colorSpace: 'srgb',
+          components: [18 / 255, 52 / 255, 86 / 255],
+        },
+      },
     },
   };
   const linter = initLinter(
@@ -24,20 +33,23 @@ void test('design-system/no-unused-tokens reports unused tokens', async () => {
     getText: () => Promise.resolve('const color = "#000000";'),
   };
   const { results } = await linter.lintDocuments([doc]);
-  const msg = results
+  const messages = results
     .flatMap((r) => r.messages)
-    .find((m) => m.ruleId === 'design-system/no-unused-tokens');
-  assert(msg);
-  assert.equal(msg.severity, 'warn');
-  assert.ok(msg.message.includes('#123456'));
+    .filter((m) => m.ruleId === 'design-system/no-unused-tokens');
+  const message = messages.find((m) => m.message.includes('#123456'));
+  assert(message);
+  assert.equal(message.severity, 'warn');
 });
 
 void test('design-system/no-unused-tokens includes token metadata', async () => {
   const tokens = {
     color: {
       unused: {
-        $value: '#123456',
         $type: 'color',
+        $value: {
+          colorSpace: 'srgb',
+          components: [18 / 255, 52 / 255, 86 / 255],
+        },
         $deprecated: true,
         $extensions: { 'vendor.foo': true },
       },
@@ -68,7 +80,12 @@ void test('design-system/no-unused-tokens includes token metadata', async () => 
 
 void test('design-system/no-unused-tokens passes when tokens used', async () => {
   const tokens = {
-    color: { primary: { $value: '#000000', $type: 'color' } },
+    color: {
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+    },
   };
   const linter = initLinter(
     {
@@ -92,8 +109,17 @@ void test('design-system/no-unused-tokens passes when tokens used', async () => 
 void test('design-system/no-unused-tokens can ignore tokens', async () => {
   const tokens = {
     color: {
-      primary: { $value: '#000000', $type: 'color' },
-      unused: { $value: '#123456', $type: 'color' },
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+      unused: {
+        $type: 'color',
+        $value: {
+          colorSpace: 'srgb',
+          components: [18 / 255, 52 / 255, 86 / 255],
+        },
+      },
     },
   };
   const linter = initLinter(
@@ -118,7 +144,17 @@ void test('design-system/no-unused-tokens can ignore tokens', async () => {
 });
 
 void test('design-system/no-unused-tokens matches hex case-insensitively', async () => {
-  const tokens = { color: { primary: { $value: '#abcdef', $type: 'color' } } };
+  const tokens = {
+    color: {
+      primary: {
+        $type: 'color',
+        $value: {
+          colorSpace: 'srgb',
+          components: [0xab / 255, 0xcd / 255, 0xef / 255],
+        },
+      },
+    },
+  };
   const linter = initLinter(
     {
       tokens,

--- a/tests/rules/opacity.test.ts
+++ b/tests/rules/opacity.test.ts
@@ -5,7 +5,7 @@ import { FileSource } from '../../src/adapters/node/file-source.js';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 function createLinter(rule: unknown = 'error') {
-  const tokens = { opacity: { $type: 'number', low: { $value: 0.2 } } };
+  const tokens = { opacity: { low: { $type: 'number', $value: 0.2 } } };
   return initLinter(
     { tokens, rules: { 'design-token/opacity': rule } },
     {

--- a/tests/rules/outline.test.ts
+++ b/tests/rules/outline.test.ts
@@ -8,7 +8,7 @@ import { registerTokenValidator } from '../../src/core/token-validators/index.js
 registerTokenValidator('string', () => undefined);
 
 const tokens = {
-  outlines: { $type: 'string', focus: { $value: '2px solid #000' } },
+  outlines: { focus: { $type: 'string', $value: '2px solid #000' } },
 };
 
 function createLinter() {

--- a/tests/rules/spacing.test.ts
+++ b/tests/rules/spacing.test.ts
@@ -6,9 +6,14 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   spacing: {
-    $type: 'dimension',
-    sm: { $value: { value: 4, unit: 'px' } },
-    md: { $value: { value: 8, unit: 'px' } },
+    sm: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 4, unit: 'px' },
+    },
+    md: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 8, unit: 'px' },
+    },
   },
 };
 

--- a/tests/rules/style-languages.test.ts
+++ b/tests/rules/style-languages.test.ts
@@ -5,12 +5,19 @@ import { FileSource } from '../../src/adapters/node/file-source.js';
 
 const config = {
   tokens: {
-    color: { $type: 'color', primary: { $value: '#000000' } },
-    spacing: {
-      $type: 'dimension',
-      sm: { $value: { value: 4, unit: 'px' } },
+    color: {
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
     },
-    opacity: { $type: 'number', full: { $value: 1 } },
+    spacing: {
+      sm: {
+        $type: 'dimension',
+        $value: { dimensionType: 'length', value: 4, unit: 'px' },
+      },
+    },
+    opacity: { full: { $type: 'number', $value: 1 } },
   },
   rules: {
     'design-token/colors': 'error',
@@ -70,7 +77,14 @@ void test('reports raw tokens in string style attributes', async () => {
 void test('reports raw tokens once for single style property', async () => {
   const linter = initLinter(
     {
-      tokens: { color: { $type: 'color', primary: { $value: '#000000' } } },
+      tokens: {
+        color: {
+          primary: {
+            $type: 'color',
+            $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+          },
+        },
+      },
       rules: { 'design-token/colors': 'error' },
     },
     new FileSource(),

--- a/tests/rules/token-colors.test.ts
+++ b/tests/rules/token-colors.test.ts
@@ -7,7 +7,6 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 function createLinter(rule: unknown = 'error') {
   const tokens = {
     palette: {
-      $type: 'color',
       neutral: {
         $type: 'color',
         $value: { colorSpace: 'srgb', components: [1, 1, 1] },

--- a/tests/rules/token-suggestion.test.ts
+++ b/tests/rules/token-suggestion.test.ts
@@ -6,9 +6,14 @@ import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
   fontSizes: {
-    $type: 'dimension',
-    sm: { $value: { value: 16, unit: 'px' } },
-    md: { $value: { value: 32, unit: 'px' } },
+    sm: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 16, unit: 'px' },
+    },
+    md: {
+      $type: 'dimension',
+      $value: { dimensionType: 'length', value: 32, unit: 'px' },
+    },
   },
 };
 

--- a/tests/rules/z-index.test.ts
+++ b/tests/rules/z-index.test.ts
@@ -5,7 +5,9 @@ import { FileSource } from '../../src/adapters/node/file-source.js';
 import { NodeTokenProvider } from '../../src/adapters/node/token-provider.js';
 
 const tokens = {
-  zIndex: { $type: 'number', modal: { $value: 100 } },
+  zIndex: {
+    modal: { $type: 'number', $value: 100 },
+  },
 };
 
 function createLinter() {


### PR DESCRIPTION
## Summary
- Converted lingering tests and docs to DTIF-compliant structures, updated rule documentation snippets (e.g. `docs/rules/design-system/deprecation.md`, `docs/configuration.md`, `docs/examples/basic/designlint.config.json`) to use canonical JSON Pointers.
- Added stricter pointer validation tests (`tests/core/token-parser.test.ts`), refreshed style-language fixtures and output generator suites to consume DTIF token shapes, and created the breaking-change changeset entry.
- Rewrote key core tests (such as `tests/core/flatten-design-tokens.test.ts` and `tests/core/get-flattened-tokens.test.ts`) around explicit `$type`/`$value` pairs and updated README guidance to highlight `@lapidist/dtif-validator` plus the “Migrating from DTCG” guide.
- Finalized DTIF migration by tightening TokenTracker hex-color expectations and updating deprecation fixtures to satisfy strict schema validation.

## Testing
- npm run lint
- npm run test
- CI=1 npm run format:check
- npm run lint:md

------
https://chatgpt.com/codex/tasks/task_e_68d0660399a483288a0ee04a77413985