### PR TITLE
fix: simplify cache validation optional chaining

### DIFF
--- a/.changeset/optimize-cache-optional-chains.md
+++ b/.changeset/optimize-cache-optional-chains.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+simplify cache validation with optional chaining

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -27,14 +27,15 @@ export class CacheManager {
         statResult = undefined;
       }
       const cached = await this.cache?.get(doc.id);
+      const cachedMtime = cached?.mtime;
+      const cachedSize = cached?.size;
       const isCacheValid =
         !this.fix &&
         statResult != null &&
-        cached != null &&
-        cached.mtime === statResult.mtimeMs &&
-        cached.size === statResult.size;
+        cachedMtime === statResult.mtimeMs &&
+        cachedSize === statResult.size;
 
-      if (isCacheValid) {
+      if (isCacheValid && cached) {
         return cached.result;
       }
       const text = await doc.getText();

--- a/src/core/framework-parsers/svelte-parser.ts
+++ b/src/core/framework-parsers/svelte-parser.ts
@@ -15,9 +15,8 @@ export async function lintSvelte(
   listeners: ReturnType<RuleModule['create']>[],
   messages: LintMessage[],
 ): Promise<void> {
-  const { parse }: { parse: typeof svelteParse } = await import(
-    'svelte/compiler'
-  );
+  const { parse }: { parse: typeof svelteParse } =
+    await import('svelte/compiler');
   const ast = parse(text, { modern: true });
   const getRange = (node: unknown): { start: number; end: number } | null => {
     return isRecord(node) &&


### PR DESCRIPTION
## Summary
- streamline cache validation logic to use derived cache metadata without unnecessary optional chaining
- apply Prettier formatting adjustments in the Svelte parser import
- add a patch changeset entry covering the cache validation improvement

## Testing
- npm run lint
- npm run format:check
- npm test
- npm run build
- npm run lint:md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c38fbfdd88328bc5dfed72674d7e1)