### PR TITLE
chore: group dtif renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,17 @@
       "matchPackageNames": ["node"],
       "allowedVersions": ">=22 <23",
       "rangeStrategy": "replace"
+    },
+    {
+      "description": "Update DTIF packages together",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@lapidist/dtif-parser",
+        "@lapidist/dtif-schema",
+        "@lapidist/dtif-validator"
+      ],
+      "groupName": "dtif stack",
+      "groupSlug": "dtif"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a Renovate package rule that groups DTIF dependencies into a single PR

## Testing
- npm run lint
- CI=1 npm run format:check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e3641588832891ff63b03f2ce4f6