### PR TITLE
docs: update DTIF guidance

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ Inline example:
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "color": {
       "primary": {
         "$type": "color",
@@ -66,8 +67,14 @@ Inline example:
       "secondary": { "$type": "color", "$ref": "#/color/primary" }
     },
     "space": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": { "value": 8, "unit": "px" } }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      },
+      "md": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 8, "unit": "px" }
+      }
     }
   }
 }
@@ -80,6 +87,7 @@ Organise tokens by category—such as `color`, `space`, or `typography`—to mir
   "tokens": {
     "light": "./light.tokens.json",
     "dark": {
+      "$version": "1.0.0",
       "color": {
         "primary": {
           "$type": "color",
@@ -169,12 +177,13 @@ import { defineConfig } from '@lapidist/design-lint';
 
 export default defineConfig({
   tokens: {
+    $version: '1.0.0',
     color: {
       primary: {
         $type: 'color',
         $value: { colorSpace: 'srgb', components: [1, 0, 0] },
       },
-      secondary: { $type: 'color', $value: '{color.primary}' },
+      secondary: { $type: 'color', $ref: '#/color/primary' },
     },
   },
   rules: { 'design-token/colors': 'error' },

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -133,7 +133,13 @@ async function loadFromFigma(): Promise<DesignTokens> {
   // convert tokens here and return a DTIF-compatible object
   return {
     $version: '1.0.0',
-    color: { primary: { $type: 'color', $value: '#0af' } },
+    color: {
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0.66, 1] },
+      },
+      accent: { $type: 'color', $ref: '#/color/primary' },
+    },
   } satisfies DesignTokens;
 }
 ```

--- a/docs/rules/design-token/animation.md
+++ b/docs/rules/design-token/animation.md
@@ -14,9 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "animations": {
       "spin": { "$type": "string", "$value": "spin 1s linear infinite" },
-      "wiggle": { "$type": "string", "$value": "{animations.spin}" }
+      "wiggle": { "$type": "string", "$ref": "#/animations/spin" }
     }
   },
   "rules": { "design-token/animation": "error" }

--- a/docs/rules/design-token/blur.md
+++ b/docs/rules/design-token/blur.md
@@ -14,14 +14,20 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "blurs": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": "{blurs.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      },
+      "md": { "$type": "dimension", "$ref": "#/blurs/sm" }
     }
   },
   "rules": { "design-token/blur": "error" }
 }
 ```
+
+Blur tokens use the `dimension` type with `dimensionType` set to `length`.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/border-radius.md
+++ b/docs/rules/design-token/border-radius.md
@@ -14,16 +14,20 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "borderRadius": {
-      "sm": { "$type": "dimension", "$value": { "value": 2, "unit": "px" } },
-      "lg": { "$type": "dimension", "$value": "{borderRadius.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 2, "unit": "px" }
+      },
+      "lg": { "$type": "dimension", "$ref": "#/borderRadius/sm" }
     }
   },
   "rules": { "design-token/border-radius": "error" }
 }
 ```
 
-Border radius tokens use the `dimension` type.
+Border radius tokens use the `dimension` type with `dimensionType` set to `length`.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/border-width.md
+++ b/docs/rules/design-token/border-width.md
@@ -14,16 +14,20 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "borderWidths": {
-      "sm": { "$type": "dimension", "$value": { "value": 1, "unit": "px" } },
-      "lg": { "$type": "dimension", "$value": "{borderWidths.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 1, "unit": "px" }
+      },
+      "lg": { "$type": "dimension", "$ref": "#/borderWidths/sm" }
     }
   },
   "rules": { "design-token/border-width": "error" }
 }
 ```
 
-Border width tokens use the `dimension` type.
+Border width tokens use the `dimension` type with `dimensionType` set to `length`.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/box-shadow.md
+++ b/docs/rules/design-token/box-shadow.md
@@ -14,25 +14,39 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
+    "color": {
+      "shadow": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0],
+          "hex": "#000000",
+          "alpha": 0.1
+        }
+      }
+    },
     "shadows": {
       "sm": {
         "$type": "shadow",
         "$value": {
-          "offsetX": { "value": 0, "unit": "px" },
-          "offsetY": { "value": 1, "unit": "px" },
-          "blur": { "value": 2, "unit": "px" },
-          "spread": { "value": 0, "unit": "px" },
-          "color": "rgba(0,0,0,0.1)"
+          "shadowType": "css.box-shadow",
+          "offsetX": { "dimensionType": "length", "value": 0, "unit": "px" },
+          "offsetY": { "dimensionType": "length", "value": 1, "unit": "px" },
+          "blur": { "dimensionType": "length", "value": 2, "unit": "px" },
+          "spread": { "dimensionType": "length", "value": 0, "unit": "px" },
+          "color": { "$ref": "#/color/shadow" }
         }
       },
-      "md": { "$type": "shadow", "$value": "{shadows.sm}" }
+      "md": { "$type": "shadow", "$ref": "#/shadows/sm" }
     }
   },
   "rules": { "design-token/box-shadow": "error" }
 }
 ```
 
-Shadow tokens use the `shadow` type with sub-values for offsets, blur, spread, and color.
+Shadow tokens use the `shadow` type with a `shadowType` context and sub-values for offsets,
+blur, spread, and color.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/duration.md
+++ b/docs/rules/design-token/duration.md
@@ -14,16 +14,25 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "durations": {
-      "short": { "$type": "duration", "$value": { "value": 100, "unit": "ms" } },
-      "long": { "$type": "duration", "$value": "{durations.short}" }
+      "short": {
+        "$type": "duration",
+        "$value": {
+          "durationType": "css.transition-duration",
+          "value": 0.1,
+          "unit": "s"
+        }
+      },
+      "long": { "$type": "duration", "$ref": "#/durations/short" }
     }
   },
   "rules": { "design-token/duration": "error" }
 }
 ```
 
