### PR TITLE
fix(release): peer-dep validation and stale pnpm version in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,8 +25,6 @@ jobs:
         with:
           fetch-depth: 1
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.4
       - uses: actions/setup-node@v6
         with:
           node-version: 24.15.0

--- a/packages/config-ai-agent/package.json
+++ b/packages/config-ai-agent/package.json
@@ -36,7 +36,7 @@
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "peerDependencies": {
-    "@lapidist/design-lint": ">=8"
+    "@lapidist/design-lint": ">=7"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"

--- a/packages/config-recommended/package.json
+++ b/packages/config-recommended/package.json
@@ -34,7 +34,7 @@
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "peerDependencies": {
-    "@lapidist/design-lint": ">=8"
+    "@lapidist/design-lint": ">=7"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"

--- a/packages/config-strict/package.json
+++ b/packages/config-strict/package.json
@@ -34,7 +34,7 @@
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "peerDependencies": {
-    "@lapidist/design-lint": ">=8"
+    "@lapidist/design-lint": ">=7"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -35,7 +35,7 @@
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "peerDependencies": {
-    "@lapidist/design-lint": ">=8"
+    "@lapidist/design-lint": ">=7"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -36,7 +36,7 @@
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "peerDependencies": {
-    "@lapidist/design-lint": ">=8"
+    "@lapidist/design-lint": ">=7"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"

--- a/packages/rdk/package.json
+++ b/packages/rdk/package.json
@@ -28,7 +28,7 @@
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "peerDependencies": {
-    "@lapidist/design-lint": ">=8",
+    "@lapidist/design-lint": ">=7",
     "@lapidist/design-lint-testing": ">=0"
   },
   "devDependencies": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -36,7 +36,7 @@
     "format:check": "prettier --check 'src/**/*.ts'"
   },
   "peerDependencies": {
-    "@lapidist/design-lint": ">=8"
+    "@lapidist/design-lint": ">=7"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"


### PR DESCRIPTION
## Problem

Two failures blocked the release workflow after the v8 merge.

**1 — Changeset peer-dep validation**

`changeset version` validates that each sub-package's `peerDependencies` range includes the *current* version of its peer before bumping. All seven sub-packages declared `"@lapidist/design-lint": ">=8"` but the package is still at `7.0.3` pre-release — so validation always failed with:

```
Package "@lapidist/design-lint-config-ai-agent" must depend on the current version of "@lapidist/design-lint": "7.0.3" vs ">=8"
```

**2 — Hardcoded pnpm version in `docs.yml`**

`docs.yml` still had `version: 10.33.4` on `pnpm/action-setup@v6`, causing `ERR_PNPM_BAD_PM_VERSION` now that `packageManager` in `package.json` is `pnpm@11.1.1`.

## Fix

- Change peer dep range from `>=8` → `>=7` in all seven sub-packages so the current `7.0.3` satisfies it (and `>=8.0.0` will too after the bump)
- Remove the explicit `version` key from `docs.yml` — the last workflow that still had it