### PR TITLE
docs: update site header and footer links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -102,11 +102,9 @@ export default defineConfig({
           { text: 'Changelog guide', link: '/changelog-guide' },
         ],
       },
-      { text: 'GitHub', link: 'https://github.com/bylapidist/design-lint' },
     ],
     socialLinks: [
       { icon: 'github', link: 'https://github.com/bylapidist/design-lint' },
-      { icon: 'linkedin', link: 'https://www.linkedin.com/company/lapidist' },
     ],
     sidebar: {
       '/rules/': rulesSidebar,
@@ -124,7 +122,6 @@ export default defineConfig({
     },
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2023-present Lapidist',
     },
   },
   markdown: {


### PR DESCRIPTION
## Summary
- remove the redundant manual GitHub entry from the header navigation
- drop the LinkedIn profile from the header social links
- remove the copyright line from the footer

## Testing
- npm run lint *(fails: existing repository lint errors about `error` typed values)*
- npm run format:check
- npm test *(fails: missing `@lapidist/dtif-parser` dependency when running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d42d0e28f4832890e3382d3abc5252