### PR TITLE
docs: fix invalid css examples in rule docs

### DIFF
--- a/.changeset/docs-fix-invalid-css-examples.md
+++ b/.changeset/docs-fix-invalid-css-examples.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix invalid CSS examples in design token rule docs

--- a/docs/rules/design-token/border-radius.md
+++ b/docs/rules/design-token/border-radius.md
@@ -46,7 +46,7 @@ This rule is not auto-fixable.
 
 ```css
 .box { border-radius: 4px; }
-.box { border-radius: md; }
+.box { border-radius: var(--border-radius-lg); }
 ```
 
 ## When Not To Use

--- a/docs/rules/design-token/spacing.md
+++ b/docs/rules/design-token/spacing.md
@@ -51,7 +51,7 @@ This rule is not auto-fixable.
 
 ```css
 .box { margin: 8px; }
-.box { margin: md; }
+.box { margin: var(--spacing-md); }
 .box { margin: calc(100% - 5px); }
 .box { margin: var(--space, 5px); }
 ```


### PR DESCRIPTION
## Summary
- replace invalid CSS placeholders in the border radius and spacing rule docs with valid custom property usage
- add a changeset describing the documentation fix

## Testing
- npm run lint *(fails: existing @typescript-eslint "error"-typed value violations in src and tests)*
- npm run --silent format:check
- npm test *(fails: existing suite failures in tests/utils/index.test.ts and related suites)*
- npm run lint:md

------
https://chatgpt.com/codex/tasks/task_e_68d42fab2eb08328b838566636f3be3b