### PR TITLE
fix(config-presets): add prepack and files so dist ships on publish

### DIFF
--- a/.changeset/fix-config-packages-prepack.md
+++ b/.changeset/fix-config-packages-prepack.md
@@ -1,0 +1,14 @@
+---
+"@lapidist/design-lint-config-recommended": patch
+"@lapidist/design-lint-config-strict": patch
+"@lapidist/design-lint-config-ai-agent": patch
+---
+
+Add `prepack` build step and `files` manifest so preset packages ship compiled dist
+
+The config preset packages were published without running `tsc`, so `dist/index.js` was absent from the npm tarball. Consumers importing the packages received `Cannot find module '…/dist/index.js'`.
+
+Changes per package:
+- `scripts.prepack`: runs `tsc -p tsconfig.json` automatically before every `npm publish` / `pnpm publish`
+- `files`: `["dist", "src"]` — explicitly declares what the tarball includes so dist is never accidentally omitted
+- `exports["."].source`: `./src/index.ts` — allows TypeScript-aware tools to resolve the source directly

--- a/packages/config-ai-agent/package.json
+++ b/packages/config-ai-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lapidist/design-lint-config-ai-agent",
   "version": "1.0.0",
-  "description": "AI agent rule configuration preset for @lapidist/design-lint — enables all rules targeting AI code generation failure modes.",
+  "description": "AI agent rule configuration preset for @lapidist/design-lint \u2014 enables all rules targeting AI code generation failure modes.",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -24,6 +24,7 @@
   ],
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
@@ -33,12 +34,17 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "format:check": "prettier --check 'src/**/*.ts'"
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "prepack": "tsc -p tsconfig.json"
   },
   "peerDependencies": {
     "@lapidist/design-lint": "8.0.0"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }

--- a/packages/config-recommended/package.json
+++ b/packages/config-recommended/package.json
@@ -22,6 +22,7 @@
   ],
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
@@ -31,12 +32,17 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "format:check": "prettier --check 'src/**/*.ts'"
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "prepack": "tsc -p tsconfig.json"
   },
   "peerDependencies": {
     "@lapidist/design-lint": "8.0.0"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }

--- a/packages/config-strict/package.json
+++ b/packages/config-strict/package.json
@@ -22,6 +22,7 @@
   ],
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
@@ -31,12 +32,17 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "format:check": "prettier --check 'src/**/*.ts'"
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "prepack": "tsc -p tsconfig.json"
   },
   "peerDependencies": {
     "@lapidist/design-lint": "8.0.0"
   },
   "devDependencies": {
     "@lapidist/design-lint": "workspace:*"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }


### PR DESCRIPTION
## Summary

- `scripts.prepack: tsc -p tsconfig.json` added to all three config preset packages — runs automatically before every `npm publish` / `pnpm publish`, ensuring `dist/` is always built
- `files: ["dist", "src"]` added — explicitly declares what the tarball includes so dist can never be accidentally omitted by a future `.npmignore` or default exclusion
- `exports["."].source: ./src/index.ts` added — allows TypeScript-aware bundlers and the `source` export condition to resolve the TypeScript source directly

## Root cause

The packages were published with `changeset publish` (which calls `pnpm pack` internally) without a `prepack` step, so `tsc` never ran and `dist/index.js` was absent from the tarball. Consumers received:

```
Cannot find module '…/dist/index.js' imported from designlint.config.js
```

## Test plan

- [ ] `cd packages/config-recommended && pnpm pack --dry-run` — confirm `dist/index.js` and `dist/index.d.ts` appear in the file list
- [ ] Repeat for `config-strict` and `config-ai-agent`
- [ ] `import recommended from '@lapidist/design-lint-config-recommended'` in a consumer project resolves without error after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)