### PR TITLE
fix(tokens): normalize dtif color literals

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -59,12 +59,20 @@ jobs:
               "color": {
                 "old": {
                   "$type": "color",
-                  "$value": { "colorSpace": "srgb", "components": [0, 0, 0] },
+                  "$value": {
+                    "colorSpace": "srgb",
+                    "components": [0, 0, 0],
+                    "hex": "#000000"
+                  },
                   "$deprecated": { "$replacement": "#/color/new" }
                 },
                 "new": {
                   "$type": "color",
-                  "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+                  "$value": {
+                    "colorSpace": "srgb",
+                    "components": [1, 1, 1],
+                    "hex": "#ffffff"
+                  }
                 }
               }
             },
@@ -113,12 +121,20 @@ jobs:
               color: {
                 old: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [0, 0, 0],
+                    hex: '#000000'
+                  },
                   $deprecated: { $replacement: '#/color/new' }
                 },
                 new: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [1, 1, 1],
+                    hex: '#ffffff'
+                  }
                 }
               }
             },
@@ -137,12 +153,20 @@ jobs:
               color: {
                 old: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [0, 0, 0],
+                    hex: '#000000'
+                  },
                   $deprecated: { $replacement: '#/color/new' }
                 },
                 new: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [1, 1, 1],
+                    hex: '#ffffff'
+                  }
                 }
               }
             },
@@ -161,12 +185,20 @@ jobs:
               color: {
                 old: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [0, 0, 0],
+                    hex: '#000000'
+                  },
                   $deprecated: { $replacement: '#/color/new' }
                 },
                 new: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [1, 1, 1],
+                    hex: '#ffffff'
+                  }
                 }
               }
             },
@@ -187,12 +219,20 @@ jobs:
               color: {
                 old: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [0, 0, 0],
+                    hex: '#000000'
+                  },
                   $deprecated: { $replacement: '#/color/new' }
                 },
                 new: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [1, 1, 1],
+                    hex: '#ffffff'
+                  }
                 }
               }
             },
@@ -213,12 +253,20 @@ jobs:
               color: {
                 old: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [0, 0, 0],
+                    hex: '#000000'
+                  },
                   $deprecated: { $replacement: '#/color/new' }
                 },
                 new: {
                   $type: 'color',
-                  $value: { colorSpace: 'srgb', components: [1, 1, 1] }
+                  $value: {
+                    colorSpace: 'srgb',
+                    components: [1, 1, 1],
+                    hex: '#ffffff'
+                  }
                 }
               }
             },

--- a/src/utils/guards/domain/dtif-token.ts
+++ b/src/utils/guards/domain/dtif-token.ts
@@ -1,4 +1,8 @@
 import type { DtifFlattenedToken } from '../../../core/types.js';
+import { isRecord } from '../data/index.js';
+
+const HEX_PATTERN =
+  /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
 /**
  * Determine whether a flattened DTIF token belongs to the provided top-level group.
@@ -24,14 +28,101 @@ export function getTokenStringValue(
   token: DtifFlattenedToken,
   options: { allowAliases?: boolean } = {},
 ): string | undefined {
-  const value = token.value;
+  const allowAliases = options.allowAliases ?? false;
+  const candidates: unknown[] = [token.resolution?.value, token.value];
+
+  for (const candidate of candidates) {
+    const literal = extractLiteral(candidate, allowAliases);
+    if (literal !== undefined) {
+      return literal;
+    }
+  }
+
+  if (token.type === 'color') {
+    for (const candidate of candidates) {
+      const formatted = formatColorValue(candidate, allowAliases);
+      if (formatted !== undefined) {
+        return formatted;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function extractLiteral(
+  value: unknown,
+  allowAliases: boolean,
+): string | undefined {
   if (typeof value !== 'string') {
     return undefined;
   }
+  if (!allowAliases && value.startsWith('{')) {
+    return undefined;
+  }
+  return value;
+}
 
-  if (!options.allowAliases && value.startsWith('{')) {
+function formatColorValue(
+  value: unknown,
+  allowAliases: boolean,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return extractLiteral(value, allowAliases);
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const formatted = formatColorValue(entry, allowAliases);
+      if (formatted !== undefined) {
+        return formatted;
+      }
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) {
     return undefined;
   }
 
-  return value;
+  const colorSpace: unknown = value.colorSpace;
+  const components: unknown = value.components;
+  const hex: unknown = value.hex;
+  const alpha: unknown = value.alpha;
+
+  if (typeof hex === 'string' && HEX_PATTERN.test(hex)) {
+    return hex.toLowerCase();
+  }
+
+  if (typeof colorSpace !== 'string' || !Array.isArray(components)) {
+    return undefined;
+  }
+
+  const parts: string[] = [];
+  for (const component of components) {
+    if (typeof component === 'number' && Number.isFinite(component)) {
+      parts.push(formatNumber(component));
+      continue;
+    }
+    if (component === 'none') {
+      parts.push('none');
+      continue;
+    }
+    return undefined;
+  }
+
+  let suffix = '';
+  if (alpha !== undefined) {
+    if (typeof alpha !== 'number' || !Number.isFinite(alpha)) {
+      return undefined;
+    }
+    suffix = ` / ${formatNumber(alpha)}`;
+  }
+
+  return `color(${colorSpace} ${parts.join(' ')}${suffix})`;
+}
+
+function formatNumber(value: number): string {
+  return String(value);
 }

--- a/tests/utils/guards/domain/dtif-token.test.ts
+++ b/tests/utils/guards/domain/dtif-token.test.ts
@@ -35,3 +35,53 @@ void test('getTokenStringValue returns literals while skipping aliases', () => {
     '{color.primary}',
   );
 });
+
+void test('getTokenStringValue returns DTIF color hex values', () => {
+  const token: DtifFlattenedToken = {
+    ...baseToken,
+    pointer: '#/color/old',
+    segments: ['color', 'old'],
+    name: 'old',
+    type: 'color',
+    value: {
+      colorSpace: 'srgb',
+      components: [0, 0, 0],
+      hex: '#000000',
+    },
+  };
+  assert.equal(getTokenStringValue(token), '#000000');
+});
+
+void test('getTokenStringValue formats DTIF colors without hex', () => {
+  const token: DtifFlattenedToken = {
+    ...baseToken,
+    pointer: '#/color/new',
+    segments: ['color', 'new'],
+    name: 'new',
+    type: 'color',
+    value: {
+      colorSpace: 'srgb',
+      components: [1, 0, 0],
+    },
+  };
+  assert.equal(getTokenStringValue(token), 'color(srgb 1 0 0)');
+});
+
+void test('getTokenStringValue reads DTIF color fallbacks', () => {
+  const token: DtifFlattenedToken = {
+    ...baseToken,
+    pointer: '#/color/fallback',
+    segments: ['color', 'fallback'],
+    name: 'fallback',
+    type: 'color',
+    value: [
+      { $ref: '#/color/new' },
+      {
+        colorSpace: 'srgb',
+        components: [1, 1, 1],
+        hex: '#ffffff',
+      },
+    ],
+  };
+  assert.equal(getTokenStringValue(token), '#ffffff');
+});


### PR DESCRIPTION
## Summary
- define CLI smoke test color tokens as DTIF objects with explicit hex metadata so the workflow uses valid inputs
- derive literal strings from DTIF color values (including fallbacks) so token-based rules can discover configured colors
- extend the guard tests to cover DTIF color objects, missing hex metadata, and fallback arrays

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d409d01e1c8328be61604cb28bb350