### PR TITLE
chore: upgrade DTIF stack dependencies

### DIFF
--- a/.changeset/upgrade-dtif-stack.md
+++ b/.changeset/upgrade-dtif-stack.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+upgrade DTIF parser, schema, and validator dependencies to the latest release and align internal type aliases

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "6.0.4",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-parser": "1.0.0",
-        "@lapidist/dtif-schema": "1.0.0",
-        "@lapidist/dtif-validator": "1.0.0",
+        "@lapidist/dtif-parser": "1.0.2",
+        "@lapidist/dtif-schema": "1.0.2",
+        "@lapidist/dtif-validator": "1.0.2",
         "@vue/compiler-sfc": "3.5.22",
         "ajv": "8.17.1",
         "chalk": "5.6.2",
@@ -1719,13 +1719,13 @@
       "license": "MIT"
     },
     "node_modules/@lapidist/dtif-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lapidist/dtif-parser/-/dtif-parser-1.0.0.tgz",
-      "integrity": "sha512-3TFAyVo4CJWUNRrWINmM61tnHrSkGH7r7HjDXxwyxaDNe5+JPh8nrnIYUknR70gNlY+VfNRWPWFKqBMkofANHA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lapidist/dtif-parser/-/dtif-parser-1.0.2.tgz",
+      "integrity": "sha512-10RWmB63K5BIcU/UOVrpGy1Fui5hsAi+UnOHH71kbld9gJ1JUCteHKAmRVOgt9zIkOS0Ic4GHcimVsLxWaC8sA==",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-schema": "^1.0.0",
-        "@lapidist/dtif-validator": "^1.0.0",
+        "@lapidist/dtif-schema": "^1.0.2",
+        "@lapidist/dtif-validator": "^1.0.2",
         "yaml": "^2.8.1"
       },
       "bin": {
@@ -1733,18 +1733,18 @@
       }
     },
     "node_modules/@lapidist/dtif-schema": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lapidist/dtif-schema/-/dtif-schema-1.0.0.tgz",
-      "integrity": "sha512-MOambI6S6yKJzLbJGvTIt3ErtxbmmD+Lg1FtWGyr1wlM4ttx44cN5m/a8Jei+MI7IH5e1DOp9T+EdO+fS5XNxg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lapidist/dtif-schema/-/dtif-schema-1.0.2.tgz",
+      "integrity": "sha512-9oudxu2sKvQRPseW5zNCB5Dp4yQCwGvXuFoPkVFyCR47iL4dCsfZtMgMORPcHCpxECYaClU3rVBxpmxKKJ/PMQ==",
       "license": "MIT"
     },
     "node_modules/@lapidist/dtif-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lapidist/dtif-validator/-/dtif-validator-1.0.0.tgz",
-      "integrity": "sha512-5OMfkSwMwfrsj6Nqb8L6r9R9AWelE6d0ffS+t6K72HHXHB/Rjz2yGFZ6W6ujkSIpxN2Ocv3hjtEQ709jpxzTyg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lapidist/dtif-validator/-/dtif-validator-1.0.2.tgz",
+      "integrity": "sha512-hUwmBq069roEpPXnYEny3OJ5ZUoeaU/ivzTa6yFYk5i8dwjKdb4X5qmftSIS2LtZaIiCvkeKR1lOjwXoollBZw==",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-schema": "^1.0.0",
+        "@lapidist/dtif-schema": "^1.0.2",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "homepage": "https://design-lint.lapidist.net",
   "license": "MIT",
   "dependencies": {
-    "@lapidist/dtif-parser": "1.0.0",
-    "@lapidist/dtif-schema": "1.0.0",
-    "@lapidist/dtif-validator": "1.0.0",
+    "@lapidist/dtif-parser": "1.0.2",
+    "@lapidist/dtif-schema": "1.0.2",
+    "@lapidist/dtif-validator": "1.0.2",
     "@vue/compiler-sfc": "3.5.22",
     "ajv": "8.17.1",
     "chalk": "5.6.2",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,8 +1,8 @@
 import type { JsonPointer as DtifJsonPointer } from '@lapidist/dtif-parser';
 import type {
-  DesignToken as DtifToken,
+  Token as DtifToken,
   DesignTokenInterchangeFormat,
-  TokenCollection as DtifCollection,
+  TokenMemberMap as DtifCollection,
 } from '@lapidist/dtif-schema';
 import type ts from 'typescript';
 import type { z } from 'zod';


### PR DESCRIPTION
## Summary
- bump `@lapidist/dtif-parser`, `@lapidist/dtif-schema`, and `@lapidist/dtif-validator` to their latest 1.0.2 releases
- update internal DTIF type aliases to match the renamed schema exports
- record the dependency upgrade in a changeset for release management

## Testing
- npm run build
- npm run lint
- CI=1 npm run format:check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f3ace5a850832881cc7dd4934ff1eb