### PR TITLE
fix: update CLI smoke test tokens to DTIF

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -55,9 +55,17 @@ jobs:
           cat > designlint.config.json <<'EOF'
           {
             "tokens": {
+              "$version": "1.0.0",
               "color": {
-                "old": { "$type": "color", "$value": "#000", "$deprecated": "Use {color.new}" },
-                "new": { "$type": "color", "$value": "#fff" }
+                "old": {
+                  "$type": "color",
+                  "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+                  "$deprecated": { "$replacement": "#/color/new" }
+                },
+                "new": {
+                  "$type": "color",
+                  "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+                }
               }
             },
             "rules": {
@@ -101,9 +109,17 @@ jobs:
           cat > designlint.config.js <<'EOF'
           module.exports = {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -117,9 +133,17 @@ jobs:
           cat > designlint.config.cjs <<'EOF'
           module.exports = {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -133,9 +157,17 @@ jobs:
           cat > designlint.config.mjs <<'EOF'
           export default {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -151,9 +183,17 @@ jobs:
 
           export default {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -169,9 +209,17 @@ jobs:
 
           export default {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -186,10 +234,15 @@ jobs:
           {
             "tokens": {
               "default": {
+                "$version": "1.0.0",
                 "spacing": {
                   "scale-100": {
                     "$type": "dimension",
-                    "$value": { "value": 4, "unit": "px" }
+                    "$value": {
+                      "dimensionType": "length",
+                      "value": 4,
+                      "unit": "px"
+                    }
                   }
                 }
               }
@@ -205,8 +258,12 @@ jobs:
           npx design-lint file.ts --format json || true
           cat > gen.tokens.json <<'EOF'
           {
+            "$version": "1.0.0",
             "color": {
-              "red": { "$type": "color", "$value": "#ff0000" }
+              "red": {
+                "$type": "color",
+                "$value": { "colorSpace": "srgb", "components": [1, 0, 0] }
+              }
             }
           }
           EOF


### PR DESCRIPTION
## Summary
- update the CLI smoke workflow to write DTIF-compliant token configurations for every init format
- convert the spacing suggestion and generated token fixtures in the smoke test to DTIF schema objects

## Testing
- npm run lint
- npm run format:check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d337a21c048328be90ec5247781232