### PR TITLE
fix: detect metadata-only theme records

### DIFF
--- a/.changeset/metadata-themes-allow.md
+++ b/.changeset/metadata-themes-allow.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+fix isThemeRecord detection for metadata-only themes lacking shared tokens

--- a/src/utils/guards/domain/is-theme-record.ts
+++ b/src/utils/guards/domain/is-theme-record.ts
@@ -2,6 +2,8 @@ import type { DesignTokens } from '../../../core/types.js';
 import { isRecord } from '../data/index.js';
 import { getDtifFlattenedTokens } from '../../tokens/dtif-cache.js';
 
+const TOKEN_METADATA_IGNORE = new Set(['$type', '$value', '$ref']);
+
 /**
  * Determines whether a value is a record of theme names mapping to design tokens.
  *
@@ -9,7 +11,8 @@ import { getDtifFlattenedTokens } from '../../tokens/dtif-cache.js';
  * - Is a record with at least one non-metadata key (keys not starting with `$`).
  * - For a single theme, it must contain at least one nested theme object (not
  *   just design tokens).
- * - For multiple themes, they must share at least one common token key.
+ * - For multiple themes, either each theme must expose DTIF metadata or they
+ *   must share at least one common token key.
  *
  * @param val - The value to test.
  * @returns `true` if the value is a theme record, `false` otherwise.
@@ -54,9 +57,15 @@ export const isThemeRecord = (
   // For multiple themes, track the intersection of their token keys to ensure
   // they share at least one common token.
   let shared: string[] | null = null;
+  let allHaveMetadata = true;
+
   for (const [, theme] of entries) {
     // Each theme must itself be a record.
     if (!isRecord(theme)) return false;
+
+    if (!hasThemeMetadata(theme)) {
+      allHaveMetadata = false;
+    }
 
     // Collect the non-metadata token keys for the current theme.
     const keys = Object.keys(theme).filter((k) => !k.startsWith('$'));
@@ -67,9 +76,18 @@ export const isThemeRecord = (
     } else {
       // Narrow the intersection to keys present in every theme so far.
       shared = shared.filter((k) => keys.includes(k));
-      // If no keys remain in common, the value can't be a theme record.
-      if (shared.length === 0) return false;
     }
   }
-  return true;
+
+  if (allHaveMetadata) {
+    return true;
+  }
+
+  return Boolean(shared?.length);
 };
+
+function hasThemeMetadata(theme: Record<string, unknown>): boolean {
+  return Object.keys(theme).some(
+    (key) => key.startsWith('$') && !TOKEN_METADATA_IGNORE.has(key),
+  );
+}

--- a/src/utils/guards/domain/is-theme-record.ts
+++ b/src/utils/guards/domain/is-theme-record.ts
@@ -2,7 +2,7 @@ import type { DesignTokens } from '../../../core/types.js';
 import { isRecord } from '../data/index.js';
 import { getDtifFlattenedTokens } from '../../tokens/dtif-cache.js';
 
-const TOKEN_METADATA_IGNORE = new Set(['$type', '$value', '$ref']);
+const THEME_METADATA_KEYS = new Set(['$version']);
 
 /**
  * Determines whether a value is a record of theme names mapping to design tokens.
@@ -88,6 +88,6 @@ export const isThemeRecord = (
 
 function hasThemeMetadata(theme: Record<string, unknown>): boolean {
   return Object.keys(theme).some(
-    (key) => key.startsWith('$') && !TOKEN_METADATA_IGNORE.has(key),
+    (key) => key.startsWith('$') && THEME_METADATA_KEYS.has(key),
   );
 }

--- a/tests/utils/guards/domain/is-theme-record.test.ts
+++ b/tests/utils/guards/domain/is-theme-record.test.ts
@@ -47,6 +47,17 @@ void test('isThemeRecord rejects invalid structures', () => {
     },
   };
   assert.equal(isThemeRecord(single), false);
+  const tokenDocument = {
+    color: {
+      $description: 'Surface colors',
+      primary: { $value: '#fff' },
+    },
+    typography: {
+      $description: 'Type ramps',
+      body: { $value: 'Inter' },
+    },
+  };
+  assert.equal(isThemeRecord(tokenDocument), false);
   const noShared = {
     light: { color: { $value: '#fff' } },
     dark: { size: { $value: '1rem' } },

--- a/tests/utils/guards/domain/is-theme-record.test.ts
+++ b/tests/utils/guards/domain/is-theme-record.test.ts
@@ -13,6 +13,20 @@ void test('isThemeRecord detects multiple themes with shared tokens', () => {
   assert.equal(isThemeRecord(themes), true);
 });
 
+void test('isThemeRecord detects themes without shared tokens when metadata present', () => {
+  const themes = {
+    light: {
+      $version: '1.0.0',
+      color: { primary: { $value: '#fff' } },
+    },
+    dark: {
+      $version: '1.0.0',
+      typography: { body: { $value: 'Inter' } },
+    },
+  };
+  assert.equal(isThemeRecord(themes), true);
+});
+
 void test('isThemeRecord detects single theme with nested group', () => {
   const themes = {
     light: {

--- a/tests/utils/tokens/normalize-tokens.test.ts
+++ b/tests/utils/tokens/normalize-tokens.test.ts
@@ -56,6 +56,28 @@ void test('validates DTIF theme records', async () => {
   assert.equal(token.pointer, '#/color/primary');
 });
 
+void test('normalizes theme records without shared token keys when metadata present', async () => {
+  const tokens = await normalizeTokens({
+    light: {
+      $version: '1.0.0',
+      color: { primary: srgb([0, 0, 0]) },
+    },
+    dark: {
+      $version: '1.0.0',
+      space: { medium: { $type: 'dimension', $value: '1rem' } },
+    },
+  });
+  assert('light' in tokens);
+  assert('dark' in tokens);
+  assert.equal('default' in tokens, false);
+  const light = tokens.light as {
+    color: { primary: { $value: { components: number[] } } };
+  };
+  assert.deepEqual(light.color.primary.$value.components, [0, 0, 0]);
+  const dark = tokens.dark as { space: { medium: { $value: string } } };
+  assert.equal(dark.space.medium.$value, '1rem');
+});
+
 void test('throws on invalid tokens', async () => {
   await assert.rejects(
     normalizeTokens({


### PR DESCRIPTION
## Summary
- allow `isThemeRecord` to accept theme records that expose DTIF metadata even when the themes do not share token keys
- cover metadata-only theme records in guard and normalization test suites
- document the patch in a changeset entry

## Testing
- npm run lint
- CI=1 npm run format:check
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5741362008328ada8340ed02b0840