### PR TITLE
fix: update DTIF dependencies and inline parsing

### DIFF
--- a/.changeset/dtif-inline-data-channel.md
+++ b/.changeset/dtif-inline-data-channel.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+Fix inline DTIF token parsing to route token objects through the parser data channel.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-parser": "0.3.1",
-        "@lapidist/dtif-schema": "0.3.1",
-        "@lapidist/dtif-validator": "0.3.1",
+        "@lapidist/dtif-parser": "^0.3.2",
+        "@lapidist/dtif-schema": "^0.3.2",
+        "@lapidist/dtif-validator": "^0.3.2",
         "@vue/compiler-sfc": "3.5.22",
         "ajv": "8.17.1",
         "chalk": "5.6.2",
@@ -224,7 +224,6 @@
       "integrity": "sha512-MLx32nSeDSNxfx28IfvwfHEfeo3AYe9JgEj0rLeYtJGmt0W30K6tCNokxhWGUUKrggQTH6H1lnohWsoj2OC2bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.36.0",
         "@algolia/requester-browser-xhr": "5.36.0",
@@ -1717,13 +1716,13 @@
       "license": "MIT"
     },
     "node_modules/@lapidist/dtif-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@lapidist/dtif-parser/-/dtif-parser-0.3.1.tgz",
-      "integrity": "sha512-7xQNV24PW5GsmiAh0YB0juAta3iMtvZRrBCCDHA4P2sWOoDZrYBjizlxXhWKWtx3j0Skn22k9Bfjs3kfll2Gtg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@lapidist/dtif-parser/-/dtif-parser-0.3.2.tgz",
+      "integrity": "sha512-Ezjo51k9K9nU/GTFipzbQiS8PgLg4h2UY5PgR38FhZvTbhlrzZ/cNqQ7Q1rAB5jRyGUGonmMhmpP49jEbsYXBA==",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-schema": "^0.3.1",
-        "@lapidist/dtif-validator": "^0.3.1",
+        "@lapidist/dtif-schema": "^0.3.2",
+        "@lapidist/dtif-validator": "^0.3.2",
         "yaml": "^2.8.1"
       },
       "bin": {
@@ -1731,18 +1730,18 @@
       }
     },
     "node_modules/@lapidist/dtif-schema": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@lapidist/dtif-schema/-/dtif-schema-0.3.1.tgz",
-      "integrity": "sha512-jlwdfH0RuEDx9nyxc/gBrGzvfmwZRQvq7sv3Iv+vUxaVa29JcwKNiepfsLipznJHxDw6HlHUMZVUO+4tclfRow==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@lapidist/dtif-schema/-/dtif-schema-0.3.2.tgz",
+      "integrity": "sha512-BG7ejkXQ5PgO6x9nY1NcTlF/3o4pj5MO3u2nkQjglGJqLq7hw3DUM2WgF7iGF8jludKjnBkVxrGNkxKcb5G6IA==",
       "license": "MIT"
     },
     "node_modules/@lapidist/dtif-validator": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@lapidist/dtif-validator/-/dtif-validator-0.3.1.tgz",
-      "integrity": "sha512-mq3uDrLud7uPBms1avZocwseeiVFTiu9I72LlhypvIOg/BRiJrZxRBVK9Dr30xvHr24z6V8AUAbUa5zxged2Yg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@lapidist/dtif-validator/-/dtif-validator-0.3.2.tgz",
+      "integrity": "sha512-t749HiDlbq1vO3jOKPFzSxLnrMb3hRzENlRiIikvtoE+IRVI3B1pljhE+ROJySlZmPITqI/ZaeB5tMKi8ZPr3A==",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-schema": "^0.3.1",
+        "@lapidist/dtif-schema": "^0.3.2",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
       }
@@ -2458,7 +2457,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -2540,7 +2538,6 @@
       "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.1",
         "@typescript-eslint/types": "8.44.1",
@@ -3055,7 +3052,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3112,7 +3108,6 @@
       "integrity": "sha512-FpwQ+p4x4RIsWnPj2z9idOC70T90ga7Oeh8BURSFKpqp5lITRsgkIj/bwYj2bY5xbyD7uBuP9AZRnM5EV20WOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.2.0",
         "@algolia/client-abtesting": "5.36.0",
@@ -3576,7 +3571,6 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -3912,7 +3906,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4360,7 +4353,6 @@
       "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -6273,7 +6265,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7566,7 +7557,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7759,7 +7749,6 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7862,7 +7851,6 @@
       "integrity": "sha512-2sBz0x/wis5TkF1XZ2vH25zWq3G1bFEPOfkBcx2ikowmphoQsPH6X0V3mmPCXA2K1N/XGTnifVyDQP4GfDDeQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.20",
         "@vue/compiler-sfc": "3.5.20",

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "homepage": "https://design-lint.lapidist.net",
   "license": "MIT",
   "dependencies": {
-    "@lapidist/dtif-parser": "0.3.1",
-    "@lapidist/dtif-schema": "0.3.1",
-    "@lapidist/dtif-validator": "0.3.1",
+    "@lapidist/dtif-parser": "^0.3.2",
+    "@lapidist/dtif-schema": "^0.3.2",
+    "@lapidist/dtif-validator": "^0.3.2",
     "@vue/compiler-sfc": "3.5.22",
     "ajv": "8.17.1",
     "chalk": "5.6.2",

--- a/src/core/dtif/parse.ts
+++ b/src/core/dtif/parse.ts
@@ -73,7 +73,7 @@ export async function parseDtifTokenObject(
   const { uri, ...parseOptions } = options;
   const input: ParseTokensInput = {
     ...(uri ? { uri } : {}),
-    contents: JSON.stringify(document),
+    data: document,
   };
   return parseDtifTokens(input, parseOptions);
 }

--- a/src/core/dtif/parse.ts
+++ b/src/core/dtif/parse.ts
@@ -1,4 +1,5 @@
 import type {
+  ParseDataInputRecord,
   ParseInput,
   ParseInputRecord,
   ResolvedTokenView,
@@ -12,6 +13,7 @@ import {
   type ParseTokensOptions,
   type ParseTokensResult,
 } from '@lapidist/dtif-parser/parse-tokens';
+import type { DesignTokenInterchangeFormat } from '@lapidist/dtif-schema';
 import type {
   DtifFlattenedToken,
   TokenDeprecation,
@@ -67,11 +69,11 @@ export async function parseInlineDtifTokens(
 }
 
 export async function parseDtifTokenObject(
-  document: unknown,
+  document: DesignTokenInterchangeFormat,
   options: ParseInlineDtifTokensOptions = {},
 ): Promise<DtifParseResult> {
   const { uri, ...parseOptions } = options;
-  const input: ParseTokensInput = {
+  const input: ParseDataInputRecord = {
     ...(uri ? { uri } : {}),
     data: document,
   };


### PR DESCRIPTION
## Summary
- bump @lapidist DTIF parser, schema, and validator dependencies to v0.3.2
- load inline DTIF token objects via the parser's data channel to satisfy stricter validation

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68d5479be8ec832898bda5baca6a0cab