### PR TITLE
fix(release): add root package to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - .
   - packages/*
 
 overrides:


### PR DESCRIPTION
## Problem

After upgrading to pnpm 11, `changeset version` fails with:

```
Found changeset add-rule-rationale for package @lapidist/design-lint which is not in the workspace
```

pnpm 11 no longer implicitly includes the root package when tools enumerate workspace members via `pnpm-workspace.yaml`. changeset discovers packages by asking pnpm, so it can't find `@lapidist/design-lint` (the root) and refuses to assemble the release plan.

## Fix

Add `"."` to the `packages` list in `pnpm-workspace.yaml` to explicitly declare the root package as a workspace member. pnpm itself already treated it as implicit; this change just makes it visible to tooling that queries the workspace definition.