### PR TITLE
fix: validate cache reuse

### DIFF
--- a/.changeset/cache-cache-validation.md
+++ b/.changeset/cache-cache-validation.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+ensure cache hits only use entries matching current file stats

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -27,13 +27,14 @@ export class CacheManager {
         statResult = undefined;
       }
       const cached = await this.cache?.get(doc.id);
-      if (
-        cached &&
-        statResult &&
+      const isCacheValid =
+        !this.fix &&
+        statResult != null &&
+        cached != null &&
         cached.mtime === statResult.mtimeMs &&
-        cached.size === statResult.size &&
-        !this.fix
-      ) {
+        cached.size === statResult.size;
+
+      if (isCacheValid) {
         return cached.result;
       }
       const text = await doc.getText();

--- a/src/core/framework-parsers/svelte-parser.ts
+++ b/src/core/framework-parsers/svelte-parser.ts
@@ -15,8 +15,9 @@ export async function lintSvelte(
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ): Promise<void> {
-  const { parse }: { parse: typeof svelteParse } =
-    await import('svelte/compiler');
+  const { parse }: { parse: typeof svelteParse } = await import(
+    'svelte/compiler'
+  );
   const ast = parse(text, { modern: true });
   const getRange = (node: unknown): { start: number; end: number } | null => {
     return isRecord(node) &&


### PR DESCRIPTION
## Summary
- ensure cache entries are only reused when file stats match and fixes are disabled
- reformat the Svelte parser import to align with Prettier expectations
- add a changeset entry for the cache validation fix

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c303ec1588328be5fb4125d5db74d)