### PR TITLE
Update CLI smoke fixtures for DTIF compliance

### DIFF
--- a/tests/fixtures.test.ts
+++ b/tests/fixtures.test.ts
@@ -31,18 +31,51 @@ const fixtures: Fixture[] = [
   },
   {
     name: 'svelte',
-    files: ['src/App.module.css', 'src/App.svelte', 'src/Multi.svelte'],
+    files: [
+      'designlint.config.json',
+      'src/App.module.css',
+      'src/App.svelte',
+      'src/ControlFlow.svelte',
+      'src/Directive.svelte',
+    ],
   },
   {
     name: 'vue',
-    files: ['src/App.module.css', 'src/App.vue', 'src/Multi.vue'],
+    files: [
+      'designlint.config.json',
+      'src/App.module.css',
+      'src/App.vue',
+      'src/Multi.vue',
+    ],
   },
-  { name: 'nextjs', files: ['styles/Home.module.css', 'pages/index.tsx'] },
-  { name: 'nuxt', files: ['pages/index.module.css', 'pages/index.vue'] },
-  { name: 'remix', files: ['app/styles.module.css', 'app/routes/_index.tsx'] },
+  {
+    name: 'nextjs',
+    files: [
+      'designlint.config.json',
+      'styles/Home.module.css',
+      'pages/index.tsx',
+    ],
+  },
+  {
+    name: 'nuxt',
+    files: [
+      'designlint.config.json',
+      'pages/index.module.css',
+      'pages/index.vue',
+    ],
+  },
+  {
+    name: 'remix',
+    files: [
+      'app/styles.module.css',
+      'app/routes/_index.tsx',
+      'designlint.config.json',
+    ],
+  },
   {
     name: 'web-components',
     files: [
+      'designlint.config.json',
       'src/component.css',
       'src/component.tsx',
       'src/component.mjs',

--- a/tests/fixtures/nested-config/designlint.config.json
+++ b/tests/fixtures/nested-config/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "base": { "$type": "color", "$value": "#000000" }
+      "base": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     }
   },
   "rules": { "design-token/colors": "error" }

--- a/tests/fixtures/nextjs/designlint.config.json
+++ b/tests/fixtures/nextjs/designlint.config.json
@@ -1,35 +1,52 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 12, "unit": "px" }
+      }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",
     "design-token/spacing": "error",
     "design-token/font-size": "error",
     "design-token/font-family": "error",
+    "design-system/no-unused-tokens": "warn",
     "design-system/component-usage": [
       "error",
       { "substitutions": { "button": "DSButton" } }

--- a/tests/fixtures/nuxt/designlint.config.json
+++ b/tests/fixtures/nuxt/designlint.config.json
@@ -1,35 +1,52 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 12, "unit": "px" }
+      }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",
     "design-token/spacing": "error",
     "design-token/font-size": "error",
     "design-token/font-family": "error",
+    "design-system/no-unused-tokens": "warn",
     "design-system/component-usage": [
       "error",
       { "substitutions": { "button": "DSButton" } }

--- a/tests/fixtures/react-vite-css-modules/designlint.config.json
+++ b/tests/fixtures/react-vite-css-modules/designlint.config.json
@@ -1,30 +1,49 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" },
-      "unused": { "$type": "color", "$value": "#ffffff" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      },
+      "unused": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 12, "unit": "px" }
+      }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/fixtures/remix/designlint.config.json
+++ b/tests/fixtures/remix/designlint.config.json
@@ -1,35 +1,52 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 12, "unit": "px" }
+      }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",
     "design-token/spacing": "error",
     "design-token/font-size": "error",
     "design-token/font-family": "error",
+    "design-system/no-unused-tokens": "warn",
     "design-system/component-usage": [
       "error",
       { "substitutions": { "button": "DSButton" } }

--- a/tests/fixtures/sample/designlint.config.json
+++ b/tests/fixtures/sample/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     }
   },
   "rules": { "design-token/colors": "error" }

--- a/tests/fixtures/svelte/designlint.config.json
+++ b/tests/fixtures/svelte/designlint.config.json
@@ -1,35 +1,52 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 12, "unit": "px" }
+      }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",
     "design-token/spacing": "error",
     "design-token/font-size": "error",
     "design-token/font-family": "error",
+    "design-system/no-unused-tokens": "warn",
     "design-system/component-usage": [
       "error",
       { "substitutions": { "button": "DSButton" } }

--- a/tests/fixtures/tagged-template/designlint.config.json
+++ b/tests/fixtures/tagged-template/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     }
   },
   "rules": { "design-token/colors": "error" }

--- a/tests/fixtures/vue/designlint.config.json
+++ b/tests/fixtures/vue/designlint.config.json
@@ -1,35 +1,52 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 12, "unit": "px" }
+      }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",
     "design-token/spacing": "error",
     "design-token/font-size": "error",
     "design-token/font-family": "error",
+    "design-system/no-unused-tokens": "warn",
     "design-system/component-usage": [
       "error",
       { "substitutions": { "button": "DSButton" } }

--- a/tests/fixtures/vue/src/App.vue
+++ b/tests/fixtures/vue/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="container" :style="{ padding: 5, color: '#ffffff' }">
     Hello
+    <button>Click</button>
   </div>
 </template>
 

--- a/tests/fixtures/vue/src/Multi.vue
+++ b/tests/fixtures/vue/src/Multi.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="container" :style="{ padding: 5, color: '#ffffff' }">
     Hello
+    <button>Click</button>
   </div>
 </template>
 

--- a/tests/fixtures/web-components/designlint.config.json
+++ b/tests/fixtures/web-components/designlint.config.json
@@ -1,35 +1,52 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     },
     "fontSizes": {
-      "sm": { "$type": "dimension", "$value": { "value": 12, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 12, "unit": "px" }
+      }
     },
     "fonts": {
       "sans": { "$type": "fontFamily", "$value": "Arial" }
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",
     "design-token/spacing": "error",
     "design-token/font-size": "error",
     "design-token/font-family": "error",
+    "design-system/no-unused-tokens": "warn",
     "design-system/component-usage": [
       "error",
       { "substitutions": { "button": "DSButton" } }


### PR DESCRIPTION
## Summary
- convert CLI smoke fixture configs to DTIF-compliant design token documents, including structured $deprecated metadata and srgb component values
- enable the design-system/no-unused-tokens rule across fixtures and adjust Vue templates to exercise component usage checks
- refresh smoke test expectations to include designlint.config.json outputs and current fixture file lists

## Testing
- npm run lint
- CI=1 npm run format:check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d330da6d288328960799ef6649b21d