### PR TITLE
Add coverage for index exports and cubic bezier validator

### DIFF
--- a/tests/core/cubic-bezier-validator.test.ts
+++ b/tests/core/cubic-bezier-validator.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for the cubic bezier validator.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateCubicBezier } from '../../src/core/token-validators/cubicBezier.js';
+
+void test('validateCubicBezier accepts four finite numbers', () => {
+  assert.doesNotThrow(() => {
+    validateCubicBezier([0.25, 0.5, 0.75, 1.5], 'ease');
+  });
+});
+
+void test('validateCubicBezier rejects non-array values', () => {
+  assert.throws(() => {
+    validateCubicBezier('ease', 'ease');
+  }, /Token ease/);
+});
+
+void test('validateCubicBezier rejects tuples with invalid length', () => {
+  assert.throws(() => {
+    validateCubicBezier([0, 0.5, 1], 'ease');
+  }, /Token ease/);
+});
+
+void test('validateCubicBezier requires numeric control points', () => {
+  assert.throws(() => {
+    validateCubicBezier([0, Number.NaN, 1, 1], 'ease');
+  }, /Token ease/);
+});
+
+void test('validateCubicBezier enforces unit interval for x control points', () => {
+  assert.throws(() => {
+    validateCubicBezier([-0.1, 0.5, 0.75, 1], 'ease');
+  }, /Token ease/);
+  assert.throws(() => {
+    validateCubicBezier([0.1, 0.5, 1.1, 1], 'ease');
+  }, /Token ease/);
+});

--- a/tests/formatters/sarif/sarif-formatter.test.ts
+++ b/tests/formatters/sarif/sarif-formatter.test.ts
@@ -3,7 +3,7 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { sarifFormatter } from '../../../src/formatters/index.js';
+import { sarifFormatter } from '../../../src/formatters/sarif/sarif-formatter.js';
 import type { LintResult } from '../../../src/core/types.js';
 
 interface SarifLog {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the top-level module exports.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createLintService,
+  builtInRules,
+  type Config,
+  type DocumentSource,
+  type Environment,
+} from '../src/index.js';
+
+class StubDocumentSource implements DocumentSource {
+  public calls: {
+    targets: string[];
+    config: Config;
+    ignore: string[];
+  }[] = [];
+
+  scan(
+    targets: string[],
+    config: Config,
+    additionalIgnore: string[] = [],
+  ): Promise<{
+    documents: [];
+    ignoreFiles: string[];
+    warning: string;
+  }> {
+    this.calls.push({ targets, config, ignore: additionalIgnore });
+    return Promise.resolve({
+      documents: [],
+      ignoreFiles: ['.designlintignore'],
+      warning: 'scan warning',
+    });
+  }
+}
+
+void test('builtInRules are exposed for consumers', () => {
+  assert.ok(Array.isArray(builtInRules));
+  assert.ok(builtInRules.length > 0);
+  assert.ok(
+    builtInRules.some((rule) => rule.name === 'design-token/animation'),
+  );
+});
+
+void test('createLintService returns lint service configured with environment', async () => {
+  const source = new StubDocumentSource();
+  const env: Environment = { documentSource: source };
+  const config: Config = {};
+  const service = createLintService(config, env);
+
+  const result = await service.lintTargets(['src/**/*.ts'], false, [
+    'custom-ignore',
+  ]);
+
+  assert.deepEqual(result.results, []);
+  assert.deepEqual(result.ignoreFiles, ['.designlintignore']);
+  assert.equal(result.warning, 'scan warning');
+  assert.deepEqual(source.calls, [
+    {
+      targets: ['src/**/*.ts'],
+      config: { tokens: {} },
+      ignore: ['custom-ignore'],
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add tests that verify the published index exports and lint service wiring
- exercise the cubic bezier validator with success and failure scenarios
- update the SARIF formatter test import to reference the formatter implementation directly

## Testing
- npm run lint
- npm run format:check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40be5b08483289192ea02ed174bb5