### PR TITLE
chore(deps): update @lapidist/dscp to v0.2.4

### DIFF
--- a/.changeset/deps-dscp-0-2-4.md
+++ b/.changeset/deps-dscp-0-2-4.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/design-lint': patch
+---
+
+update dependency @lapidist/dscp to v0.2.4

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://design-lint.lapidist.net",
   "license": "MIT",
   "dependencies": {
-    "@lapidist/dscp": "0.2.0",
+    "@lapidist/dscp": "0.2.4",
     "@lapidist/dsr": "0.2.0",
     "@lapidist/dtif-parser": "2.0.0",
     "@lapidist/dtif-schema": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@lapidist/dscp':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.2.4
+        version: 0.2.4
       '@lapidist/dsr':
         specifier: 0.2.0
         version: 0.2.0
@@ -783,8 +783,8 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
-  '@lapidist/dscp@0.2.0':
-    resolution: {integrity: sha512-U6/5XEpbU6sUvZAUIF39xNhkhqQScwxE0I7CY7VleRHDyn3ePPHCMR7NLnT61DUlNkSlBMlB7V1nKcTkqCm63Q==}
+  '@lapidist/dscp@0.2.4':
+    resolution: {integrity: sha512-WnqbLxT5j5yG+fIMKuHMMIWaBQpydxyOkk2tIP3eJdgnGVChBgUYmvpXbswdr6vUjPkyjY0+T5OG/JxqG9+Vjg==}
     engines: {node: '>=22'}
 
   '@lapidist/dsr@0.2.0':
@@ -3135,7 +3135,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@lapidist/dscp@0.2.0': {}
+  '@lapidist/dscp@0.2.4': {}
 
   '@lapidist/dsr@0.2.0':
     dependencies:


### PR DESCRIPTION
Updates `@lapidist/dscp` from `0.2.0` to `0.2.4`. Includes a patch changeset.