### PR TITLE
test(fixtures): use dtif-compliant deprecated metadata

### DIFF
--- a/.changeset/align-fixture-deprecations.md
+++ b/.changeset/align-fixture-deprecations.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+Update test fixtures and in-repo configs to use DTIF-compliant $deprecated metadata.

--- a/tests/fixtures/nextjs/designlint.config.json
+++ b/tests/fixtures/nextjs/designlint.config.json
@@ -49,7 +49,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/new-token"
+      "$deprecated": {
+        "$message": "Use #/new-token",
+        "$replacement": "#/new-token"
+      }
     },
     "new-token": {
       "$type": "color",
@@ -72,7 +75,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/NewComponent"
+      "$deprecated": {
+        "$message": "Use #/NewComponent",
+        "$replacement": "#/NewComponent"
+      }
     },
     "NewComponent": {
       "$type": "color",

--- a/tests/fixtures/nuxt/designlint.config.json
+++ b/tests/fixtures/nuxt/designlint.config.json
@@ -49,7 +49,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/new-token"
+      "$deprecated": {
+        "$message": "Use #/new-token",
+        "$replacement": "#/new-token"
+      }
     },
     "new-token": {
       "$type": "color",
@@ -72,7 +75,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/NewComponent"
+      "$deprecated": {
+        "$message": "Use #/NewComponent",
+        "$replacement": "#/NewComponent"
+      }
     },
     "NewComponent": {
       "$type": "color",

--- a/tests/fixtures/react-vite-css-modules/designlint.config.json
+++ b/tests/fixtures/react-vite-css-modules/designlint.config.json
@@ -60,7 +60,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/new-token"
+      "$deprecated": {
+        "$message": "Use #/new-token",
+        "$replacement": "#/new-token"
+      }
     },
     "new-token": {
       "$type": "color",
@@ -83,7 +86,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/NewComponent"
+      "$deprecated": {
+        "$message": "Use #/NewComponent",
+        "$replacement": "#/NewComponent"
+      }
     },
     "NewComponent": {
       "$type": "color",

--- a/tests/fixtures/remix/designlint.config.json
+++ b/tests/fixtures/remix/designlint.config.json
@@ -49,7 +49,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/new-token"
+      "$deprecated": {
+        "$message": "Use #/new-token",
+        "$replacement": "#/new-token"
+      }
     },
     "new-token": {
       "$type": "color",
@@ -72,7 +75,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/NewComponent"
+      "$deprecated": {
+        "$message": "Use #/NewComponent",
+        "$replacement": "#/NewComponent"
+      }
     },
     "NewComponent": {
       "$type": "color",

--- a/tests/fixtures/svelte/designlint.config.json
+++ b/tests/fixtures/svelte/designlint.config.json
@@ -49,7 +49,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/new-token"
+      "$deprecated": {
+        "$message": "Use #/new-token",
+        "$replacement": "#/new-token"
+      }
     },
     "new-token": {
       "$type": "color",
@@ -72,7 +75,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/NewComponent"
+      "$deprecated": {
+        "$message": "Use #/NewComponent",
+        "$replacement": "#/NewComponent"
+      }
     },
     "NewComponent": {
       "$type": "color",

--- a/tests/fixtures/vue/designlint.config.json
+++ b/tests/fixtures/vue/designlint.config.json
@@ -49,7 +49,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/new-token"
+      "$deprecated": {
+        "$message": "Use #/new-token",
+        "$replacement": "#/new-token"
+      }
     },
     "new-token": {
       "$type": "color",
@@ -72,7 +75,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/NewComponent"
+      "$deprecated": {
+        "$message": "Use #/NewComponent",
+        "$replacement": "#/NewComponent"
+      }
     },
     "NewComponent": {
       "$type": "color",

--- a/tests/fixtures/web-components/designlint.config.json
+++ b/tests/fixtures/web-components/designlint.config.json
@@ -49,7 +49,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/new-token"
+      "$deprecated": {
+        "$message": "Use #/new-token",
+        "$replacement": "#/new-token"
+      }
     },
     "new-token": {
       "$type": "color",
@@ -72,7 +75,10 @@
           0
         ]
       },
-      "$deprecated": "Use #/NewComponent"
+      "$deprecated": {
+        "$message": "Use #/NewComponent",
+        "$replacement": "#/NewComponent"
+      }
     },
     "NewComponent": {
       "$type": "color",

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -10,7 +10,10 @@ const tokens = {
   old: {
     $type: 'color',
     $value: { colorSpace: 'srgb', components: [0, 0, 0] },
-    $deprecated: 'Use #/new',
+    $deprecated: {
+      $message: 'Use #/new',
+      $replacement: '#/new',
+    },
   },
   new: {
     $type: 'color',

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -10,7 +10,10 @@ const tokens = {
   old: {
     $type: 'color',
     $value: { colorSpace: 'srgb', components: [0, 0, 0] },
-    $deprecated: 'Use #/new',
+    $deprecated: {
+      $message: 'Use #/new',
+      $replacement: '#/new',
+    },
   },
   new: {
     $type: 'color',


### PR DESCRIPTION
## Summary
- replace legacy string `$deprecated` values in fixture configs with object metadata that includes DTIF-compliant `$message` and `$replacement`
- update inline test token fixtures to use the new `$deprecated` shape and add a changeset documenting the fix

## Testing
- npm run lint
- CI=1 npm run format:check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d07d15b2e48328983eceff3d9bea8c