### PR TITLE
fix(ci): ensure cli smoke spacing tokens use dtif

### DIFF
--- a/.changeset/fix-cli-smoke-dtif.md
+++ b/.changeset/fix-cli-smoke-dtif.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix CLI smoke test tokens to use valid DTIF dimension values

--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -238,7 +238,11 @@ jobs:
                 "spacing": {
                   "scale-100": {
                     "$type": "dimension",
-                    "$value": { "value": 4, "unit": "px" }
+                    "$value": {
+                      "dimensionType": "length",
+                      "value": 4,
+                      "unit": "px"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- declare the CLI smoke test spacing token with a DTIF-compliant dimension payload
- add a patch changeset describing the CI smoke test fix

## Testing
- npm run lint
- npm run format:check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40193f9bc832888c25446657c1b82