### PR TITLE
Add coverage for token validators

### DIFF
--- a/tests/core/border-validator.test.ts
+++ b/tests/core/border-validator.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateBorder } from '../../src/core/token-validators/border.js';
+
+const COLOR = {
+  colorSpace: 'srgb',
+  components: [0, 0, 0],
+  alpha: 1,
+  hex: '#000000',
+} as const;
+
+const WIDTH = { value: 2, unit: 'px' } as const;
+
+void test('validateBorder accepts complete border values', () => {
+  assert.doesNotThrow(() => {
+    validateBorder(
+      {
+        color: { ...COLOR },
+        width: { ...WIDTH },
+        style: 'solid',
+      },
+      'border',
+    );
+  });
+});
+
+void test('validateBorder rejects non-record values', () => {
+  assert.throws(() => {
+    validateBorder(null, 'border');
+  }, /invalid border value/);
+});
+
+void test('validateBorder rejects extra properties', () => {
+  assert.throws(() => {
+    validateBorder(
+      {
+        color: { ...COLOR },
+        width: { ...WIDTH },
+        style: 'solid',
+        mode: 'unexpected',
+      },
+      'border',
+    );
+  }, /invalid border value/);
+});
+
+void test('validateBorder requires all supported properties', () => {
+  assert.throws(() => {
+    validateBorder(
+      {
+        color: { ...COLOR },
+        width: { ...WIDTH },
+      } as unknown,
+      'border',
+    );
+  }, /invalid border value/);
+});

--- a/tests/core/gradient-validator.test.ts
+++ b/tests/core/gradient-validator.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateGradient } from '../../src/core/token-validators/gradient.js';
+
+const COLOR = {
+  colorSpace: 'srgb',
+  components: [0, 0, 0],
+  alpha: 1,
+  hex: '#000000',
+} as const;
+
+void test('validateGradient clamps stop positions', () => {
+  const gradient = [
+    { color: { ...COLOR }, position: -0.5 },
+    { color: { ...COLOR }, position: 1.2 },
+  ];
+  assert.doesNotThrow(() => {
+    validateGradient(gradient, 'gradient');
+  });
+  assert.equal(gradient[0].position, 0);
+  assert.equal(gradient[1].position, 1);
+});
+
+void test('validateGradient rejects non-array values', () => {
+  assert.throws(() => {
+    validateGradient({}, 'gradient');
+  }, /invalid gradient value/);
+});
+
+void test('validateGradient requires at least two stops', () => {
+  assert.throws(() => {
+    validateGradient([{ color: { ...COLOR }, position: 0.5 }], 'gradient');
+  }, /invalid gradient value/);
+});
+
+void test('validateGradient enforces stop structure', () => {
+  assert.throws(() => {
+    validateGradient(
+      [
+        { color: { ...COLOR }, position: 0.5 },
+        { color: { ...COLOR }, position: 0.75, unexpected: true },
+      ] as unknown,
+      'gradient',
+    );
+  }, /invalid gradient value/);
+});
+
+void test('validateGradient rejects non-record stops', () => {
+  assert.throws(() => {
+    validateGradient(
+      [{ color: { ...COLOR }, position: 0.25 }, null] as unknown,
+      'gradient',
+    );
+  }, /invalid gradient value/);
+});
+
+void test('validateGradient rejects non-finite stop positions', () => {
+  assert.throws(() => {
+    validateGradient(
+      [
+        { color: { ...COLOR }, position: Number.NaN },
+        { color: { ...COLOR }, position: 0.5 },
+      ],
+      'gradient',
+    );
+  }, /invalid gradient value/);
+});

--- a/tests/core/stroke-style-validator.test.ts
+++ b/tests/core/stroke-style-validator.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateStrokeStyle } from '../../src/core/token-validators/strokeStyle.js';
+
+const DASH = { value: 4, unit: 'px' } as const;
+
+void test('validateStrokeStyle accepts keyword styles', () => {
+  assert.doesNotThrow(() => {
+    validateStrokeStyle('solid', 'stroke');
+  });
+});
+
+void test('validateStrokeStyle rejects unknown keywords', () => {
+  assert.throws(() => {
+    validateStrokeStyle('squiggly', 'stroke');
+  }, /invalid strokeStyle value/);
+});
+
+void test('validateStrokeStyle accepts structured style definitions', () => {
+  assert.doesNotThrow(() => {
+    validateStrokeStyle(
+      {
+        dashArray: [{ ...DASH }, { ...DASH, value: 2, unit: 'rem' }],
+        lineCap: 'round',
+      },
+      'stroke',
+    );
+  });
+});
+
+void test('validateStrokeStyle enforces allowed properties', () => {
+  assert.throws(() => {
+    validateStrokeStyle(
+      {
+        dashArray: [{ ...DASH }],
+        lineCap: 'round',
+        mode: 'unexpected',
+      },
+      'stroke',
+    );
+  }, /invalid strokeStyle value/);
+});
+
+void test('validateStrokeStyle requires dash arrays and known line caps', () => {
+  assert.throws(() => {
+    validateStrokeStyle(
+      {
+        dashArray: 'invalid',
+        lineCap: 'round',
+      },
+      'stroke',
+    );
+  }, /invalid strokeStyle value/);
+  assert.throws(() => {
+    validateStrokeStyle(
+      {
+        dashArray: [{ ...DASH }],
+        lineCap: 'pointy',
+      },
+      'stroke',
+    );
+  }, /invalid strokeStyle value/);
+});


### PR DESCRIPTION
## Summary
- add unit tests for border token validation to assert required properties and rejections
- cover gradient validator edge cases including clamping positions and invalid stops
- validate stroke style handling for keywords, structured definitions, and invalid inputs

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68d41545581883288dc8cfce235d5fff