### PR TITLE
docs: link dtif site in hero tagline

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: >-
 hero:
   name: design-lint
   text: Design systems that ship consistently
-  tagline: Keep components, tokens, and styles aligned with a DTIF-native linter built for teams.
+  tagline: "Keep components, tokens, and styles aligned with a [DTIF-native](https://dtif.lapidist.net) linter built for teams."
   actions:
     - theme: brand
       text: Get started


### PR DESCRIPTION
## Summary
- link the hero tagline's DTIF reference to https://dtif.lapidist.net so readers can reach the spec directly

## Testing
- `npm run lint` *(fails: repository currently reports 357 `@typescript-eslint` errors in existing TypeScript sources)*
- `npm run format:check`
- `npm test` *(fails: environment lacks the `@lapidist/dtif-parser` dependency required by the test suite)*
- `npm run lint:md` *(fails: environment lacks the `@lapidist/dtif-parser` dependency required by the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d42d392f808328ac815232c0478f3c