### PR TITLE
Fix hero tagline link markup on docs homepage

### DIFF
--- a/.changeset/fix-hero-tagline-link.md
+++ b/.changeset/fix-hero-tagline-link.md
@@ -1,0 +1,5 @@
+---
+"@lapidist/design-lint": patch
+---
+
+fix hero tagline link markup on the docs homepage

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: >-
 hero:
   name: design-lint
   text: Design systems that ship consistently
-  tagline: "Keep components, tokens, and styles aligned with a [DTIF-native](https://dtif.lapidist.net) linter built for teams."
+  tagline: "Keep components, tokens, and styles aligned with a <a href=\"https://dtif.lapidist.net\">DTIF-native</a> linter built for teams."
   actions:
     - theme: brand
       text: Get started


### PR DESCRIPTION
## Summary
- replace the hero tagline markdown link with an HTML anchor so the docs home page renders the DTIF link correctly
- add a changeset for the documentation fix

## Testing
- npm run lint
- CI=1 npm run format:check --silent
- npm test --silent
- npm run lint:md --silent

------
https://chatgpt.com/codex/tasks/task_e_68d867b179848328b83c4de362faf33e