### PR TITLE
fix: align inline token fixtures with DTIF format

### DIFF
--- a/.changeset/update-inline-dtif-smoke.md
+++ b/.changeset/update-inline-dtif-smoke.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+Update inline token fixtures, tests, and docs to use the current DTIF format so smoke tests parse tokens correctly.

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -55,9 +55,17 @@ jobs:
           cat > designlint.config.json <<'EOF'
           {
             "tokens": {
+              "$version": "1.0.0",
               "color": {
-                "old": { "$type": "color", "$value": "#000", "$deprecated": "Use {color.new}" },
-                "new": { "$type": "color", "$value": "#fff" }
+                "old": {
+                  "$type": "color",
+                  "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+                  "$deprecated": { "$replacement": "#/color/new" }
+                },
+                "new": {
+                  "$type": "color",
+                  "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+                }
               }
             },
             "rules": {
@@ -101,9 +109,17 @@ jobs:
           cat > designlint.config.js <<'EOF'
           module.exports = {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -117,9 +133,17 @@ jobs:
           cat > designlint.config.cjs <<'EOF'
           module.exports = {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -133,9 +157,17 @@ jobs:
           cat > designlint.config.mjs <<'EOF'
           export default {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -151,9 +183,17 @@ jobs:
 
           export default {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -169,9 +209,17 @@ jobs:
 
           export default {
             tokens: {
+              $version: '1.0.0',
               color: {
-                old: { $type: 'color', $value: '#000', $deprecated: 'Use {color.new}' },
-                new: { $type: 'color', $value: '#fff' }
+                old: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $deprecated: { $replacement: '#/color/new' }
+                },
+                new: {
+                  $type: 'color',
+                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                }
               }
             },
             rules: {
@@ -186,6 +234,7 @@ jobs:
           {
             "tokens": {
               "default": {
+                "$version": "1.0.0",
                 "spacing": {
                   "scale-100": {
                     "$type": "dimension",
@@ -205,8 +254,12 @@ jobs:
           npx design-lint file.ts --format json || true
           cat > gen.tokens.json <<'EOF'
           {
+            "$version": "1.0.0",
             "color": {
-              "red": { "$type": "color", "$value": "#ff0000" }
+              "red": {
+                "$type": "color",
+                "$value": { "colorSpace": "srgb", "components": [1, 0, 0] }
+              }
             }
           }
           EOF

--- a/docs/examples/basic/designlint.config.json
+++ b/docs/examples/basic/designlint.config.json
@@ -1,8 +1,12 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#ff0000" },
-      "secondary": { "$type": "color", "$value": "{color.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 0, 0] }
+      },
+      "secondary": { "$type": "color", "$ref": "#/color/primary" }
     }
   },
   "rules": {

--- a/docs/examples/token-outputs.md
+++ b/docs/examples/token-outputs.md
@@ -11,10 +11,26 @@ This guide shows a minimal setup that writes CSS variables, JavaScript constants
 
 ```jsonc
 // tokens/default.tokens.json
-{ "color": { "primary": { "$value": "#fff" } } }
+{
+  "$version": "1.0.0",
+  "color": {
+    "primary": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
+  }
+}
 
 // tokens/dark.tokens.json
-{ "color": { "primary": { "$value": "#000" } } }
+{
+  "$version": "1.0.0",
+  "color": {
+    "primary": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+    }
+  }
+}
 ```
 
 ## Configuration

--- a/docs/rules/design-system/deprecation.md
+++ b/docs/rules/design-system/deprecation.md
@@ -14,14 +14,24 @@ Enable this rule in `designlint.config.*`. See [configuration](../../configurati
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
       "old": {
         "$type": "color",
-        "$value": "#000",
-        "$deprecated": "Use {color.new}"
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0]
+        },
+        "$deprecated": { "$replacement": "#/color/new" }
       },
-      "new": { "$type": "color", "$value": "#fff" },
-      "alias": { "$type": "color", "$value": "{color.new}" }
+      "new": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [1, 1, 1]
+        }
+      },
+      "alias": { "$type": "color", "$ref": "#/color/new" }
     }
   },
   "rules": { "design-system/deprecation": "error" }

--- a/docs/rules/design-system/no-unused-tokens.md
+++ b/docs/rules/design-system/no-unused-tokens.md
@@ -21,9 +21,16 @@ Given this configuration:
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" },
-      "unused": { "$type": "color", "$value": "{color.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0]
+        }
+      },
+      "unused": { "$type": "color", "$ref": "#/color/primary" }
     }
   },
   "rules": { "design-system/no-unused-tokens": "warn" }

--- a/docs/rules/design-token/border-color.md
+++ b/docs/rules/design-token/border-color.md
@@ -14,9 +14,16 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "borderColors": {
-      "primary": { "$type": "color", "$value": "#ffffff" },
-      "secondary": { "$type": "color", "$value": "{borderColors.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [1, 1, 1]
+        }
+      },
+      "secondary": { "$type": "color", "$ref": "#/borderColors/primary" }
     }
   },
   "rules": { "design-token/border-color": "error" }

--- a/docs/rules/design-token/colors.md
+++ b/docs/rules/design-token/colors.md
@@ -14,9 +14,16 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#ff0000" },
-      "secondary": { "$type": "color", "$value": "{color.primary}" }
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [1, 0, 0]
+        }
+      },
+      "secondary": { "$type": "color", "$ref": "#/color/primary" }
     }
   },
   "rules": {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -16,6 +16,29 @@ import ignore from 'ignore';
 const tsxLoader = require.resolve('tsx/esm');
 const WATCH_TIMEOUT = 2000;
 
+const srgb = (components: [number, number, number]) => ({
+  colorSpace: 'srgb',
+  components,
+});
+
+function createDeprecatedTokens() {
+  return {
+    $version: '1.0.0',
+    old: {
+      $type: 'color',
+      $value: srgb([0, 0, 0]),
+      $deprecated: true,
+    },
+  };
+}
+
+function createDeprecatedConfig(rules: Record<string, unknown>) {
+  return JSON.stringify({
+    tokens: createDeprecatedTokens(),
+    rules,
+  });
+}
+
 void test('CLI aborts on unsupported Node versions', async () => {
   const { run } = await import('../src/cli/index.js');
   const original = process.versions.node;
@@ -257,10 +280,7 @@ void test('CLI exits 0 when warnings equal --max-warnings', () => {
   fs.writeFileSync(path.join(dir, 'file.ts'), 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'warn' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'warn' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const res = spawnSync(
@@ -287,10 +307,7 @@ void test('CLI exits 1 when warnings exceed --max-warnings', () => {
   fs.writeFileSync(path.join(dir, 'file.ts'), 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'warn' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'warn' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const res = spawnSync(
@@ -393,10 +410,7 @@ void test('CLI --fix applies fixes', () => {
   fs.writeFileSync(path.join(dir, 'file.ts'), 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const res = spawnSync(
@@ -492,10 +506,7 @@ void test('CLI writes report to file with --output', () => {
   fs.writeFileSync(path.join(dir, 'file.ts'), 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const res = spawnSync(
@@ -619,10 +630,7 @@ void test('CLI outputs SARIF reports', () => {
     fs.writeFileSync(path.join(dir, 'file.ts'), 'const a = "old";');
     fs.writeFileSync(
       path.join(dir, 'designlint.config.json'),
-      JSON.stringify({
-        tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-        rules: { 'design-system/deprecation': 'error' },
-      }),
+      createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
     );
     const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
     const res = spawnSync(
@@ -717,10 +725,7 @@ void test('CLI ignores common directories by default', () => {
   fs.writeFileSync(path.join(dir, 'dist', 'file.ts'), 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const parent = path.dirname(dir);
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
@@ -761,10 +766,7 @@ void test('.designlintignore can unignore paths via CLI', () => {
   fs.writeFileSync(path.join(dir, '.designlintignore'), '!node_modules/**');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const res = spawnSync(
@@ -812,10 +814,7 @@ void test('CLI skips directories listed in .designlintignore', () => {
   fs.writeFileSync(path.join(dir, '.designlintignore'), 'ignored');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const res = spawnSync(
@@ -852,10 +851,7 @@ void test('CLI --ignore-path excludes files', () => {
   fs.writeFileSync(path.join(dir, '.extraignore'), 'src/skip.ts');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const res = spawnSync(
@@ -973,10 +969,7 @@ void test('CLI --report outputs JSON log', () => {
   fs.writeFileSync(path.join(dir, 'file.ts'), 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const report = path.join(dir, 'report.json');
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
@@ -1012,10 +1005,7 @@ void test('CLI re-runs on file change in watch mode', async () => {
   fs.writeFileSync(file, 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const proc = spawn(
@@ -1117,7 +1107,7 @@ void test('CLI cache updates after --fix run', async () => {
   const file = path.join(dir, 'file.ts');
   fs.writeFileSync(file, 'const a = "old";');
   const config = {
-    tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
+    tokens: createDeprecatedTokens(),
     rules: { 'design-system/deprecation': 'error' },
   };
   const store = new Map<
@@ -1327,13 +1317,7 @@ void test('CLI re-runs with updated config in watch mode', async () => {
   const file = path.join(dir, 'file.ts');
   fs.writeFileSync(file, 'const a = "old";');
   const configPath = path.join(dir, 'designlint.config.json');
-  fs.writeFileSync(
-    configPath,
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: {},
-    }),
-  );
+  fs.writeFileSync(configPath, createDeprecatedConfig({}));
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const proc = spawn(
     process.execPath,
@@ -1362,12 +1346,7 @@ void test('CLI re-runs with updated config in watch mode', async () => {
       if (buffer.includes('Watching for changes...')) {
         fs.writeFileSync(
           configPath,
-          JSON.stringify({
-            tokens: {
-              old: { $type: 'color', $value: '#000', $deprecated: true },
-            },
-            rules: { 'design-system/deprecation': 'error' },
-          }),
+          createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
         );
         buffer = '';
       } else if (buffer.includes('design-system/deprecation')) {
@@ -1653,10 +1632,7 @@ void test('CLI reloads when nested ignore file changes in watch mode', async () 
   fs.writeFileSync(file, 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const ignorePath = path.join(nested, '.designlintignore');
   fs.writeFileSync(ignorePath, 'file.ts\n');
@@ -1708,10 +1684,7 @@ void test('CLI updates ignore list when .gitignore changes in watch mode', async
   fs.writeFileSync(file, 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   fs.writeFileSync(path.join(dir, '.gitignore'), '');
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
@@ -1764,10 +1737,7 @@ void test('CLI continues watching after deleting ignore files in watch mode', as
   fs.writeFileSync(file, 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const gitIgnorePath = path.join(dir, '.gitignore');
   const designIgnorePath = path.join(dir, '.designlintignore');
@@ -1825,10 +1795,7 @@ void test('CLI clears cache when a watched file is deleted', async () => {
   fs.writeFileSync(file, 'const a = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const proc = spawn(
@@ -1882,10 +1849,7 @@ void test('CLI continues linting after deleting a watched file', async () => {
   fs.writeFileSync(fileB, 'const b = "old";');
   fs.writeFileSync(
     path.join(dir, 'designlint.config.json'),
-    JSON.stringify({
-      tokens: { old: { $type: 'color', $value: '#000', $deprecated: true } },
-      rules: { 'design-system/deprecation': 'error' },
-    }),
+    createDeprecatedConfig({ 'design-system/deprecation': 'error' }),
   );
   const cli = path.join(__dirname, '..', 'src', 'cli', 'index.ts');
   const proc = spawn(

--- a/tests/cli/error-handling.test.ts
+++ b/tests/cli/error-handling.test.ts
@@ -32,10 +32,14 @@ void test('fails on unresolved aliases', () => {
   fs.writeFileSync(
     path.join(dir, 'tokens.tokens.json'),
     JSON.stringify({
+      $version: '1.0.0',
       color: {
-        red: { $type: 'color', $value: '#ff0000' },
-        bad1: { $type: 'color', $value: '{color.missing}' },
-        bad2: { $type: 'color', $value: '{color.missing}' },
+        red: {
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [1, 0, 0] },
+        },
+        bad1: { $type: 'color', $ref: '#/color/missing' },
+        bad2: { $type: 'color', $ref: '#/color/missing' },
       },
     }),
   );

--- a/tests/core/dtif/parse.test.ts
+++ b/tests/core/dtif/parse.test.ts
@@ -82,8 +82,14 @@ void test('parseDtifTokenObject flattens inline documents', async () => {
   const document = {
     $version: '1.0.0',
     color: {
-      primary: { $type: 'color', $value: '#000000' },
-      secondary: { $type: 'color', $value: '#ffffff' },
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+      secondary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+      },
     },
   };
 

--- a/tests/fixtures/nested-config/designlint.config.json
+++ b/tests/fixtures/nested-config/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "base": { "$type": "color", "$value": "#000000" }
+      "base": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     }
   },
   "rules": { "design-token/colors": "error" }

--- a/tests/fixtures/nested-config/packages/app/designlint.config.json
+++ b/tests/fixtures/nested-config/packages/app/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#00ff00" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 1, 0] }
+      }
     }
   },
   "rules": { "design-token/colors": "error" }

--- a/tests/fixtures/nextjs/designlint.config.json
+++ b/tests/fixtures/nextjs/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
@@ -14,16 +18,22 @@
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/fixtures/nuxt/designlint.config.json
+++ b/tests/fixtures/nuxt/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
@@ -14,16 +18,22 @@
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/fixtures/react-vite-css-modules/designlint.config.json
+++ b/tests/fixtures/react-vite-css-modules/designlint.config.json
@@ -1,8 +1,15 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" },
-      "unused": { "$type": "color", "$value": "#ffffff" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      },
+      "unused": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+      }
     },
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
@@ -15,16 +22,22 @@
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/fixtures/remix/designlint.config.json
+++ b/tests/fixtures/remix/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
@@ -14,16 +18,22 @@
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/fixtures/sample/designlint.config.json
+++ b/tests/fixtures/sample/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     }
   },
   "rules": { "design-token/colors": "error" }

--- a/tests/fixtures/svelte/designlint.config.json
+++ b/tests/fixtures/svelte/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
@@ -14,16 +18,22 @@
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/fixtures/tagged-template/designlint.config.json
+++ b/tests/fixtures/tagged-template/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     }
   },
   "rules": { "design-token/colors": "error" }

--- a/tests/fixtures/vue/designlint.config.json
+++ b/tests/fixtures/vue/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
@@ -14,16 +18,22 @@
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/fixtures/web-components/designlint.config.json
+++ b/tests/fixtures/web-components/designlint.config.json
@@ -1,7 +1,11 @@
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
-      "primary": { "$type": "color", "$value": "#000000" }
+      "primary": {
+        "$type": "color",
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      }
     },
     "spacing": {
       "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } }
@@ -14,16 +18,22 @@
     },
     "old-token": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {new-token}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/new-token" }
     },
-    "new-token": { "$type": "color", "$value": "#ffffff" },
+    "new-token": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    },
     "OldComponent": {
       "$type": "color",
-      "$value": "#000000",
-      "$deprecated": "Use {NewComponent}"
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+      "$deprecated": { "$replacement": "#/NewComponent" }
     },
-    "NewComponent": { "$type": "color", "$value": "#ffffff" }
+    "NewComponent": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+    }
   },
   "rules": {
     "design-token/colors": "error",

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -7,8 +7,16 @@ import { createLinter as initLinter } from '../src/index.js';
 import { FileSource } from '../src/adapters/node/file-source.js';
 
 const tokens = {
-  old: { $type: 'color', $value: '#000', $deprecated: 'Use {new}' },
-  new: { $type: 'color', $value: '#fff' },
+  $version: '1.0.0',
+  old: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+    $deprecated: { $replacement: '#/new' },
+  },
+  new: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+  },
 };
 
 void test('lintTargets ignores common directories by default', async () => {

--- a/tests/inline-disable.test.ts
+++ b/tests/inline-disable.test.ts
@@ -7,8 +7,16 @@ import { createLinter as initLinter } from '../src/index.js';
 import { FileSource } from '../src/adapters/node/file-source.js';
 
 const tokens = {
-  old: { $type: 'color', $value: '#000', $deprecated: 'Use {new}' },
-  new: { $type: 'color', $value: '#fff' },
+  $version: '1.0.0',
+  old: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+    $deprecated: { $replacement: '#/new' },
+  },
+  new: {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+  },
 };
 
 void test('inline directives disable linting', async () => {

--- a/tests/node-token-provider.test.ts
+++ b/tests/node-token-provider.test.ts
@@ -6,9 +6,14 @@ import { getDtifFlattenedTokens } from '../src/utils/tokens/dtif-cache.js';
 import { createDtifTheme } from './helpers/dtif.js';
 import type { DesignTokens } from '../src/core/types.js';
 
+const srgb = (components: [number, number, number]) => ({
+  colorSpace: 'srgb',
+  components,
+});
+
 const tokens = {
   color: {
-    primary: { $type: 'color', $value: '#fff' },
+    primary: { $type: 'color', $value: srgb([1, 1, 1]) },
   },
 };
 
@@ -68,8 +73,8 @@ void test('accepts explicit theme records without modification', async () => {
 
 void test('accepts theme records with tokens at the root', async () => {
   const themes = {
-    light: { primary: { $type: 'color', $value: '#fff' } },
-    dark: { primary: { $type: 'color', $value: '#000' } },
+    light: { primary: { $type: 'color', $value: srgb([1, 1, 1]) } },
+    dark: { primary: { $type: 'color', $value: srgb([0, 0, 0]) } },
   };
   const provider = new NodeTokenProvider(themes);
   const result = await provider.load();
@@ -79,10 +84,16 @@ void test('accepts theme records with tokens at the root', async () => {
 void test('accepts theme records created with createDtifTheme', async () => {
   const themes = {
     light: createDtifTheme({
-      'color.primary': { type: 'color', value: '#fff' },
+      'color.primary': {
+        type: 'color',
+        value: srgb([1, 1, 1]),
+      },
     }),
     dark: createDtifTheme({
-      'color.primary': { type: 'color', value: '#000' },
+      'color.primary': {
+        type: 'color',
+        value: srgb([0, 0, 0]),
+      },
     }),
   } as const;
 

--- a/tests/patterns.test.ts
+++ b/tests/patterns.test.ts
@@ -6,13 +6,21 @@ import { makeTmpDir } from '../src/adapters/node/utils/tmp.js';
 import { createLinter as initLinter } from '../src/index.js';
 import { FileSource } from '../src/adapters/node/file-source.js';
 
+const srgb = (components: [number, number, number]) => ({
+  colorSpace: 'srgb',
+  components,
+});
+
 void test('lintTargets uses patterns option to include custom extensions', async () => {
   const tmp = makeTmpDir();
   const file = path.join(tmp, 'bad.foo');
   fs.writeFileSync(file, "const color = '#ffffff';");
   const baseConfig = {
     tokens: {
-      color: { $type: 'color', primary: { $value: '#000000' } },
+      $version: '1.0.0',
+      color: {
+        primary: { $type: 'color', $value: srgb([0, 0, 0]) },
+      },
     },
     rules: { 'design-token/colors': 'error' },
   };

--- a/tests/token-completions.test.ts
+++ b/tests/token-completions.test.ts
@@ -3,18 +3,25 @@ import assert from 'node:assert/strict';
 import { createLinter as initLinter } from '../src/index.js';
 import { FileSource } from '../src/adapters/node/file-source.js';
 
+const srgb = (components: [number, number, number]) => ({
+  colorSpace: 'srgb',
+  components,
+});
+
 void test('getTokenCompletions returns token paths by theme', async () => {
   const linter = initLinter(
     {
       tokens: {
         light: {
+          $version: '1.0.0',
           color: {
-            primary: { $type: 'color', $value: '#f00' },
+            primary: { $type: 'color', $value: srgb([1, 0, 0]) },
           },
         },
         dark: {
+          $version: '1.0.0',
           color: {
-            primary: { $type: 'color', $value: '#0f0' },
+            primary: { $type: 'color', $value: srgb([0, 1, 0]) },
           },
         },
       },

--- a/tests/utils/tokens/theme.test.ts
+++ b/tests/utils/tokens/theme.test.ts
@@ -4,25 +4,27 @@ import { toThemeRecord } from '../../../src/utils/tokens/index.js';
 import { attachDtifFlattenedTokens } from '../../../src/utils/tokens/dtif-cache.js';
 import type { DtifFlattenedToken } from '../../../src/core/types.js';
 
+const srgb = (components: [number, number, number]) => ({
+  colorSpace: 'srgb',
+  components,
+});
+
 void test('wrap single token object into default theme', () => {
-  const tokens: Record<string, { $type: string; $value: string }> = {
-    color: { $type: 'color', $value: '#fff' },
+  const tokens = {
+    color: { $type: 'color', $value: srgb([1, 1, 1]) },
   };
   const record = toThemeRecord(tokens);
   assert.deepEqual(Object.keys(record), ['default']);
-  assert.equal(record.default.color.$value, '#fff');
+  assert.deepEqual(record.default.color.$value, srgb([1, 1, 1]));
 });
 
 void test('preserve existing theme record', () => {
-  const tokens: Record<
-    string,
-    Record<string, { $type: string; $value: string }>
-  > = {
-    light: { color: { $type: 'color', $value: '#fff' } },
-    dark: { color: { $type: 'color', $value: '#000' } },
+  const tokens = {
+    light: { color: { $type: 'color', $value: srgb([1, 1, 1]) } },
+    dark: { color: { $type: 'color', $value: srgb([0, 0, 0]) } },
   };
   const record = toThemeRecord(tokens);
-  assert.equal(record.dark.color.$value, '#000');
+  assert.deepEqual(record.dark.color.$value, srgb([0, 0, 0]));
 });
 
 void test('return empty record for invalid input', () => {


### PR DESCRIPTION
## Summary
- update smoke test fixture configs to include DTIF-compliant color tokens and structured deprecation metadata
- refresh inline token tests to construct srgb values and helpers that match the current DTIF schema
- document the DTIF inline token format in docs and example configurations

## Testing
- `npm run lint`
- `CI=true npm run format:check`
- `npm test`
- `npm run lint:md`


------
https://chatgpt.com/codex/tasks/task_e_68d3f8523cd48328ae5a4ffd1142c044