### PR TITLE
docs: fix border width rule examples

### DIFF
--- a/docs/rules/design-token/border-width.md
+++ b/docs/rules/design-token/border-width.md
@@ -20,7 +20,10 @@ Enable the rule in `designlint.config.*`. See [configuration](../../configuratio
         "$type": "dimension",
         "$value": { "dimensionType": "length", "value": 1, "unit": "px" }
       },
-      "lg": { "$type": "dimension", "$ref": "#/borderWidths/sm" }
+      "lg": {
+        "$type": "dimension",
+        "$value": { "dimensionType": "length", "value": 4, "unit": "px" }
+      }
     }
   },
   "rules": { "design-token/border-width": "error" }
@@ -46,7 +49,7 @@ This rule is not auto-fixable.
 
 ```css
 .box { border-width: 1px; }
-.box { border-width: sm; }
+.box { border-width: 4px; }
 ```
 
 ## When Not To Use


### PR DESCRIPTION
## Summary
- adjust the sample border width tokens to demonstrate distinct dimension values
- replace the invalid CSS example with token-compliant `border-width` values

## Testing
- npm run lint *(fails: existing TypeScript eslint config flags many `error`-typed usages in the repository)*
- npm run format:check
- npm test *(fails: tsx cannot resolve `@lapidist/dtif-parser` when running the test suite)*
- npm run lint:md

------
https://chatgpt.com/codex/tasks/task_e_68d42ced89a08328b1f5a5e3670b6763