-Duration tokens use objects with a numeric `value` and a `unit` of `ms` or `s`.
+Duration tokens identify the timing context via `durationType` and provide a numeric `value`
+with a corresponding `unit` such as `ms` or `s`.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/font-family.md
+++ b/docs/rules/design-token/font-family.md
@@ -14,9 +14,13 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "fonts": {
-      "sans": { "$type": "fontFamily", "$value": "Inter, sans-serif" },
-      "alt": { "$type": "fontFamily", "$value": "{fonts.sans}" }
+      "sans": {
+        "$type": "fontFamily",
+        "$value": ["Inter", "Arial", "sans-serif"]
+      },
+      "alt": { "$type": "fontFamily", "$ref": "#/fonts/sans" }
     }
   },
   "rules": { "design-token/font-family": "error" }

--- a/docs/rules/design-token/font-size.md
+++ b/docs/rules/design-token/font-size.md
@@ -14,16 +14,20 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "fontSizes": {
-      "base": { "$type": "dimension", "$value": { "value": 1, "unit": "rem" } },
-      "lg": { "$type": "dimension", "$value": "{fontSizes.base}" }
+      "base": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 1, "unit": "rem" }
+      },
+      "lg": { "$type": "dimension", "$ref": "#/fontSizes/base" }
     }
   },
   "rules": { "design-token/font-size": "error" }
 }
 ```
 
-Font-size tokens use the `dimension` type with explicit units.
+Font-size tokens use the `dimension` type with `dimensionType` set to `length` and explicit units.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/font-weight.md
+++ b/docs/rules/design-token/font-weight.md
@@ -14,10 +14,11 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "fontWeights": {
       "regular": { "$type": "fontWeight", "$value": 400 },
       "bold": { "$type": "fontWeight", "$value": 700 },
-      "emphasis": { "$type": "fontWeight", "$value": "{fontWeights.bold}" }
+      "emphasis": { "$type": "fontWeight", "$ref": "#/fontWeights/bold" }
     }
   },
   "rules": { "design-token/font-weight": "error" }

--- a/docs/rules/design-token/letter-spacing.md
+++ b/docs/rules/design-token/letter-spacing.md
@@ -14,16 +14,20 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "letterSpacings": {
-      "tight": { "$type": "dimension", "$value": { "value": -0.05, "unit": "rem" } },
-      "loose": { "$type": "dimension", "$value": "{letterSpacings.tight}" }
+      "tight": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": -0.05, "unit": "rem" }
+      },
+      "loose": { "$type": "dimension", "$ref": "#/letterSpacings/tight" }
     }
   },
   "rules": { "design-token/letter-spacing": "error" }
 }
 ```
 
