### PR TITLE
Fix lint defaults and optional cache access

### DIFF
--- a/.changeset/optional-chain-lint-cleanup.md
+++ b/.changeset/optional-chain-lint-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+align execute lint destructuring with return types and favor optional chaining in cache management

--- a/src/cli/execute.ts
+++ b/src/cli/execute.ts
@@ -32,15 +32,12 @@ export async function executeLint(
   services: ExecuteServices,
 ): Promise<{ results: LintResult[]; exitCode: number; ignoreFiles: string[] }> {
   const start = performance.now();
-  const {
-    results,
-    ignoreFiles = [],
-    warning,
-  } = await services.linterRef.current.lintTargets(
-    targets,
-    opts.fix,
-    services.ignorePath ? [services.ignorePath] : [],
-  );
+  const { results, ignoreFiles, warning } =
+    await services.linterRef.current.lintTargets(
+      targets,
+      opts.fix,
+      services.ignorePath ? [services.ignorePath] : [],
+    );
   const duration = performance.now() - start;
   if (warning && !opts.quiet) console.warn(warning);
   const output = services.formatter(results, services.useColor);

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -26,7 +26,7 @@ export class CacheManager {
       } catch {
         statResult = undefined;
       }
-      const cached = this.cache ? await this.cache.get(doc.id) : undefined;
+      const cached = await this.cache?.get(doc.id);
       if (
         cached &&
         statResult &&
@@ -72,8 +72,6 @@ export class CacheManager {
   }
 
   async save(): Promise<void> {
-    if (this.cache) {
-      await this.cache.save();
-    }
+    await this.cache?.save();
   }
 }

--- a/src/core/framework-parsers/svelte-parser.ts
+++ b/src/core/framework-parsers/svelte-parser.ts
@@ -15,9 +15,8 @@ export async function lintSvelte(
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ): Promise<void> {
-  const { parse }: { parse: typeof svelteParse } = await import(
-    'svelte/compiler'
-  );
+  const { parse }: { parse: typeof svelteParse } =
+    await import('svelte/compiler');
   const ast = parse(text, { modern: true });
   const getRange = (node: unknown): { start: number; end: number } | null => {
     return isRecord(node) &&


### PR DESCRIPTION
## Summary
- align execute lint destructuring with linter return values to avoid useless defaults
- prefer optional chaining within cache manager and format Svelte parser import for consistency
- add changeset capturing lint-driven runtime cleanups

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run build
- npm run lint:md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c26fcafc88328bf865bd2c07fd1ba)