### PR TITLE
Fix docs build

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,10 @@
+import DefaultTheme from 'vitepress/theme';
+import type { Theme } from 'vitepress';
+
+import './custom.css';
+
+const theme: Theme = {
+  ...DefaultTheme,
+};
+
+export default theme;


### PR DESCRIPTION
## Summary
- add a VitePress theme entry point so the docs build no longer fails when loading custom CSS

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d41f4d274c8328b1e748988ea4f87e