-Letter-spacing tokens use the `dimension` type.
+Letter-spacing tokens use the `dimension` type with `dimensionType` set to `length`.
 
 ## Options
 No additional options.

--- a/docs/rules/design-token/line-height.md
+++ b/docs/rules/design-token/line-height.md
@@ -14,9 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "lineHeights": {
       "base": { "$type": "number", "$value": 1.5 },
-      "tight": { "$type": "number", "$value": "{lineHeights.base}" }
+      "tight": { "$type": "number", "$ref": "#/lineHeights/base" }
     }
   },
   "rules": { "design-token/line-height": "error" }

--- a/docs/rules/design-token/opacity.md
+++ b/docs/rules/design-token/opacity.md
@@ -14,9 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "opacity": {
       "low": { "$type": "number", "$value": 0.2 },
-      "high": { "$type": "number", "$value": "{opacity.low}" }
+      "high": { "$type": "number", "$ref": "#/opacity/low" }
     }
   },
   "rules": { "design-token/opacity": "error" }

--- a/docs/rules/design-token/outline.md
+++ b/docs/rules/design-token/outline.md
@@ -14,9 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "outlines": {
       "focus": { "$type": "string", "$value": "2px solid #000" },
-      "active": { "$type": "string", "$value": "{outlines.focus}" }
+      "active": { "$type": "string", "$ref": "#/outlines/focus" }
     }
   },
   "rules": { "design-token/outline": "error" }

--- a/docs/rules/design-token/spacing.md
+++ b/docs/rules/design-token/spacing.md
@@ -14,9 +14,13 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "spacing": {
-      "sm": { "$type": "dimension", "$value": { "value": 4, "unit": "px" } },
-      "md": { "$type": "dimension", "$value": "{spacing.sm}" }
+      "sm": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      },
+      "md": { "$type": "dimension", "$ref": "#/spacing/sm" }
     }
   },
   "rules": {
@@ -25,7 +29,7 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 }
 ```
 
-Spacing tokens use the `dimension` type.
+Spacing tokens use the `dimension` type with `dimensionType` set to `length`.
 
 ## Options
 - `base` (`number`): values must be multiples of this number. Defaults to `4`.

--- a/docs/rules/design-token/z-index.md
+++ b/docs/rules/design-token/z-index.md
@@ -14,9 +14,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
 ```json
 {
   "tokens": {
+    "$version": "1.0.0",
     "zIndex": {
       "modal": { "$type": "number", "$value": 1000 },
-      "dropdown": { "$type": "number", "$value": "{zIndex.modal}" }
+      "dropdown": { "$type": "number", "$ref": "#/zIndex/modal" }
     }
   },
   "rules": { "design-token/z-index": "error" }


### PR DESCRIPTION
## Summary
- align configuration and plugin guides with the DTIF spec by including `$version`, canonical color values, and `$ref` aliases
- refresh rule documentation to showcase valid DTIF examples with required fields such as `dimensionType`, `durationType`, and `shadowType`

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run lint:md

------
https://chatgpt.com/codex/tasks/task_e_68d4014b6a088328ae4c5e1f71411204